### PR TITLE
chore: update release workflow to install nFPM via APT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,7 +273,10 @@ jobs:
 
       - name: Install nFPM
         run: |
-          curl -sfL https://install.goreleaser.com/github.com/goreleaser/nfpm.sh | sh
+          echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+          sudo apt update
+          sudo apt install -y nfpm
+          nfpm --version
 
       - name: Generate packages
         run: |


### PR DESCRIPTION
- Replaced the installation method for nFPM from a script to using APT.
- Added commands to add the Goreleaser APT repository, update package lists, and install nFPM.
- Included a command to verify the nFPM installation by checking its version.