### PR TITLE
chore: update plugin versions to 0.5.3 across all dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2025-12-26
+
+### Fixed
+
+- `lla --fuzzy` editor integration now properly handles empty editor config strings, allowing the fallback chain to work correctly when the config editor field is empty.
+
+Thanks to @chenrui333 for the pr #148
+
 ## [0.5.2] - 2025-12-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "brew"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -220,7 +220,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "categorizer"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "colored",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "code_complexity"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "colored",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "code_snippet_extractor"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arboard",
  "base64 0.21.7",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "dirs_meta"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "colored",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "duplicate_file_detector"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "colored",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "file_copier"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "colored",
  "dialoguer",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "file_hash"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "colored",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "file_meta"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "file_mover"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "colored",
  "dialoguer",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "file_organizer"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "chrono",
  "colored",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "file_remover"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "colored",
  "dialoguer",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "file_tagger"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "colored",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "flush_dns"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -990,7 +990,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git_status"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "colored",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "google_meet"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arboard",
  "bytes",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "google_search"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arboard",
  "bytes",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "hackernews"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arboard",
  "bytes",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "jwt"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "keyword_search"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arboard",
  "bytes",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "last_git_commit"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "colored",
@@ -1571,7 +1571,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lla"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "atty",
  "chrono",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_interface"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "prost",
  "prost-build",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_utils"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -1717,7 +1717,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "npm"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arboard",
  "bytes",
@@ -2264,7 +2264,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remove_paywall"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arboard",
  "bytes",
@@ -2590,7 +2590,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sizeviz"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "colored",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "speed_test"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "youtube"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arboard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["lla", "lla_plugin_interface", "lla_plugin_utils", "plugins/*"]
 [workspace.package]
 description = "Blazing Fast and highly customizable ls Replacement with Superpowers"
 authors = ["Achaq <hi@achaq.dev>"]
-version = "0.5.2"
+version = "0.5.3"
 categories = ["utilities", "file-system", "cli", "file-management"]
 edition = "2021"
 license = "MIT"

--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -29,8 +29,8 @@ walkdir.workspace = true
 tempfile.workspace = true
 users.workspace = true
 parking_lot.workspace = true
-lla_plugin_interface = { version = "0.5.2", path = "../lla_plugin_interface" }
-lla_plugin_utils = { version = "0.5.2", path = "../lla_plugin_utils" }
+lla_plugin_interface = { version = "0.5.3", path = "../lla_plugin_interface" }
+lla_plugin_utils = { version = "0.5.3", path = "../lla_plugin_utils" }
 once_cell.workspace = true
 dashmap.workspace = true
 unicode-width.workspace = true

--- a/lla_plugin_utils/Cargo.toml
+++ b/lla_plugin_utils/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.2" }
+lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.3" }
 serde = { workspace = true }
 colored = { workspace = true }
 toml = { workspace = true }

--- a/plugins/brew/Cargo.toml
+++ b/plugins/brew/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brew"
 description = "Homebrew package manager plugin - install, uninstall, upgrade, and search packages"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/categorizer/Cargo.toml
+++ b/plugins/categorizer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "categorizer"
 description = "Categorizes files based on their extensions and metadata"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/code_complexity/Cargo.toml
+++ b/plugins/code_complexity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "code_complexity"
 description = "Analyzes code complexity and provides metrics"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/code_snippet_extractor/Cargo.toml
+++ b/plugins/code_snippet_extractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code_snippet_extractor"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Extract and manage code snippets with tagging support"
 

--- a/plugins/dirs_meta/Cargo.toml
+++ b/plugins/dirs_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dirs_meta"
 description = "Analyzes directories and shows metadata"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/duplicate_file_detector/Cargo.toml
+++ b/plugins/duplicate_file_detector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "duplicate_file_detector"
 description = "Detects duplicate files by comparing their content hashes"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_copier/Cargo.toml
+++ b/plugins/file_copier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_copier"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for copying files and directories"
 

--- a/plugins/file_hash/Cargo.toml
+++ b/plugins/file_hash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_hash"
 description = "Displays the hash of each file"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_meta/Cargo.toml
+++ b/plugins/file_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_meta"
 description = "Displays the file metadata of each file"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_mover/Cargo.toml
+++ b/plugins/file_mover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_mover"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for moving files and directories"
 

--- a/plugins/file_organizer/Cargo.toml
+++ b/plugins/file_organizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_organizer"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "A plugin for lla that organizes files using various strategies"
 

--- a/plugins/file_remover/Cargo.toml
+++ b/plugins/file_remover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_remover"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "A plugin for lla that provides interactive file and directory removal"
 

--- a/plugins/file_tagger/Cargo.toml
+++ b/plugins/file_tagger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_tagger"
 description = "Add and manage tags for files"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/flush_dns/Cargo.toml
+++ b/plugins/flush_dns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flush_dns"
 description = "Flush DNS cache on macOS, Linux, and Windows"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/git_status/Cargo.toml
+++ b/plugins/git_status/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "git_status"
 description = "Shows Git repository status information"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_meet/Cargo.toml
+++ b/plugins/google_meet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_meet"
 description = "Google Meet plugin for creating meeting rooms and managing links"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_search/Cargo.toml
+++ b/plugins/google_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_search"
 description = "Google search with autosuggestions, search history management, and clipboard fallback"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/hackernews/Cargo.toml
+++ b/plugins/hackernews/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hackernews"
 description = "Hacker News plugin - browse top stories, best stories, new stories, ask HN, and show HN"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/jwt/Cargo.toml
+++ b/plugins/jwt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jwt"
 description = "JWT decoder and analyzer with search and validation capabilities"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/keyword_search/Cargo.toml
+++ b/plugins/keyword_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "keyword_search"
 description = "Searches file contents for user-specified keywords"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/last_git_commit/Cargo.toml
+++ b/plugins/last_git_commit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "last_git_commit"
 description = "A plugin for the lla that provides the last git commit hash"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/npm/Cargo.toml
+++ b/plugins/npm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "npm"
 description = "NPM package search with bundlephobia integration and favorites management"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/remove_paywall/Cargo.toml
+++ b/plugins/remove_paywall/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "remove_paywall"
 description = "Remove paywalls from URLs using services like 12ft.io, archive.is, and removepaywall.com"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/sizeviz/Cargo.toml
+++ b/plugins/sizeviz/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sizeviz"
 description = "File size visualizer plugin for lla"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/speed_test/Cargo.toml
+++ b/plugins/speed_test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "speed_test"
 description = "Internet speed test plugin - test download/upload speeds and latency"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]

--- a/plugins/youtube/Cargo.toml
+++ b/plugins/youtube/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "youtube"
 description = "YouTube search plugin with autosuggestions and history management"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
- Bumped version numbers for all plugins and workspace packages to 0.5.3 in Cargo.toml and Cargo.lock files.
- Updated CHANGELOG to reflect the new version and fixed editor integration issue in `lla --fuzzy` command.

Thanks to @chenrui333 for the contribution.