### PR TITLE
feat: default plugin install

### DIFF
--- a/lla/src/commands/args.rs
+++ b/lla/src/commands/args.rs
@@ -550,10 +550,15 @@ impl Args {
                 Some(Command::Install(InstallSource::GitHub(
                     github_url.to_string(),
                 )))
+            } else if let Some(local_dir) = install_matches.value_of("dir") {
+                Some(Command::Install(InstallSource::LocalDir(
+                    local_dir.to_string(),
+                )))
             } else {
-                install_matches.value_of("dir").map(|local_dir| {
-                    Command::Install(InstallSource::LocalDir(local_dir.to_string()))
-                })
+                // default --git https://github.com/triyanox/lla
+                Some(Command::Install(InstallSource::GitHub(
+                    "https://github.com/triyanox/lla".to_string(),
+                )))
             }
         } else if matches.subcommand_matches("list-plugins").is_some() {
             Some(Command::ListPlugins)


### PR DESCRIPTION
This pull request implements the changes from commit e3fb4eb67ad18af17015f67eb2648f25c43a2442, originally on the local main branch and now moved to `feat/default-github-install` in the `abelcha/lla` fork.

Changes include:
- Defaulting to GitHub install source (https://github.com/triyanox/lla) when no specific source is provided.
- Improved handling of local directory installations.