### PR TITLE
improvements and fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,10 @@ jobs:
         run: |
           find themes -name "*.toml" -type f | zip themes.zip -@
 
+      - name: Create completions archive
+        run: |
+          find completions -name "*" -type f | zip completions.zip -@
+
       - name: Generate SHA256 checksums
         run: |
           cd artifacts
@@ -212,6 +216,7 @@ jobs:
           done
           cd ..
           sha256sum themes.zip >> SHA256SUMS
+          sha256sum completions.zip >> SHA256SUMS
 
       - name: Create Release Notes
         run: |
@@ -255,6 +260,9 @@ jobs:
 
           # Upload themes archive
           gh release upload "v${{ needs.check_release.outputs.current_version }}" themes.zip --clobber
+
+          # Upload completions archive
+          gh release upload "v${{ needs.check_release.outputs.current_version }}" completions.zip --clobber
 
           # Upload checksums
           gh release upload "v${{ needs.check_release.outputs.current_version }}" SHA256SUMS --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,10 +204,6 @@ jobs:
         run: |
           find themes -name "*.toml" -type f | zip themes.zip -@
 
-      - name: Create completions archive
-        run: |
-          find completions -name "*" -type f | zip completions.zip -@
-
       - name: Generate SHA256 checksums
         run: |
           cd artifacts
@@ -216,7 +212,6 @@ jobs:
           done
           cd ..
           sha256sum themes.zip >> SHA256SUMS
-          sha256sum completions.zip >> SHA256SUMS
 
       - name: Create Release Notes
         run: |
@@ -260,9 +255,6 @@ jobs:
 
           # Upload themes archive
           gh release upload "v${{ needs.check_release.outputs.current_version }}" themes.zip --clobber
-
-          # Upload completions archive
-          gh release upload "v${{ needs.check_release.outputs.current_version }}" completions.zip --clobber
 
           # Upload checksums
           gh release upload "v${{ needs.check_release.outputs.current_version }}" SHA256SUMS --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.10] - 2025-01-06
