### PR TITLE
Fix install.sh verify_checksum

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,6 +77,8 @@ verify_checksum() {
     curl -L "$CHECKSUM_URL" -o "${TMP_DIR}/SHA256SUMS"
     
     cd "$TMP_DIR"
+    mkdir "${PLATFORM}"
+    cp lla "${PLATFORM}/${PLATFORM}"
     if ! sha256sum -c --ignore-missing SHA256SUMS; then
         print_error "Checksum verification failed"
         cd - > /dev/null


### PR DESCRIPTION
Minor edit. The default installation didn't work for me:
```
❯ curl -sSL https://raw.githubusercontent.com/chaqchase/lla/main/install.sh | bash
==> Installing lla...
==> Downloading lla v0.3.10 for linux-amd64...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 4542k  100 4542k    0     0  3701k      0  0:00:01  0:00:01 --:--:-- 17.3M
==> Verifying checksum...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   565  100   565    0     0    731      0 --:--:-- --:--:-- --:--:--     0
sha256sum: SHA256SUMS: no file was verified
==> Checksum verification failed
```
The file name is `lla` but in `SHA256SUMS` is expected `${PLATFORM}/${PLATFORM}`