### PR TITLE
fix: directory size computation

### DIFF
--- a/lla/src/lister/recursive.rs
+++ b/lla/src/lister/recursive.rs
@@ -37,16 +37,12 @@ impl RecursiveLister {
             return false;
         }
 
-        if !entry.file_type().is_file() {
+        if entry.file_type().is_file() && !Self::is_hidden(entry) {
+            counter.fetch_add(1, Ordering::Relaxed);
             return true;
         }
 
-        if !Self::is_hidden(entry) {
-            counter.fetch_add(1, Ordering::Relaxed);
-            true
-        } else {
-            false
-        }
+        false
     }
 }
 


### PR DESCRIPTION
I've noticed the output from `lla -S` seems off:

<img width="555" alt="Screenshot 2025-01-15 at 8 25 02 AM" src="https://github.com/user-attachments/assets/1cefea82-227d-4474-a589-1f17fb860244" />
<img width="604" alt="Screenshot 2025-01-15 at 8 25 07 AM" src="https://github.com/user-attachments/assets/f3880a19-218d-41e1-8b02-1105865e3332" />

Here'e a shot at a fix!