+
+### Added
+
+- Enhanced symlink support:
+
+  - New symlink metadata retrieval and display
+  - Improved symlink target information in output
+  - Better visual representation of symlinks
+
+- New permission format options:
+
+  - `--permission-format` argument with multiple display formats:
+    - symbolic (default)
+    - octal
+    - binary
+    - verbose
+    - compact
+  - Configurable default permission format in settings in configuration file
+
+- Enhanced grid format configuration:
+  - New `--grid-ignore` option
+  - Configurable grid width settings in configuration file
+
+### Changed
+
+- Improved plugin configuration with enhanced tilde expansion for plugin directories
+
+- Refined symlink target display positioning in LongFormatter output
+- Enhanced documentation and README formatting
+- Added completions archive to release workflow
+
+### Fixed
+
+- Fixed symlink handling to respect 'no_symlinks' argument
+
 ## [0.3.9] - 2025-01-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,7 +1052,7 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lla"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "atty",
  "chrono",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_interface"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "prost",
  "prost-build",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_utils"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["lla", "lla_plugin_interface", "lla_plugin_utils", "plugins/*"]
 [workspace.package]
 description = "Blazing Fast and highly customizable ls Replacement with Superpowers"
 authors = ["Achaq <hi@achaq.dev>"]
-version = "0.3.9"
+version = "0.3.10"
 categories = ["utilities", "file-system", "cli", "file-management"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -321,13 +321,15 @@ will show a detailed listing of all files and directories in the current directo
 
 ### Configuration & Setup
 
-| Command      | Description                       | Example               |
-| ------------ | --------------------------------- | --------------------- |
-| `init`       | Initialize the configuration file | `lla init`            |
-| `config`     | View or modify configuration      | `lla config`          |
-| `theme`      | Interactive theme manager         | `lla theme`           |
-| `completion` | Generate shell completion scripts | `lla completion bash` |
-| `clean`      | Clean up invalid plugins          | `lla clean`           |
+| Command         | Description                       | Example                                                                         |
+| --------------- | --------------------------------- | ------------------------------------------------------------------------------- |
+| `init`          | Initialize the configuration file | `lla init`                                                                      |
+| `config`        | View or modify configuration      | `lla config`                                                                    |
+| `theme`         | Interactive theme manager         | `lla theme`                                                                     |
+| `theme pull`    | Pull the built-in themes          | `lla theme pull`                                                                |
+| `theme install` | Install theme from file/directory | `lla theme install /path/to/theme.toml`<br>`lla theme install /path/to/themes/` |
+| `completion`    | Generate shell completion scripts | `lla completion bash`                                                           |
+| `clean`         | Clean up invalid plugins          | `lla clean`                                                                     |
 
 ### General Options
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 <p align="center">
     Modern, customizable, feature-rich and extensible `ls` replacement.
     <br />
-   <br />
     <a href="https://lla.chaqchase.com">Documentation</a>
     ·
     <a href="#features">Features</a>
@@ -227,11 +226,12 @@ will show a detailed listing of all files and directories in the current directo
 
 #### Display Modifiers
 
-| Command      | Description                          | Example          |
-| ------------ | ------------------------------------ | ---------------- |
-| `--icons`    | Show icons for files and directories | `lla --icons`    |
-| `--no-icons` | Hide icons for files and directories | `lla --no-icons` |
-| `--no-color` | Disable all colors in the output     | `lla --no-color` |
+| Command               | Description                                                                           | Example                         |
+| --------------------- | ------------------------------------------------------------------------------------- | ------------------------------- |
+| `--icons`             | Show icons for files and directories                                                  | `lla --icons`                   |
+| `--no-icons`          | Hide icons for files and directories                                                  | `lla --no-icons`                |
+| `--no-color`          | Disable all colors in the output                                                      | `lla --no-color`                |
+| `--permission-format` | Set the format for displaying permissions (symbolic, octal, binary, verbose, compact) | `lla --permission-format octal` |
 
 ### Sort & Filter Options
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ lla -T
 Space-efficient layout for dense directories:
 
 ```bash
-lla -g
+lla -g                  # Basic grid view
+lla -g --grid-ignore    # Grid view ignoring terminal width (Warning: may extend beyond screen)
 ```
 
 <img src="https://github.com/user-attachments/assets/b81d01ea-b830-4833-8791-7b62ff9137df" className="rounded-2xl" alt="grid" />
@@ -206,13 +207,13 @@ will show a detailed listing of all files and directories in the current directo
 
 #### Basic Views
 
-| Command   | Short | Description                             | Example  |
-| --------- | ----- | --------------------------------------- | -------- |
-| (default) |       | List current directory                  | `lla`    |
-| `--long`  | `-l`  | Detailed file information with metadata | `lla -l` |
-| `--tree`  | `-t`  | Hierarchical directory visualization    | `lla -t` |
-| `--table` | `-T`  | Structured data display                 | `lla -T` |
-| `--grid`  | `-g`  | Organized grid layout                   | `lla -g` |
+| Command   | Short | Description                                                                                                       | Example  |
+| --------- | ----- | ----------------------------------------------------------------------------------------------------------------- | -------- |
+| (default) |       | List current directory                                                                                            | `lla`    |
+| `--long`  | `-l`  | Detailed file information with metadata                                                                           | `lla -l` |
+| `--tree`  | `-t`  | Hierarchical directory visualization                                                                              | `lla -t` |
+| `--table` | `-T`  | Structured data display                                                                                           | `lla -T` |
+| `--grid`  | `-g`  | Organized grid layout you can use `-g --grid-ignore` to ignore terminal width (Warning: may extend beyond screen) | `lla -g` |
 
 #### Advanced Views
 

--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -28,8 +28,8 @@ walkdir.workspace = true
 tempfile.workspace = true
 users.workspace = true
 parking_lot.workspace = true
-lla_plugin_interface = { version = "0.3.9", path = "../lla_plugin_interface" }
-lla_plugin_utils = { version = "0.3.9", path = "../lla_plugin_utils" }
+lla_plugin_interface = { version = "0.3.10", path = "../lla_plugin_interface" }
+lla_plugin_utils = { version = "0.3.10", path = "../lla_plugin_utils" }
 once_cell.workspace = true
 dashmap.workspace = true
 unicode-width.workspace = true

--- a/lla/src/commands/args.rs
+++ b/lla/src/commands/args.rs
@@ -37,6 +37,7 @@ pub struct Args {
     pub no_symlinks: bool,
     pub no_dotfiles: bool,
     pub dotfiles_only: bool,
+    pub permission_format: String,
     pub command: Option<Command>,
 }
 
@@ -274,6 +275,14 @@ impl Args {
                     .long("dotfiles-only")
                     .help("Show only dot files and directories (those starting with a dot)"),
             )
+            .arg(
+                Arg::with_name("permission-format")
+                    .long("permission-format")
+                    .help("Format for displaying permissions (symbolic, octal, binary, verbose, compact)")
+                    .takes_value(true)
+                    .possible_values(&["symbolic", "octal", "binary",  "verbose", "compact"])
+                    .default_value(&config.permission_format),
+            )
             .subcommand(
                 SubCommand::with_name("install")
                     .about("Install a plugin")
@@ -473,6 +482,7 @@ impl Args {
                     no_symlinks: false,
                     no_dotfiles: config.filter.no_dotfiles,
                     dotfiles_only: false,
+                    permission_format: config.permission_format.clone(),
                     command: Some(Command::Shortcut(ShortcutAction::Run(
                         potential_shortcut.clone(),
                         args[2..].to_vec(),
@@ -644,6 +654,10 @@ impl Args {
             no_symlinks: matches.is_present("no-symlinks"),
             no_dotfiles: matches.is_present("no-dotfiles") || config.filter.no_dotfiles,
             dotfiles_only: matches.is_present("dotfiles-only"),
+            permission_format: matches
+                .value_of("permission-format")
+                .unwrap_or(&config.permission_format)
+                .to_string(),
             command,
         }
     }

--- a/lla/src/commands/args.rs
+++ b/lla/src/commands/args.rs
@@ -10,6 +10,7 @@ pub struct Args {
     pub tree_format: bool,
     pub table_format: bool,
     pub grid_format: bool,
+    pub grid_ignore: bool,
     pub sizemap_format: bool,
     pub timeline_format: bool,
     pub git_format: bool,
@@ -115,6 +116,11 @@ impl Args {
                     .short('g')
                     .long("grid")
                     .help("Use grid listing format (overrides config format)"),
+            )
+            .arg(
+                Arg::with_name("grid-ignore")
+                    .long("grid-ignore")
+                    .help("Use grid view ignoring terminal width (Warning: output may extend beyond screen width)"),
             )
             .arg(
                 Arg::with_name("sizemap")
@@ -440,6 +446,7 @@ impl Args {
                     tree_format: config.default_format == "tree",
                     table_format: config.default_format == "table",
                     grid_format: config.default_format == "grid",
+                    grid_ignore: false,
                     sizemap_format: config.default_format == "sizemap",
                     timeline_format: config.default_format == "timeline",
                     git_format: config.default_format == "git",
@@ -592,6 +599,7 @@ impl Args {
                 || (!has_format_flag && config.default_format == "table"),
             grid_format: matches.is_present("grid")
                 || (!has_format_flag && config.default_format == "grid"),
+            grid_ignore: matches.is_present("grid-ignore"),
             sizemap_format: matches.is_present("sizemap")
                 || (!has_format_flag && config.default_format == "sizemap"),
             timeline_format: matches.is_present("timeline")

--- a/lla/src/commands/file_utils.rs
+++ b/lla/src/commands/file_utils.rs
@@ -325,13 +325,22 @@ fn create_base_filter(pattern: &str, case_insensitive: bool) -> Box<dyn FileFilt
 
 pub fn create_formatter(args: &Args) -> Box<dyn FileFormatter> {
     if args.fuzzy_format {
-        Box::new(FuzzyFormatter::new(args.show_icons))
+        Box::new(FuzzyFormatter::new(
+            args.show_icons,
+            args.permission_format.clone(),
+        ))
     } else if args.long_format {
-        Box::new(LongFormatter::new(args.show_icons))
+        Box::new(LongFormatter::new(
+            args.show_icons,
+            args.permission_format.clone(),
+        ))
     } else if args.tree_format {
         Box::new(TreeFormatter::new(args.show_icons))
     } else if args.table_format {
-        Box::new(TableFormatter::new(args.show_icons))
+        Box::new(TableFormatter::new(
+            args.show_icons,
+            args.permission_format.clone(),
+        ))
     } else if args.grid_format {
         let config = Config::load(&Config::get_config_path()).unwrap_or_default();
         Box::new(GridFormatter::new(

--- a/lla/src/commands/file_utils.rs
+++ b/lla/src/commands/file_utils.rs
@@ -169,7 +169,7 @@ pub fn list_and_decorate_files(
             } else if args.files_only {
                 metadata.is_file
             } else if args.symlinks_only {
-                metadata.is_symlink
+                metadata.is_symlink && !args.no_symlinks
             } else {
                 let include_dirs = !args.no_dirs;
                 let include_files = !args.no_files;

--- a/lla/src/commands/file_utils.rs
+++ b/lla/src/commands/file_utils.rs
@@ -333,7 +333,12 @@ pub fn create_formatter(args: &Args) -> Box<dyn FileFormatter> {
     } else if args.table_format {
         Box::new(TableFormatter::new(args.show_icons))
     } else if args.grid_format {
-        Box::new(GridFormatter::new(args.show_icons, args.grid_ignore))
+        let config = Config::load(&Config::get_config_path()).unwrap_or_default();
+        Box::new(GridFormatter::new(
+            args.show_icons,
+            args.grid_ignore || config.formatters.grid.ignore_width,
+            config.formatters.grid.max_width,
+        ))
     } else if args.sizemap_format {
         Box::new(SizeMapFormatter::new(args.show_icons))
     } else if args.timeline_format {

--- a/lla/src/commands/file_utils.rs
+++ b/lla/src/commands/file_utils.rs
@@ -333,7 +333,7 @@ pub fn create_formatter(args: &Args) -> Box<dyn FileFormatter> {
     } else if args.table_format {
         Box::new(TableFormatter::new(args.show_icons))
     } else if args.grid_format {
-        Box::new(GridFormatter::new(args.show_icons))
+        Box::new(GridFormatter::new(args.show_icons, args.grid_ignore))
     } else if args.sizemap_format {
         Box::new(SizeMapFormatter::new(args.show_icons))
     } else if args.timeline_format {

--- a/lla/src/config/mod.rs
+++ b/lla/src/config/mod.rs
@@ -269,10 +269,10 @@ include_dirs = {}
 # Format for displaying file permissions    
 # Possible values:
 #   - "symbolic": Traditional Unix-style (e.g., -rw-r--r--)
-#   - "octal": Numeric mode (e.g., 644)
+#   - "octal": Numeric mode (e.g., d644)
 #   - "binary": Binary representation (e.g., 110100100)
-#   - "compact": Compact representation (e.g., rwxr-xr-x)
-#   - "descriptive": Descriptive representation (e.g., directory, file, symlink, etc.)
+#   - "compact": Compact representation (e.g., 644)
+#   - "verbose": Verbose representation (e.g., type:file owner:rwx group:r-x others:r-x)
 # Default: "symbolic"
 permission_format = "{}"
 

--- a/lla/src/formatter/fuzzy.rs
+++ b/lla/src/formatter/fuzzy.rs
@@ -12,11 +12,15 @@ use std::time::{Duration, SystemTime};
 
 pub struct FuzzyFormatter {
     pub show_icons: bool,
+    pub permission_format: String,
 }
 
 impl FuzzyFormatter {
-    pub fn new(show_icons: bool) -> Self {
-        Self { show_icons }
+    pub fn new(show_icons: bool, permission_format: String) -> Self {
+        Self {
+            show_icons,
+            permission_format,
+        }
     }
 
     fn format_entry(
@@ -41,7 +45,7 @@ impl FuzzyFormatter {
         };
 
         let perms = Permissions::from_mode(metadata.permissions);
-        let perms_display = colorize_permissions(&perms);
+        let perms_display = colorize_permissions(&perms, Some(&self.permission_format));
         let size = colorize_size(metadata.size);
         let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(metadata.modified);
         let date = colorize_date(&modified);

--- a/lla/src/formatter/grid.rs
+++ b/lla/src/formatter/grid.rs
@@ -10,11 +10,15 @@ use unicode_width::UnicodeWidthStr;
 
 pub struct GridFormatter {
     pub show_icons: bool,
+    pub grid_ignore: bool,
 }
 
 impl GridFormatter {
-    pub fn new(show_icons: bool) -> Self {
-        Self { show_icons }
+    pub fn new(show_icons: bool, grid_ignore: bool) -> Self {
+        Self {
+            show_icons,
+            grid_ignore,
+        }
     }
 }
 impl FileFormatter for GridFormatter {
@@ -28,9 +32,13 @@ impl FileFormatter for GridFormatter {
             return Ok(String::new());
         }
 
-        let term_width = terminal_size()
-            .map(|(Width(w), _)| w as usize)
-            .unwrap_or(80);
+        let term_width = if self.grid_ignore {
+            200
+        } else {
+            terminal_size()
+                .map(|(Width(w), _)| w as usize)
+                .unwrap_or(80)
+        };
 
         let mut formatted_entries = Vec::with_capacity(files.len());
         let mut max_width = 0;

--- a/lla/src/formatter/grid.rs
+++ b/lla/src/formatter/grid.rs
@@ -11,13 +11,15 @@ use unicode_width::UnicodeWidthStr;
 pub struct GridFormatter {
     pub show_icons: bool,
     pub grid_ignore: bool,
+    pub max_width: usize,
 }
 
 impl GridFormatter {
-    pub fn new(show_icons: bool, grid_ignore: bool) -> Self {
+    pub fn new(show_icons: bool, grid_ignore: bool, max_width: usize) -> Self {
         Self {
             show_icons,
             grid_ignore,
+            max_width,
         }
     }
 }
@@ -33,7 +35,7 @@ impl FileFormatter for GridFormatter {
         }
 
         let term_width = if self.grid_ignore {
-            200
+            self.max_width
         } else {
             terminal_size()
                 .map(|(Width(w), _)| w as usize)

--- a/lla/src/formatter/long.rs
+++ b/lla/src/formatter/long.rs
@@ -112,22 +112,8 @@ impl FileFormatter for LongFormatter {
                 format!(" {}", plugin_fields)
             };
 
-            output.push_str(&format!(
-                "{} {:>width_size$} {} {:<width_user$} {:<width_group$} {}{}\n",
-                permissions,
-                size,
-                modified_str,
-                colorize_user(&user),
-                colorize_group(&group),
-                name,
-                plugin_suffix,
-                width_size = min_size_len,
-                width_user = max_user_len,
-                width_group = max_group_len
-            ));
-
+            let mut name_with_target = name;
             if let Some(target) = entry.custom_fields.get("symlink_target") {
-                output.pop();
                 let current_dir = std::path::Path::new(&entry.path)
                     .parent()
                     .unwrap_or_else(|| std::path::Path::new("."));
@@ -138,8 +124,22 @@ impl FileFormatter for LongFormatter {
                 } else {
                     target.red().italic()
                 };
-                output.push_str(&format!(" -> {}\n", colored_target));
+                name_with_target = format!("{} -> {}", name_with_target, colored_target);
             }
+
+            output.push_str(&format!(
+                "{} {:>width_size$} {} {:<width_user$} {:<width_group$} {}{}\n",
+                permissions,
+                size,
+                modified_str,
+                colorize_user(&user),
+                colorize_group(&group),
+                name_with_target,
+                plugin_suffix,
+                width_size = min_size_len,
+                width_user = max_user_len,
+                width_group = max_group_len
+            ));
         }
         Ok(output)
     }

--- a/lla/src/formatter/long.rs
+++ b/lla/src/formatter/long.rs
@@ -3,7 +3,6 @@ use crate::error::Result;
 use crate::plugin::PluginManager;
 use crate::utils::color::*;
 use crate::utils::icons::format_with_icon;
-use colored::*;
 use lla_plugin_interface::proto::DecoratedEntry;
 use once_cell::sync::Lazy;
 
@@ -20,13 +19,18 @@ static GROUP_CACHE: Lazy<Mutex<HashMap<u32, String>>> = Lazy::new(|| Mutex::new(
 
 pub struct LongFormatter {
     pub show_icons: bool,
+    pub permission_format: String,
 }
 
 impl LongFormatter {
-    pub fn new(show_icons: bool) -> Self {
-        Self { show_icons }
+    pub fn new(show_icons: bool, permission_format: String) -> Self {
+        Self {
+            show_icons,
+            permission_format,
+        }
     }
 }
+
 impl FileFormatter for LongFormatter {
     fn format_files(
         &self,
@@ -65,7 +69,7 @@ impl FileFormatter for LongFormatter {
             let metadata = entry.metadata.as_ref().cloned().unwrap_or_default();
             let size = colorize_size(metadata.size);
             let perms = Permissions::from_mode(metadata.permissions);
-            let permissions = colorize_permissions(&perms);
+            let permissions = colorize_permissions(&perms, Some(&self.permission_format));
             let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(metadata.modified);
             let modified_str = colorize_date(&modified);
             let path = Path::new(&entry.path);
@@ -84,11 +88,11 @@ impl FileFormatter for LongFormatter {
                 if let Some(cached_user) = cache.get(&uid) {
                     cached_user.clone()
                 } else {
-                    let user_str = get_user_by_uid(uid)
+                    let user = get_user_by_uid(uid)
                         .map(|u| u.name().to_string_lossy().into_owned())
                         .unwrap_or_else(|| uid.to_string());
-                    cache.insert(uid, user_str.clone());
-                    user_str
+                    cache.insert(uid, user.clone());
+                    user
                 }
             };
 
@@ -97,11 +101,11 @@ impl FileFormatter for LongFormatter {
                 if let Some(cached_group) = cache.get(&gid) {
                     cached_group.clone()
                 } else {
-                    let group_str = get_group_by_gid(gid)
+                    let group = get_group_by_gid(gid)
                         .map(|g| g.name().to_string_lossy().into_owned())
                         .unwrap_or_else(|| gid.to_string());
-                    cache.insert(gid, group_str.clone());
-                    group_str
+                    cache.insert(gid, group.clone());
+                    group
                 }
             };
 
@@ -112,20 +116,15 @@ impl FileFormatter for LongFormatter {
                 format!(" {}", plugin_fields)
             };
 
-            let mut name_with_target = name;
-            if let Some(target) = entry.custom_fields.get("symlink_target") {
-                let current_dir = std::path::Path::new(&entry.path)
-                    .parent()
-                    .unwrap_or_else(|| std::path::Path::new("."));
-                let target_path = current_dir.join(target);
-                let colored_target = if let Ok(_) = target_path.symlink_metadata() {
-                    let target_path = std::path::Path::new(target);
-                    colorize_symlink_target(target_path)
+            let name_with_target = if metadata.is_symlink {
+                if let Some(target) = entry.custom_fields.get("symlink_target") {
+                    format!("{} -> {}", name, colorize_symlink_target(Path::new(target)))
                 } else {
-                    target.red().italic()
-                };
-                name_with_target = format!("{} -> {}", name_with_target, colored_target);
-            }
+                    name
+                }
+            } else {
+                name
+            };
 
             output.push_str(&format!(
                 "{} {:>width_size$} {} {:<width_user$} {:<width_group$} {}{}\n",

--- a/lla/src/lister/fuzzy.rs
+++ b/lla/src/lister/fuzzy.rs
@@ -722,7 +722,7 @@ impl ResultList {
                     .as_ref()
                     .map(|m| m.permissions())
                     .unwrap_or_else(|| Permissions::from_mode(0o644));
-                let perms_display = colorize_permissions(&perms);
+                let perms_display = colorize_permissions(&perms, Some("symbolic"));
                 let size_display = colorize_size(size);
                 let date_display = colorize_date(&modified);
 

--- a/lla/src/utils/color.rs
+++ b/lla/src/utils/color.rs
@@ -140,15 +140,25 @@ pub fn colorize_user(user: &str) -> ColoredString {
 use std::fs::Permissions;
 use std::os::unix::fs::PermissionsExt;
 
-pub fn colorize_permissions(permissions: &Permissions) -> String {
+pub fn colorize_permissions(permissions: &Permissions, format: Option<&str>) -> String {
     let mode = permissions.mode();
 
     if is_no_color() {
-        return format_permissions_no_color(mode);
+        return format_permissions_no_color(mode, format);
     }
 
     let theme = get_theme();
 
+    match format.unwrap_or("symbolic") {
+        "octal" => format_octal_permissions(mode, &theme),
+        "binary" => format_binary_permissions(mode, &theme),
+        "verbose" => format_verbose_permissions(mode, &theme),
+        "compact" => format_compact_permissions(mode, &theme),
+        _ => format_symbolic_permissions(mode, &theme),
+    }
+}
+
+fn format_symbolic_permissions(mode: u32, theme: &Theme) -> String {
     let file_type = if mode & 0o170000 == 0o120000 {
         "l".color(get_color(&theme.colors.permission_dir))
     } else if mode & 0o170000 == 0o040000 {
@@ -162,7 +172,293 @@ pub fn colorize_permissions(permissions: &Permissions) -> String {
     format!("{}{}{}{}", file_type, user, group, other)
 }
 
-fn format_permissions_no_color(mode: u32) -> String {
+fn format_octal_permissions(mode: u32, theme: &Theme) -> String {
+    let file_type = if mode & 0o170000 == 0o120000 {
+        "l".color(get_color(&theme.colors.permission_dir))
+    } else if mode & 0o170000 == 0o040000 {
+        "d".color(get_color(&theme.colors.permission_dir))
+    } else {
+        "-".color(get_color(&theme.colors.permission_none))
+    };
+
+    let perms = mode & 0o777;
+    let user = ((perms >> 6) & 0o7)
+        .to_string()
+        .color(get_color(&theme.colors.permission_read));
+    let group = ((perms >> 3) & 0o7)
+        .to_string()
+        .color(get_color(&theme.colors.permission_write));
+    let other = (perms & 0o7)
+        .to_string()
+        .color(get_color(&theme.colors.permission_exec));
+
+    format!("{}{}{}{}", file_type, user, group, other)
+}
+
+fn format_binary_permissions(mode: u32, theme: &Theme) -> String {
+    let file_type = if mode & 0o170000 == 0o120000 {
+        "l".color(get_color(&theme.colors.permission_dir))
+    } else if mode & 0o170000 == 0o040000 {
+        "d".color(get_color(&theme.colors.permission_dir))
+    } else {
+        "-".color(get_color(&theme.colors.permission_none))
+    };
+
+    let perms = mode & 0o777;
+    let binary = format!("{:09b}", perms);
+
+    let mut colored_binary = Vec::new();
+
+    for c in binary[0..3].chars() {
+        colored_binary.push(if c == '1' {
+            "1".color(get_color(&theme.colors.permission_read))
+                .to_string()
+        } else {
+            "0".color(get_color(&theme.colors.permission_none))
+                .to_string()
+        });
+    }
+
+    for c in binary[3..6].chars() {
+        colored_binary.push(if c == '1' {
+            "1".color(get_color(&theme.colors.permission_write))
+                .to_string()
+        } else {
+            "0".color(get_color(&theme.colors.permission_none))
+                .to_string()
+        });
+    }
+
+    for c in binary[6..9].chars() {
+        colored_binary.push(if c == '1' {
+            "1".color(get_color(&theme.colors.permission_exec))
+                .to_string()
+        } else {
+            "0".color(get_color(&theme.colors.permission_none))
+                .to_string()
+        });
+    }
+
+    format!("{}{}", file_type, colored_binary.join(""))
+}
+
+fn format_verbose_permissions(mode: u32, theme: &Theme) -> String {
+    let file_type = if mode & 0o170000 == 0o120000 {
+        "type:link".color(get_color(&theme.colors.permission_dir))
+    } else if mode & 0o170000 == 0o040000 {
+        "type:dir ".color(get_color(&theme.colors.permission_dir))
+    } else {
+        "type:file".color(get_color(&theme.colors.permission_none))
+    };
+
+    let user = format!(
+        "owner:{}{}{}",
+        if mode & 0o400 != 0 { "r" } else { "-" },
+        if mode & 0o200 != 0 { "w" } else { "-" },
+        if mode & 0o100 != 0 { "x" } else { "-" }
+    )
+    .color(get_color(&theme.colors.permission_read));
+
+    let group = format!(
+        "group:{}{}{}",
+        if mode & 0o40 != 0 { "r" } else { "-" },
+        if mode & 0o20 != 0 { "w" } else { "-" },
+        if mode & 0o10 != 0 { "x" } else { "-" }
+    )
+    .color(get_color(&theme.colors.permission_write));
+
+    let other = format!(
+        "others:{}{}{}",
+        if mode & 0o4 != 0 { "r" } else { "-" },
+        if mode & 0o2 != 0 { "w" } else { "-" },
+        if mode & 0o1 != 0 { "x" } else { "-" }
+    )
+    .color(get_color(&theme.colors.permission_exec));
+
+    format!("{} {} {} {}", file_type, user, group, other)
+}
+
+fn format_compact_permissions(mode: u32, theme: &Theme) -> String {
+    let perms = mode & 0o777;
+    format!("{:03o}", perms)
+        .color(get_color(&theme.colors.permission_read))
+        .to_string()
+}
+
+fn format_permissions_no_color(mode: u32, format: Option<&str>) -> String {
+    match format.unwrap_or("symbolic") {
+        "octal" => {
+            let file_type = if mode & 0o170000 == 0o120000 {
+                "l"
+            } else if mode & 0o170000 == 0o040000 {
+                "d"
+            } else {
+                "-"
+            };
+            let perms = mode & 0o777;
+            format!("{}{:03o}", file_type, perms)
+        }
+        "binary" => {
+            let file_type = if mode & 0o170000 == 0o120000 {
+                "l"
+            } else if mode & 0o170000 == 0o040000 {
+                "d"
+            } else {
+                "-"
+            };
+            let perms = mode & 0o777;
+            format!("{}{:09b}", file_type, perms)
+        }
+        "extended" => {
+            let file_type = if mode & 0o170000 == 0o120000 {
+                "l"
+            } else if mode & 0o170000 == 0o040000 {
+                "d"
+            } else {
+                "-"
+            };
+            let user_x = if mode & 0o100 != 0 {
+                if mode & 0o4000 != 0 {
+                    "s"
+                } else {
+                    "x"
+                }
+            } else {
+                if mode & 0o4000 != 0 {
+                    "S"
+                } else {
+                    "-"
+                }
+            };
+            let group_x = if mode & 0o10 != 0 {
+                if mode & 0o2000 != 0 {
+                    "s"
+                } else {
+                    "x"
+                }
+            } else {
+                if mode & 0o2000 != 0 {
+                    "S"
+                } else {
+                    "-"
+                }
+            };
+            let other_x = if mode & 0o1 != 0 {
+                if mode & 0o1000 != 0 {
+                    "t"
+                } else {
+                    "x"
+                }
+            } else {
+                if mode & 0o1000 != 0 {
+                    "T"
+                } else {
+                    "-"
+                }
+            };
+            format!(
+                "{}{}{}{}{}{}{}{}{}{}",
+                file_type,
+                if mode & 0o400 != 0 { "r" } else { "-" },
+                if mode & 0o200 != 0 { "w" } else { "-" },
+                user_x,
+                if mode & 0o40 != 0 { "r" } else { "-" },
+                if mode & 0o20 != 0 { "w" } else { "-" },
+                group_x,
+                if mode & 0o4 != 0 { "r" } else { "-" },
+                if mode & 0o2 != 0 { "w" } else { "-" },
+                other_x
+            )
+        }
+        "verbose" => {
+            let file_type = if mode & 0o170000 == 0o120000 {
+                "type:link"
+            } else if mode & 0o170000 == 0o040000 {
+                "type:dir"
+            } else {
+                "type:file"
+            };
+            format!(
+                "{} owner:{}{}{} group:{}{}{} others:{}{}{}",
+                file_type,
+                if mode & 0o400 != 0 { "r" } else { "-" },
+                if mode & 0o200 != 0 { "w" } else { "-" },
+                if mode & 0o100 != 0 { "x" } else { "-" },
+                if mode & 0o40 != 0 { "r" } else { "-" },
+                if mode & 0o20 != 0 { "w" } else { "-" },
+                if mode & 0o10 != 0 { "x" } else { "-" },
+                if mode & 0o4 != 0 { "r" } else { "-" },
+                if mode & 0o2 != 0 { "w" } else { "-" },
+                if mode & 0o1 != 0 { "x" } else { "-" }
+            )
+        }
+        "compact" => {
+            let perms = mode & 0o777;
+            format!("{:03o}", perms)
+        }
+        "descriptive" => {
+            let file_type = if mode & 0o170000 == 0o120000 {
+                "symbolic link"
+            } else if mode & 0o170000 == 0o040000 {
+                "directory"
+            } else {
+                "regular file"
+            };
+            format!(
+                "{}\n{}\n{}\n{}",
+                file_type,
+                if mode & 0o400 != 0 {
+                    "read"
+                } else {
+                    "not read"
+                },
+                if mode & 0o200 != 0 { " & write" } else { "" },
+                if mode & 0o100 != 0 { " & execute" } else { "" }
+            )
+        }
+        _ => {
+            let file_type = if mode & 0o170000 == 0o120000 {
+                "l"
+            } else if mode & 0o170000 == 0o040000 {
+                "d"
+            } else {
+                "-"
+            };
+            let user = triplet_no_color(mode, 6);
+            let group = triplet_no_color(mode, 3);
+            let other = triplet_no_color(mode, 0);
+            format!("{}{}{}{}", file_type, user, group, other)
+        }
+    }
+}
+
+fn triplet(mode: u32, shift: u32) -> String {
+    let theme = get_theme();
+    let r = if mode >> (shift + 2) & 1u32 != 0 {
+        "r".color(get_color(&theme.colors.permission_read))
+            .to_string()
+    } else {
+        "-".color(get_color(&theme.colors.permission_none))
+            .to_string()
+    };
+    let w = if mode >> (shift + 1) & 1u32 != 0 {
+        "w".color(get_color(&theme.colors.permission_write))
+            .to_string()
+    } else {
+        "-".color(get_color(&theme.colors.permission_none))
+            .to_string()
+    };
+    let x = if mode >> shift & 1u32 != 0 {
+        "x".color(get_color(&theme.colors.permission_exec))
+            .to_string()
+    } else {
+        "-".color(get_color(&theme.colors.permission_none))
+            .to_string()
+    };
+    format!("{}{}{}", r, w, x)
+}
+
+fn triplet_no_color(mode: u32, _shift: u32) -> String {
     let file_type = if mode & 0o170000 == 0o120000 {
         "l"
     } else if mode & 0o170000 == 0o040000 {
@@ -205,32 +501,6 @@ fn format_permissions_no_color(mode: u32) -> String {
         write(0),
         exec(0)
     )
-}
-
-fn triplet(mode: u32, shift: u32) -> String {
-    let theme = get_theme();
-    let r = if mode >> (shift + 2) & 1u32 != 0 {
-        "r".color(get_color(&theme.colors.permission_read))
-            .to_string()
-    } else {
-        "-".color(get_color(&theme.colors.permission_none))
-            .to_string()
-    };
-    let w = if mode >> (shift + 1) & 1u32 != 0 {
-        "w".color(get_color(&theme.colors.permission_write))
-            .to_string()
-    } else {
-        "-".color(get_color(&theme.colors.permission_none))
-            .to_string()
-    };
-    let x = if mode >> shift & 1u32 != 0 {
-        "x".color(get_color(&theme.colors.permission_exec))
-            .to_string()
-    } else {
-        "-".color(get_color(&theme.colors.permission_none))
-            .to_string()
-    };
-    format!("{}{}{}", r, w, x)
 }
 
 pub fn colorize_date(date: &std::time::SystemTime) -> ColoredString {

--- a/lla/src/utils/color.rs
+++ b/lla/src/utils/color.rs
@@ -149,7 +149,9 @@ pub fn colorize_permissions(permissions: &Permissions) -> String {
 
     let theme = get_theme();
 
-    let file_type = if mode & 0o40000 != 0 {
+    let file_type = if mode & 0o170000 == 0o120000 {
+        "l".color(get_color(&theme.colors.permission_dir))
+    } else if mode & 0o170000 == 0o040000 {
         "d".color(get_color(&theme.colors.permission_dir))
     } else {
         "-".color(get_color(&theme.colors.permission_none))
@@ -161,7 +163,13 @@ pub fn colorize_permissions(permissions: &Permissions) -> String {
 }
 
 fn format_permissions_no_color(mode: u32) -> String {
-    let file_type = if mode & 0o40000u32 != 0u32 { "d" } else { "-" };
+    let file_type = if mode & 0o170000 == 0o120000 {
+        "l"
+    } else if mode & 0o170000 == 0o040000 {
+        "d"
+    } else {
+        "-"
+    };
     let read = |shift| {
         if mode >> shift & 0o4u32 != 0u32 {
             "r"
@@ -267,4 +275,16 @@ impl ColorState {
     pub fn is_enabled(&self) -> bool {
         !self.no_color
     }
+}
+
+pub fn colorize_symlink_target(path: &Path) -> ColoredString {
+    if is_no_color() {
+        return path.to_string_lossy().into_owned().normal();
+    }
+
+    let theme = get_theme();
+    format!("{}", path.display())
+        .color(get_color(&theme.colors.symlink))
+        .italic()
+        .underline()
 }

--- a/lla_plugin_utils/Cargo.toml
+++ b/lla_plugin_utils/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.3.9" }
+lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.3.10" }
 serde = { workspace = true }
 colored = { workspace = true }
 toml = { workspace = true }


### PR DESCRIPTION
This pull request includes several updates to the `lla` project, focusing on enhancing the `README.md` documentation, adding new command-line options for formatting, and improving the file listing functionality. The most important changes include the addition of new command-line arguments, updates to the configuration file, and enhancements to the file listing logic.

### Enhancements to command-line options and configuration:

* Added `--grid-ignore` and `--permission-format` command-line arguments to `Args` struct and implemented their handling in `impl Args` (`lla/src/commands/args.rs`). [[1]](diffhunk://#diff-7ee069a02ec6297c808194fffe965bbc044aafea6a4bb9735202a34f3335d5d1R13) [[2]](diffhunk://#diff-7ee069a02ec6297c808194fffe965bbc044aafea6a4bb9735202a34f3335d5d1R40) [[3]](diffhunk://#diff-7ee069a02ec6297c808194fffe965bbc044aafea6a4bb9735202a34f3335d5d1R121-R125) [[4]](diffhunk://#diff-7ee069a02ec6297c808194fffe965bbc044aafea6a4bb9735202a34f3335d5d1R278-R285) [[5]](diffhunk://#diff-7ee069a02ec6297c808194fffe965bbc044aafea6a4bb9735202a34f3335d5d1R458) [[6]](diffhunk://#diff-7ee069a02ec6297c808194fffe965bbc044aafea6a4bb9735202a34f3335d5d1R485) [[7]](diffhunk://#diff-7ee069a02ec6297c808194fffe965bbc044aafea6a4bb9735202a34f3335d5d1R612) [[8]](diffhunk://#diff-7ee069a02ec6297c808194fffe965bbc044aafea6a4bb9735202a34f3335d5d1R657-R660)
* Updated `FormatterConfig` to include `GridFormatterConfig` with `ignore_width` and `max_width` attributes, and added default values for these attributes (`lla/src/config/mod.rs`). [[1]](diffhunk://#diff-f9ad0af36035815784d031019838b9125aa2a98ae85924693b84c541b96ef530L16-R35) [[2]](diffhunk://#diff-f9ad0af36035815784d031019838b9125aa2a98ae85924693b84c541b96ef530L40-R80)
* Added `permission_format` to the `Config` struct and updated the configuration file handling to support this new attribute (`lla/src/config/mod.rs`). [[1]](diffhunk://#diff-f9ad0af36035815784d031019838b9125aa2a98ae85924693b84c541b96ef530R146) [[2]](diffhunk://#diff-f9ad0af36035815784d031019838b9125aa2a98ae85924693b84c541b96ef530R165-R190) [[3]](diffhunk://#diff-f9ad0af36035815784d031019838b9125aa2a98ae85924693b84c541b96ef530R223-R233) [[4]](diffhunk://#diff-f9ad0af36035815784d031019838b9125aa2a98ae85924693b84c541b96ef530R269-R278)

### Documentation updates:

* Updated `README.md` to include descriptions and examples for the new `--grid-ignore` and `--permission-format` options, and improved the formatting of the command descriptions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L140-R140) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L210-R215) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L230-R234) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L325-R331)

### File listing improvements:

* Modified `list_and_decorate_files` function to use `symlink_metadata` instead of `metadata` to correctly handle symbolic links, and added custom fields for symlink targets (`lla/src/commands/file_utils.rs`). [[1]](diffhunk://#diff-abaae53e34f688f90bdc509016a02512f11d64a19f9dae54fdaf78447711c7b6L151-R152) [[2]](diffhunk://#diff-abaae53e34f688f90bdc509016a02512f11d64a19f9dae54fdaf78447711c7b6R201-R214)
* Updated `create_formatter` function to pass the new `permission_format` and `grid_ignore` options to the appropriate formatters (`lla/src/commands/file_utils.rs`).

### Workflow updates:

* Added steps to create and upload a completions archive in the release workflow (`.github/workflows/release.yml`). [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R207-R210) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R219) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R264-R266)