### PR TITLE
docs: update plugins_dir default path to ~/.config/lla/plugins in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ enabled_plugins = []
 
 # Directory where plugins are stored
 # Default: ~/.config/lla/plugins
-plugins_dir = "/Users/mohamedachaq/.config/lla/plugins"
+plugins_dir = "~/.config/lla/plugins"
 
 # Maximum depth for recursive directory traversal
 # Controls how deep lla will go when showing directory contents


### PR DESCRIPTION
docs: update `plugins_dir` default path to `~/.config/lla/plugins` in config file

![Capture d’écran_2024-12-19_14-42-32](https://github.com/user-attachments/assets/dc3f0898-8e63-494a-8f99-1c5c0d7ed0a4)
