### PR TITLE
feat: add multiple new themes

### DIFF
--- a/themes/README.md
+++ b/themes/README.md
@@ -233,14 +233,22 @@ lla includes several pre-configured themes:
 - **ayu_light**: Light theme with carefully selected colors for optimal readability
 - **ayu_mirage**: Refined dark theme with muted colors and soft contrasts
 - **catppuccin_mocha**: A soothing pastel theme for the high-spirited, featuring warm, cozy colors
+- **circuit_dreams**: A theme inspired by vintage circuit boards and electronic components
+- **cosmic_night**: A sophisticated dark theme with cosmic-inspired colors and nebula accents
+- **deep_sea**: An ocean-inspired theme featuring the colors of marine depths
 - **dracula**: Classic Dracula color scheme with vibrant colors and high contrast
+- **forest_depths**: A theme inspired by the depths of an ancient forest at twilight
 - **gruvbox_dark**: Retro groove color scheme with warm, earthy tones and high contrast
 - **material_ocean**: Deep blue theme based on Material Design, featuring oceanic colors
+- **moonlight**: A minimal theme with subtle blue-gray tones inspired by moonlit nights
+- **neon_dreams**: A vibrant cyberpunk theme featuring electric neons and digital gradients
 - **nord**: Arctic, north-bluish color palette with elegant pastel colors
 - **one_dark**: Dark theme inspired by Atom, featuring a perfect balance of cool and warm colors
 - **poimandres**: Deep space aesthetic with vibrant accents
+- **synthwave_84**: A retro-computing theme inspired by 1980s aesthetics
 - **tokyo_night**: Dark theme inspired by the vibrant lights of Tokyo at night
 - **vesper**: Minimalist dark theme with warm accents
+- **zen**: A minimal monochromatic theme emphasizing simplicity and clarity
 
 ## Usage
 

--- a/themes/circuit_dreams.toml
+++ b/themes/circuit_dreams.toml
@@ -1,0 +1,116 @@
+name = "circuit_dreams"
+author = "Mohamed Achaq"
+description = "A theme inspired by vintage circuit boards and electronic components, featuring copper traces, solder joints, and LED indicators"
+
+[colors]
+file = "#FFD484"
+directory = "#4AE0B8"
+symlink = "#73DFFF"
+executable = "#FF6B97"
+size = "#958993"
+date = "#958993"
+user = "#B79CFF"
+group = "#6B6B6B"
+permission_dir = "#4AE0B8"
+permission_read = "#73DFFF"
+permission_write = "#FFD484"
+permission_exec = "#FF6B97"
+permission_none = "#1F2433"
+
+[special_files]
+[special_files.folders]
+"node_modules" = { h = 0, s = 0, l = 0.15 }
+"target" = "#1F2433"
+"dist" = "#1F2433"
+".git" = "#4AE0B8"
+"build" = "#1F2433"
+".cache" = "#1F2433"
+"coverage" = "#1F2433"
+"vendor" = "#1F2433"
+"*-env" = "#FF6B97"
+"venv" = "#FF6B97"
+".env" = "#FF6B97"
+"env" = "#FF6B97"
+"*.d" = "#73DFFF"
+"*_cache" = "#1F2433"
+"*-cache" = "#1F2433"
+".terraform" = "#1F2433"
+
+[special_files.dotfiles]
+".gitignore" = "#73DFFF"
+".env" = "#FF6B97"
+".dockerignore" = "#73DFFF"
+".editorconfig" = "#73DFFF"
+".prettierrc" = "#73DFFF"
+".eslintrc" = "#73DFFF"
+".babelrc" = "#73DFFF"
+".npmrc" = "#73DFFF"
+".yarnrc" = "#73DFFF"
+".zshrc" = "#73DFFF"
+".bashrc" = "#73DFFF"
+
+[special_files.exact_match]
+"Dockerfile" = "#73DFFF"
+"docker-compose.yml" = "#73DFFF"
+"Makefile" = "#FF6B97"
+"CMakeLists.txt" = "#FF6B97"
+"README.md" = "#4AE0B8"
+"LICENSE" = "#4AE0B8"
+"CHANGELOG.md" = "#4AE0B8"
+"CONTRIBUTING.md" = "#4AE0B8"
+"package.json" = "#4AE0B8"
+"package-lock.json" = "#1F2433"
+"yarn.lock" = "#1F2433"
+"Cargo.toml" = "#FF6B97"
+"Cargo.lock" = "#1F2433"
+"composer.json" = "#4AE0B8"
+"go.mod" = "#73DFFF"
+"go.sum" = "#1F2433"
+
+[special_files.patterns]
+"*rc" = "#73DFFF"
+"*.config.*" = "#73DFFF"
+"*.conf" = "#73DFFF"
+"*.min.*" = "#1F2433"
+"*.map" = "#1F2433"
+"*.lock" = "#1F2433"
+"*.test.*" = "#FF6B97"
+"*.spec.*" = "#FF6B97"
+"*_test.*" = "#FF6B97"
+"*_spec.*" = "#FF6B97"
+
+[extensions.groups]
+logic = ["rs", "cpp", "c", "h", "hpp"]
+compute = ["py", "java", "go", "rb", "php"]
+web = ["js", "ts", "jsx", "tsx"]
+markup = ["html", "xml", "svg", "vue"]
+style = ["css", "scss", "sass", "less"]
+config = ["json", "yaml", "toml", "ini"]
+shell = ["sh", "bash", "zsh", "fish"]
+docs = ["md", "txt", "pdf", "doc"]
+data = ["csv", "sql", "db", "sqlite"]
+media = ["png", "jpg", "mp3", "mp4"]
+archive = ["zip", "tar", "gz", "7z"]
+
+[extensions.colors]
+logic = "#FF6B97"
+compute = "#4AE0B8"
+web = "#FFD484"
+markup = "#B79CFF"
+style = "#73DFFF"
+config = "#4AE0B8"
+shell = "#FF6B97"
+docs = "#FFD484"
+data = "#73DFFF"
+media = "#B79CFF"
+archive = "#FF6B97"
+rs = "#FF6B97"
+cpp = "#FF6B97"
+py = "#4AE0B8"
+js = "#FFD484"
+ts = "#FFD484"
+go = "#4AE0B8"
+html = "#B79CFF"
+css = "#73DFFF"
+md = "#FFD484"
+sql = "#73DFFF"

--- a/themes/cosmic_night.toml
+++ b/themes/cosmic_night.toml
@@ -1,0 +1,183 @@
+name = "cosmic_night"
+author = "Mohamed Achaq"
+description = "A sophisticated dark theme with cosmic-inspired colors, featuring deep space blues and nebula accents for comfortable viewing"
+
+[colors]
+file = "#C9D4FF"
+directory = "#7B93DB"
+symlink = "#84CAFF"
+executable = "#95F2D9"
+
+size = "#8B8FA3"
+date = "#8B8FA3"
+user = "#B488D9"
+group = "#6D7185"
+
+permission_dir = "#7B93DB"
+permission_read = "#95F2D9"
+permission_write = "#FFD479"
+permission_exec = "#FF9CAC"
+permission_none = "#3D3F4D"
+
+[special_files]
+[special_files.folders]
+"node_modules" = "#3D3F4D"
+"target" = "#3D3F4D"
+"dist" = "#3D3F4D"
+".git" = "#7B93DB"
+"build" = "#3D3F4D"
+".cache" = "#3D3F4D"
+"coverage" = "#3D3F4D"
+"vendor" = "#3D3F4D"
+
+"*-env" = "#95F2D9"
+"venv" = "#95F2D9"
+".env" = "#95F2D9"
+"env" = "#95F2D9"
+"*.d" = "#84CAFF"
+
+"*_cache" = "#3D3F4D"
+"*-cache" = "#3D3F4D"
+".terraform" = "#3D3F4D"
+
+[special_files.dotfiles]
+".gitignore" = "#84CAFF"
+".env" = "#95F2D9"
+".dockerignore" = "#84CAFF"
+".editorconfig" = "#84CAFF"
+".prettierrc" = "#84CAFF"
+".eslintrc" = "#84CAFF"
+".babelrc" = "#84CAFF"
+".npmrc" = "#84CAFF"
+".yarnrc" = "#84CAFF"
+".zshrc" = "#84CAFF"
+".bashrc" = "#84CAFF"
+
+[special_files.exact_match]
+"Dockerfile" = "#84CAFF"
+"docker-compose.yml" = "#84CAFF"
+"Makefile" = "#FF9CAC"
+"CMakeLists.txt" = "#FF9CAC"
+
+"README.md" = "#7B93DB"
+"LICENSE" = "#7B93DB"
+"CHANGELOG.md" = "#7B93DB"
+"CONTRIBUTING.md" = "#7B93DB"
+
+"package.json" = "#7B93DB"
+"package-lock.json" = "#3D3F4D"
+"yarn.lock" = "#3D3F4D"
+"Cargo.toml" = "#FF9CAC"
+"Cargo.lock" = "#3D3F4D"
+"composer.json" = "#7B93DB"
+"go.mod" = "#84CAFF"
+"go.sum" = "#3D3F4D"
+
+"tsconfig.json" = "#84CAFF"
+"webpack.config.js" = "#84CAFF"
+"vite.config.ts" = "#84CAFF"
+"next.config.js" = "#84CAFF"
+"nuxt.config.js" = "#84CAFF"
+"svelte.config.js" = "#84CAFF"
+
+"flake.nix" = "#7B93DB"
+"flake.lock" = "#3D3F4D"
+"shell.nix" = "#7B93DB"
+"default.nix" = "#7B93DB"
+
+[special_files.patterns]
+"*rc" = "#84CAFF"
+"*.config.*" = "#84CAFF"
+"*.conf" = "#84CAFF"
+
+"*.min.*" = "#3D3F4D"
+"*.map" = "#3D3F4D"
+"*.lock" = "#3D3F4D"
+
+"*.test.*" = "#95F2D9"
+"*.spec.*" = "#95F2D9"
+"*_test.*" = "#95F2D9"
+"*_spec.*" = "#95F2D9"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++", "h", "c"]
+go = ["go", "mod", "sum"]
+ruby = ["rb", "erb", "gemspec"]
+php = ["php", "phtml", "php.inc"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+elixir = ["ex", "exs"]
+haskell = ["hs", "lhs"]
+lua = ["lua"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs", "jsx", "tsx"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = ["md", "rst", "txt", "org", "wiki", "adoc", "tex", "pdf", "epub", "doc", "docx", "rtf"]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic", "raw", "cr2", "nef"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma", "midi"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#FF9CAC"
+python = "#95F2D9"
+javascript = "#FFD479"
+typescript = "#84CAFF"
+java = "#FF9CAC"
+csharp = "#95F2D9"
+cpp = "#FF9CAC"
+go = "#84CAFF"
+ruby = "#FF9CAC"
+php = "#95F2D9"
+swift = "#FF9CAC"
+kotlin = "#95F2D9"
+elixir = "#B488D9"
+haskell = "#84CAFF"
+lua = "#7B93DB"
+nix = "#84CAFF"
+
+markup = "#B488D9"
+style = "#95F2D9"
+web_config = "#7B93DB"
+
+shell = "#95F2D9"
+script = "#7B93DB"
+
+doc = "#C9D4FF"
+image = "#FFB07B"
+video = "#FFB07B"
+audio = "#FFB07B"
+
+data = "#7B93DB"
+archive = "#FF9CAC"
+
+rs = "#FF9CAC"
+py = "#95F2D9"
+js = "#FFD479"
+ts = "#84CAFF"
+jsx = "#FFD479"
+tsx = "#84CAFF"
+vue = "#95F2D9"
+css = "#95F2D9"
+scss = "#95F2D9"
+html = "#B488D9"
+md = "#C9D4FF"
+json = "#7B93DB"
+yaml = "#7B93DB"
+toml = "#7B93DB"
+sql = "#84CAFF"

--- a/themes/deep_sea.toml
+++ b/themes/deep_sea.toml
@@ -1,0 +1,183 @@
+name = "deep_sea"
+author = "Mohamed Achaq"
+description = "An ocean-inspired theme featuring the colors of marine depths, from sunlit surface waters to bioluminescent deep sea creatures"
+
+[colors]
+file = "#E1F5FE"
+directory = "#64B5F6"
+symlink = "#4DD0E1"
+executable = "#80DEEA"
+
+size = "#78909C"
+date = "#78909C"
+user = "#B388FF"
+group = "#546E7A"
+
+permission_dir = "#64B5F6"
+permission_read = "#80DEEA"
+permission_write = "#FFD180"
+permission_exec = "#FF8A80"
+permission_none = "#1E2A3A"
+
+[special_files]
+[special_files.folders]
+"node_modules" = "#1E2A3A"
+"target" = "#1E2A3A"
+"dist" = "#1E2A3A"
+".git" = "#64B5F6"
+"build" = "#1E2A3A"
+".cache" = "#1E2A3A"
+"coverage" = "#1E2A3A"
+"vendor" = "#1E2A3A"
+
+"*-env" = "#80DEEA"
+"venv" = "#80DEEA"
+".env" = "#80DEEA"
+"env" = "#80DEEA"
+"*.d" = "#4DD0E1"
+
+"*_cache" = "#1E2A3A"
+"*-cache" = "#1E2A3A"
+".terraform" = "#1E2A3A"
+
+[special_files.dotfiles]
+".gitignore" = "#4DD0E1"
+".env" = "#80DEEA"
+".dockerignore" = "#4DD0E1"
+".editorconfig" = "#4DD0E1"
+".prettierrc" = "#4DD0E1"
+".eslintrc" = "#4DD0E1"
+".babelrc" = "#4DD0E1"
+".npmrc" = "#4DD0E1"
+".yarnrc" = "#4DD0E1"
+".zshrc" = "#4DD0E1"
+".bashrc" = "#4DD0E1"
+
+[special_files.exact_match]
+"Dockerfile" = "#4DD0E1"
+"docker-compose.yml" = "#4DD0E1"
+"Makefile" = "#FF8A80"
+"CMakeLists.txt" = "#FF8A80"
+
+"README.md" = "#64B5F6"
+"LICENSE" = "#64B5F6"
+"CHANGELOG.md" = "#64B5F6"
+"CONTRIBUTING.md" = "#64B5F6"
+
+"package.json" = "#64B5F6"
+"package-lock.json" = "#1E2A3A"
+"yarn.lock" = "#1E2A3A"
+"Cargo.toml" = "#FF8A80"
+"Cargo.lock" = "#1E2A3A"
+"composer.json" = "#64B5F6"
+"go.mod" = "#4DD0E1"
+"go.sum" = "#1E2A3A"
+
+"tsconfig.json" = "#4DD0E1"
+"webpack.config.js" = "#4DD0E1"
+"vite.config.ts" = "#4DD0E1"
+"next.config.js" = "#4DD0E1"
+"nuxt.config.js" = "#4DD0E1"
+"svelte.config.js" = "#4DD0E1"
+
+"flake.nix" = "#64B5F6"
+"flake.lock" = "#1E2A3A"
+"shell.nix" = "#64B5F6"
+"default.nix" = "#64B5F6"
+
+[special_files.patterns]
+"*rc" = "#4DD0E1"
+"*.config.*" = "#4DD0E1"
+"*.conf" = "#4DD0E1"
+
+"*.min.*" = "#1E2A3A"
+"*.map" = "#1E2A3A"
+"*.lock" = "#1E2A3A"
+
+"*.test.*" = "#80DEEA"
+"*.spec.*" = "#80DEEA"
+"*_test.*" = "#80DEEA"
+"*_spec.*" = "#80DEEA"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++", "h", "c"]
+go = ["go", "mod", "sum"]
+ruby = ["rb", "erb", "gemspec"]
+php = ["php", "phtml", "php.inc"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+elixir = ["ex", "exs"]
+haskell = ["hs", "lhs"]
+lua = ["lua"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs", "jsx", "tsx"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = ["md", "rst", "txt", "org", "wiki", "adoc", "tex", "pdf", "epub", "doc", "docx", "rtf"]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic", "raw", "cr2", "nef"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma", "midi"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#FF8A80"
+python = "#80DEEA"
+javascript = "#FFD180"
+typescript = "#4DD0E1"
+java = "#FF8A80"
+csharp = "#80DEEA"
+cpp = "#FF8A80"
+go = "#4DD0E1"
+ruby = "#FF8A80"
+php = "#80DEEA"
+swift = "#FF8A80"
+kotlin = "#80DEEA"
+elixir = "#B388FF"
+haskell = "#4DD0E1"
+lua = "#64B5F6"
+nix = "#4DD0E1"
+
+markup = "#B388FF"
+style = "#80DEEA"
+web_config = "#64B5F6"
+
+shell = "#80DEEA"
+script = "#64B5F6"
+
+doc = "#E1F5FE"
+image = "#F06292"
+video = "#F06292"
+audio = "#F06292"
+
+data = "#64B5F6"
+archive = "#FF8A80"
+
+rs = "#FF8A80"
+py = "#80DEEA"
+js = "#FFD180"
+ts = "#4DD0E1"
+jsx = "#FFD180"
+tsx = "#4DD0E1"
+vue = "#80DEEA"
+css = "#80DEEA"
+scss = "#80DEEA"
+html = "#B388FF"
+md = "#E1F5FE"
+json = "#64B5F6"
+yaml = "#64B5F6"
+toml = "#64B5F6"
+sql = "#4DD0E1"

--- a/themes/forest_depths.toml
+++ b/themes/forest_depths.toml
@@ -1,0 +1,220 @@
+name = "forest_depths"
+author = "Mohamed Achaq"
+description = "A theme inspired by the depths of an ancient forest at twilight, featuring moss greens, bark browns, and bioluminescent accents"
+
+[colors]
+file = "#E0E8D5"
+directory = "#8FB573"
+symlink = "#78E8C6"
+executable = "#A2FF91"
+
+size = "#9A8A75"
+date = "#9A8A75"
+user = "#D7B875"
+group = "#6A5F51"
+
+permission_dir = "#8FB573"
+permission_read = "#A2FF91"
+permission_write = "#FFE175"
+permission_exec = "#FF9B82"
+permission_none = "#2A332D"
+
+[special_files]
+[special_files.folders]
+"node_modules" = "#2A332D"
+"target" = "#2A332D"
+"dist" = "#2A332D"
+".git" = "#8FB573"
+"build" = "#2A332D"
+".cache" = "#2A332D"
+"coverage" = "#2A332D"
+"vendor" = "#2A332D"
+
+"*-env" = "#A2FF91"
+"venv" = "#A2FF91"
+".env" = "#A2FF91"
+"env" = "#A2FF91"
+"*.d" = "#78E8C6"
+
+"*_cache" = "#2A332D"
+"*-cache" = "#2A332D"
+".terraform" = "#2A332D"
+
+[special_files.dotfiles]
+".gitignore" = "#78E8C6"
+".env" = "#A2FF91"
+".dockerignore" = "#78E8C6"
+".editorconfig" = "#78E8C6"
+".prettierrc" = "#78E8C6"
+".eslintrc" = "#78E8C6"
+".babelrc" = "#78E8C6"
+".npmrc" = "#78E8C6"
+".yarnrc" = "#78E8C6"
+".zshrc" = "#78E8C6"
+".bashrc" = "#78E8C6"
+
+[special_files.exact_match]
+"Dockerfile" = "#78E8C6"
+"docker-compose.yml" = "#78E8C6"
+"Makefile" = "#FF9B82"
+"CMakeLists.txt" = "#FF9B82"
+
+"README.md" = "#8FB573"
+"LICENSE" = "#8FB573"
+"CHANGELOG.md" = "#8FB573"
+"CONTRIBUTING.md" = "#8FB573"
+
+"package.json" = "#8FB573"
+"package-lock.json" = "#2A332D"
+"yarn.lock" = "#2A332D"
+"Cargo.toml" = "#FF9B82"
+"Cargo.lock" = "#2A332D"
+"composer.json" = "#8FB573"
+"go.mod" = "#78E8C6"
+"go.sum" = "#2A332D"
+
+"tsconfig.json" = "#78E8C6"
+"webpack.config.js" = "#78E8C6"
+"vite.config.ts" = "#78E8C6"
+"next.config.js" = "#78E8C6"
+"nuxt.config.js" = "#78E8C6"
+"svelte.config.js" = "#78E8C6"
+
+"flake.nix" = "#8FB573"
+"flake.lock" = "#2A332D"
+"shell.nix" = "#8FB573"
+"default.nix" = "#8FB573"
+
+[special_files.patterns]
+"*rc" = "#78E8C6"
+"*.config.*" = "#78E8C6"
+"*.conf" = "#78E8C6"
+
+"*.min.*" = "#2A332D"
+"*.map" = "#2A332D"
+"*.lock" = "#2A332D"
+
+"*.test.*" = "#A2FF91"
+"*.spec.*" = "#A2FF91"
+"*_test.*" = "#A2FF91"
+"*_spec.*" = "#A2FF91"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++", "h", "c"]
+go = ["go", "mod", "sum"]
+ruby = ["rb", "erb", "gemspec"]
+php = ["php", "phtml", "php.inc"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+elixir = ["ex", "exs"]
+haskell = ["hs", "lhs"]
+lua = ["lua"]
+nix = ["nix"]
+
+markup = [
+    "html",
+    "htm",
+    "xhtml",
+    "xml",
+    "svg",
+    "vue",
+    "wasm",
+    "ejs",
+    "jsx",
+    "tsx",
+]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+image = [
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "bmp",
+    "tiff",
+    "webp",
+    "ico",
+    "heic",
+    "raw",
+    "cr2",
+    "nef",
+]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma", "midi"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#FF9B82"
+python = "#A2FF91"
+javascript = "#FFE175"
+typescript = "#78E8C6"
+java = "#FF9B82"
+csharp = "#A2FF91"
+cpp = "#FF9B82"
+go = "#78E8C6"
+ruby = "#FF9B82"
+php = "#A2FF91"
+swift = "#FF9B82"
+kotlin = "#A2FF91"
+elixir = "#D7B875"
+haskell = "#78E8C6"
+lua = "#8FB573"
+nix = "#78E8C6"
+
+markup = "#D7B875"
+style = "#A2FF91"
+web_config = "#8FB573"
+
+shell = "#A2FF91"
+script = "#8FB573"
+
+doc = "#E0E8D5"
+image = "#FFB892"
+video = "#FFB892"
+audio = "#FFB892"
+
+data = "#8FB573"
+archive = "#FF9B82"
+
+rs = "#FF9B82"
+py = "#A2FF91"
+js = "#FFE175"
+ts = "#78E8C6"
+jsx = "#FFE175"
+tsx = "#78E8C6"
+vue = "#A2FF91"
+css = "#A2FF91"
+scss = "#A2FF91"
+html = "#D7B875"
+md = "#E0E8D5"
+json = "#8FB573"
+yaml = "#8FB573"
+toml = "#8FB573"
+sql = "#78E8C6"

--- a/themes/moonlight.toml
+++ b/themes/moonlight.toml
@@ -1,0 +1,115 @@
+name = "moonlight"
+author = "Mohamed Achaq"
+description = "A minimal theme with subtle blue-gray tones inspired by moonlit nights"
+
+[colors]
+file = "#C8D3E3"
+directory = "#E2E8F0"
+symlink = "#A9B8D2"
+executable = "#E2E8F0"
+
+size = "#7A8599"
+date = "#7A8599"
+user = "#A9B8D2"
+group = "#677387"
+
+permission_dir = "#E2E8F0"
+permission_read = "#C8D3E3"
+permission_write = "#B4C2D6"
+permission_exec = "#E2E8F0"
+permission_none = "#363B47"
+
+[special_files]
+[special_files.folders]
+"node_modules" = "#363B47"
+"target" = "#363B47"
+"dist" = "#363B47"
+".git" = "#E2E8F0"
+"build" = "#363B47"
+".cache" = "#363B47"
+"coverage" = "#363B47"
+"vendor" = "#363B47"
+
+"*-env" = "#E2E8F0"
+"venv" = "#E2E8F0"
+".env" = "#E2E8F0"
+"env" = "#E2E8F0"
+"*.d" = "#A9B8D2"
+
+"*_cache" = "#363B47"
+"*-cache" = "#363B47"
+".terraform" = "#363B47"
+
+[special_files.dotfiles]
+".gitignore" = "#A9B8D2"
+".env" = "#E2E8F0"
+".dockerignore" = "#A9B8D2"
+".editorconfig" = "#A9B8D2"
+".prettierrc" = "#A9B8D2"
+".eslintrc" = "#A9B8D2"
+".babelrc" = "#A9B8D2"
+".npmrc" = "#A9B8D2"
+".yarnrc" = "#A9B8D2"
+".zshrc" = "#A9B8D2"
+".bashrc" = "#A9B8D2"
+
+[special_files.exact_match]
+"Dockerfile" = "#A9B8D2"
+"docker-compose.yml" = "#A9B8D2"
+"Makefile" = "#E2E8F0"
+"CMakeLists.txt" = "#E2E8F0"
+
+"README.md" = "#E2E8F0"
+"LICENSE" = "#E2E8F0"
+"CHANGELOG.md" = "#E2E8F0"
+"CONTRIBUTING.md" = "#E2E8F0"
+
+"package.json" = "#E2E8F0"
+"package-lock.json" = "#363B47"
+"yarn.lock" = "#363B47"
+"Cargo.toml" = "#E2E8F0"
+"Cargo.lock" = "#363B47"
+"composer.json" = "#E2E8F0"
+"go.mod" = "#A9B8D2"
+"go.sum" = "#363B47"
+
+[special_files.patterns]
+"*rc" = "#A9B8D2"
+"*.config.*" = "#A9B8D2"
+"*.conf" = "#A9B8D2"
+
+"*.min.*" = "#363B47"
+"*.map" = "#363B47"
+"*.lock" = "#363B47"
+
+"*.test.*" = "#E2E8F0"
+"*.spec.*" = "#E2E8F0"
+"*_test.*" = "#E2E8F0"
+"*_spec.*" = "#E2E8F0"
+
+[extensions.groups]
+source = ["rs", "py", "js", "ts", "java", "c", "cpp", "go", "rb", "php", "swift", "kt"]
+config = ["json", "yml", "yaml", "toml", "ini", "conf"]
+doc = ["md", "txt", "pdf", "doc", "docx", "rtf"]
+web = ["html", "css", "scss", "sass"]
+script = ["sh", "bash", "zsh", "fish"]
+data = ["csv", "sql", "db"]
+media = ["jpg", "png", "gif", "mp3", "mp4"]
+archive = ["zip", "tar", "gz", "7z"]
+
+[extensions.colors]
+source = "#C8D3E3"
+config = "#C8D3E3"
+doc = "#C8D3E3"
+web = "#C8D3E3"
+script = "#C8D3E3"
+data = "#C8D3E3"
+media = "#C8D3E3"
+archive = "#C8D3E3"
+
+rs = "#E2E8F0"
+py = "#E2E8F0"
+js = "#E2E8F0"
+ts = "#E2E8F0"
+go = "#E2E8F0"
+java = "#E2E8F0"

--- a/themes/neon_dreams.toml
+++ b/themes/neon_dreams.toml
@@ -1,0 +1,183 @@
+name = "neon_dreams"
+author = "Mohamed Achaq"
+description = "A vibrant cyberpunk theme featuring electric neons and digital gradients, perfect for those who dream in RGB"
+
+[colors]
+file = "#E0FFFF"
+directory = "#00FFBD"
+symlink = "#00AAFF"
+executable = "#FF3366"
+
+size = "#607D8B"
+date = "#607D8B"
+user = "#FF00FF"
+group = "#455A64"
+
+permission_dir = "#00FFBD"
+permission_read = "#FF3366"
+permission_write = "#FFFF00"
+permission_exec = "#FF00FF"
+permission_none = "#1A1B26"
+
+[special_files]
+[special_files.folders]
+"node_modules" = "#1A1B26"
+"target" = "#1A1B26"
+"dist" = "#1A1B26"
+".git" = "#00FFBD"
+"build" = "#1A1B26"
+".cache" = "#1A1B26"
+"coverage" = "#1A1B26"
+"vendor" = "#1A1B26"
+
+"*-env" = "#FF3366"
+"venv" = "#FF3366"
+".env" = "#FF3366"
+"env" = "#FF3366"
+"*.d" = "#00AAFF"
+
+"*_cache" = "#1A1B26"
+"*-cache" = "#1A1B26"
+".terraform" = "#1A1B26"
+
+[special_files.dotfiles]
+".gitignore" = "#00AAFF"
+".env" = "#FF3366"
+".dockerignore" = "#00AAFF"
+".editorconfig" = "#00AAFF"
+".prettierrc" = "#00AAFF"
+".eslintrc" = "#00AAFF"
+".babelrc" = "#00AAFF"
+".npmrc" = "#00AAFF"
+".yarnrc" = "#00AAFF"
+".zshrc" = "#00AAFF"
+".bashrc" = "#00AAFF"
+
+[special_files.exact_match]
+"Dockerfile" = "#00AAFF"
+"docker-compose.yml" = "#00AAFF"
+"Makefile" = "#FF3366"
+"CMakeLists.txt" = "#FF3366"
+
+"README.md" = "#00FFBD"
+"LICENSE" = "#00FFBD"
+"CHANGELOG.md" = "#00FFBD"
+"CONTRIBUTING.md" = "#00FFBD"
+
+"package.json" = "#00FFBD"
+"package-lock.json" = "#1A1B26"
+"yarn.lock" = "#1A1B26"
+"Cargo.toml" = "#FF3366"
+"Cargo.lock" = "#1A1B26"
+"composer.json" = "#00FFBD"
+"go.mod" = "#00AAFF"
+"go.sum" = "#1A1B26"
+
+"tsconfig.json" = "#00AAFF"
+"webpack.config.js" = "#00AAFF"
+"vite.config.ts" = "#00AAFF"
+"next.config.js" = "#00AAFF"
+"nuxt.config.js" = "#00AAFF"
+"svelte.config.js" = "#00AAFF"
+
+"flake.nix" = "#00FFBD"
+"flake.lock" = "#1A1B26"
+"shell.nix" = "#00FFBD"
+"default.nix" = "#00FFBD"
+
+[special_files.patterns]
+"*rc" = "#00AAFF"
+"*.config.*" = "#00AAFF"
+"*.conf" = "#00AAFF"
+
+"*.min.*" = "#1A1B26"
+"*.map" = "#1A1B26"
+"*.lock" = "#1A1B26"
+
+"*.test.*" = "#FF3366"
+"*.spec.*" = "#FF3366"
+"*_test.*" = "#FF3366"
+"*_spec.*" = "#FF3366"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++", "h", "c"]
+go = ["go", "mod", "sum"]
+ruby = ["rb", "erb", "gemspec"]
+php = ["php", "phtml", "php.inc"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+elixir = ["ex", "exs"]
+haskell = ["hs", "lhs"]
+lua = ["lua"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs", "jsx", "tsx"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = ["md", "rst", "txt", "org", "wiki", "adoc", "tex", "pdf", "epub", "doc", "docx", "rtf"]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic", "raw", "cr2", "nef"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma", "midi"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#FF3366"
+python = "#00FFBD"
+javascript = "#FFFF00"
+typescript = "#00AAFF"
+java = "#FF3366"
+csharp = "#00FFBD"
+cpp = "#FF3366"
+go = "#00AAFF"
+ruby = "#FF3366"
+php = "#00FFBD"
+swift = "#FF3366"
+kotlin = "#00FFBD"
+elixir = "#FF00FF"
+haskell = "#00AAFF"
+lua = "#00FFBD"
+nix = "#00AAFF"
+
+markup = "#FF00FF"
+style = "#00FFBD"
+web_config = "#00FFBD"
+
+shell = "#00FFBD"
+script = "#00FFBD"
+
+doc = "#E0FFFF"
+image = "#FF1A75"
+video = "#FF1A75"
+audio = "#FF1A75"
+
+data = "#00FFBD"
+archive = "#FF3366"
+
+rs = "#FF3366"
+py = "#00FFBD"
+js = "#FFFF00"
+ts = "#00AAFF"
+jsx = "#FFFF00"
+tsx = "#00AAFF"
+vue = "#00FFBD"
+css = "#00FFBD"
+scss = "#00FFBD"
+html = "#FF00FF"
+md = "#E0FFFF"
+json = "#00FFBD"
+yaml = "#00FFBD"
+toml = "#00FFBD"
+sql = "#00AAFF"

--- a/themes/synthwave_84.toml
+++ b/themes/synthwave_84.toml
@@ -1,0 +1,183 @@
+name = "synthwave_84"
+author = "Mohamed Achaq"
+description = "A retro-computing theme inspired by 1980s aesthetics, vintage terminals, and synthwave music visuals"
+
+[colors]
+file = "#F4D03F"
+directory = "#FF5F87"
+symlink = "#5FD7FF"
+executable = "#87FF5F"
+
+size = "#808080"
+date = "#808080"
+user = "#FF875F"
+group = "#666666"
+
+permission_dir = "#FF5F87"
+permission_read = "#87FF5F"
+permission_write = "#FFD700"
+permission_exec = "#FF5555"
+permission_none = "#282634"
+
+[special_files]
+[special_files.folders]
+"node_modules" = "#282634"
+"target" = "#282634"
+"dist" = "#282634"
+".git" = "#FF5F87"
+"build" = "#282634"
+".cache" = "#282634"
+"coverage" = "#282634"
+"vendor" = "#282634"
+
+"*-env" = "#87FF5F"
+"venv" = "#87FF5F"
+".env" = "#87FF5F"
+"env" = "#87FF5F"
+"*.d" = "#5FD7FF"
+
+"*_cache" = "#282634"
+"*-cache" = "#282634"
+".terraform" = "#282634"
+
+[special_files.dotfiles]
+".gitignore" = "#5FD7FF"
+".env" = "#87FF5F"
+".dockerignore" = "#5FD7FF"
+".editorconfig" = "#5FD7FF"
+".prettierrc" = "#5FD7FF"
+".eslintrc" = "#5FD7FF"
+".babelrc" = "#5FD7FF"
+".npmrc" = "#5FD7FF"
+".yarnrc" = "#5FD7FF"
+".zshrc" = "#5FD7FF"
+".bashrc" = "#5FD7FF"
+
+[special_files.exact_match]
+"Dockerfile" = "#5FD7FF"
+"docker-compose.yml" = "#5FD7FF"
+"Makefile" = "#FF5555"
+"CMakeLists.txt" = "#FF5555"
+
+"README.md" = "#FF5F87"
+"LICENSE" = "#FF5F87"
+"CHANGELOG.md" = "#FF5F87"
+"CONTRIBUTING.md" = "#FF5F87"
+
+"package.json" = "#FF5F87"
+"package-lock.json" = "#282634"
+"yarn.lock" = "#282634"
+"Cargo.toml" = "#FF5555"
+"Cargo.lock" = "#282634"
+"composer.json" = "#FF5F87"
+"go.mod" = "#5FD7FF"
+"go.sum" = "#282634"
+
+"tsconfig.json" = "#5FD7FF"
+"webpack.config.js" = "#5FD7FF"
+"vite.config.ts" = "#5FD7FF"
+"next.config.js" = "#5FD7FF"
+"nuxt.config.js" = "#5FD7FF"
+"svelte.config.js" = "#5FD7FF"
+
+"flake.nix" = "#FF5F87"
+"flake.lock" = "#282634"
+"shell.nix" = "#FF5F87"
+"default.nix" = "#FF5F87"
+
+[special_files.patterns]
+"*rc" = "#5FD7FF"
+"*.config.*" = "#5FD7FF"
+"*.conf" = "#5FD7FF"
+
+"*.min.*" = "#282634"
+"*.map" = "#282634"
+"*.lock" = "#282634"
+
+"*.test.*" = "#87FF5F"
+"*.spec.*" = "#87FF5F"
+"*_test.*" = "#87FF5F"
+"*_spec.*" = "#87FF5F"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++", "h", "c"]
+go = ["go", "mod", "sum"]
+ruby = ["rb", "erb", "gemspec"]
+php = ["php", "phtml", "php.inc"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+elixir = ["ex", "exs"]
+haskell = ["hs", "lhs"]
+lua = ["lua"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs", "jsx", "tsx"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = ["md", "rst", "txt", "org", "wiki", "adoc", "tex", "pdf", "epub", "doc", "docx", "rtf"]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic", "raw", "cr2", "nef"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma", "midi"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#FF5555"
+python = "#87FF5F"
+javascript = "#FFD700"
+typescript = "#5FD7FF"
+java = "#FF5555"
+csharp = "#87FF5F"
+cpp = "#FF5555"
+go = "#5FD7FF"
+ruby = "#FF5555"
+php = "#87FF5F"
+swift = "#FF5555"
+kotlin = "#87FF5F"
+elixir = "#FF875F"
+haskell = "#5FD7FF"
+lua = "#FF5F87"
+nix = "#5FD7FF"
+
+markup = "#FF875F"
+style = "#87FF5F"
+web_config = "#FF5F87"
+
+shell = "#87FF5F"
+script = "#FF5F87"
+
+doc = "#F4D03F"
+image = "#FF87D7"
+video = "#FF87D7"
+audio = "#FF87D7"
+
+data = "#FF5F87"
+archive = "#FF5555"
+
+rs = "#FF5555"
+py = "#87FF5F"
+js = "#FFD700"
+ts = "#5FD7FF"
+jsx = "#FFD700"
+tsx = "#5FD7FF"
+vue = "#87FF5F"
+css = "#87FF5F"
+scss = "#87FF5F"
+html = "#FF875F"
+md = "#F4D03F"
+json = "#FF5F87"
+yaml = "#FF5F87"
+toml = "#FF5F87"
+sql = "#5FD7FF"

--- a/themes/zen.toml
+++ b/themes/zen.toml
@@ -1,0 +1,115 @@
+name = "zen"
+author = "Mohamed Achaq"
+description = "A minimal monochromatic theme emphasizing simplicity and clarity through subtle shades"
+
+[colors]
+file = "#D4D4D4"
+directory = "#FFFFFF"
+symlink = "#A8A8A8"
+executable = "#FFFFFF"
+
+size = "#808080"
+date = "#808080"
+user = "#A8A8A8"
+group = "#707070"
+
+permission_dir = "#FFFFFF"
+permission_read = "#D4D4D4"
+permission_write = "#BEBEBE"
+permission_exec = "#FFFFFF"
+permission_none = "#404040"
+
+[special_files]
+[special_files.folders]
+"node_modules" = "#404040"
+"target" = "#404040"
+"dist" = "#404040"
+".git" = "#FFFFFF"
+"build" = "#404040"
+".cache" = "#404040"
+"coverage" = "#404040"
+"vendor" = "#404040"
+
+"*-env" = "#FFFFFF"
+"venv" = "#FFFFFF"
+".env" = "#FFFFFF"
+"env" = "#FFFFFF"
+"*.d" = "#A8A8A8"
+
+"*_cache" = "#404040"
+"*-cache" = "#404040"
+".terraform" = "#404040"
+
+[special_files.dotfiles]
+".gitignore" = "#A8A8A8"
+".env" = "#FFFFFF"
+".dockerignore" = "#A8A8A8"
+".editorconfig" = "#A8A8A8"
+".prettierrc" = "#A8A8A8"
+".eslintrc" = "#A8A8A8"
+".babelrc" = "#A8A8A8"
+".npmrc" = "#A8A8A8"
+".yarnrc" = "#A8A8A8"
+".zshrc" = "#A8A8A8"
+".bashrc" = "#A8A8A8"
+
+[special_files.exact_match]
+"Dockerfile" = "#A8A8A8"
+"docker-compose.yml" = "#A8A8A8"
+"Makefile" = "#FFFFFF"
+"CMakeLists.txt" = "#FFFFFF"
+
+"README.md" = "#FFFFFF"
+"LICENSE" = "#FFFFFF"
+"CHANGELOG.md" = "#FFFFFF"
+"CONTRIBUTING.md" = "#FFFFFF"
+
+"package.json" = "#FFFFFF"
+"package-lock.json" = "#404040"
+"yarn.lock" = "#404040"
+"Cargo.toml" = "#FFFFFF"
+"Cargo.lock" = "#404040"
+"composer.json" = "#FFFFFF"
+"go.mod" = "#A8A8A8"
+"go.sum" = "#404040"
+
+[special_files.patterns]
+"*rc" = "#A8A8A8"
+"*.config.*" = "#A8A8A8"
+"*.conf" = "#A8A8A8"
+
+"*.min.*" = "#404040"
+"*.map" = "#404040"
+"*.lock" = "#404040"
+
+"*.test.*" = "#FFFFFF"
+"*.spec.*" = "#FFFFFF"
+"*_test.*" = "#FFFFFF"
+"*_spec.*" = "#FFFFFF"
+
+[extensions.groups]
+code = ["rs", "py", "js", "ts", "java", "c", "cpp", "go", "rb", "php", "swift", "kt"]
+markup = ["html", "xml", "md", "yml", "json", "toml"]
+style = ["css", "scss", "sass", "less"]
+shell = ["sh", "bash", "zsh", "fish"]
+data = ["csv", "sql", "sqlite", "db"]
+doc = ["txt", "pdf", "doc", "docx", "rtf"]
+media = ["jpg", "png", "gif", "mp3", "mp4", "wav"]
+archive = ["zip", "tar", "gz", "7z"]
+
+[extensions.colors]
+code = "#D4D4D4"
+markup = "#D4D4D4"
+style = "#D4D4D4"
+shell = "#D4D4D4"
+data = "#D4D4D4"
+doc = "#D4D4D4"
+media = "#D4D4D4"
+archive = "#D4D4D4"
+
+rs = "#FFFFFF"
+py = "#FFFFFF"
+js = "#FFFFFF"
+ts = "#FFFFFF"
+go = "#FFFFFF"
+java = "#FFFFFF"


### PR DESCRIPTION
- Introduced several new themes: `circuit_dreams`, `cosmic_night`, `deep_sea`, `forest_depths`, `moonlight`, `neon_dreams`, `synthwave_84`, and `zen`.
- Each theme includes a unique color palette and description, enhancing the visual customization options for users.
- Updated `README.md` to include descriptions of the new themes for better user guidance.