### PR TITLE
Bump `onig`/`onig_sys` versions to fix GCC 15 build errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,11 +1934,11 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "onig"
-version = "6.4.0"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1946,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.8.1"
+version = "69.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",


### PR DESCRIPTION
This PR simply bumps the versions of the `onig` and `onig_sys` packages (dependents of `syntect`), similar to rust-lang/rust#141684, to fix the errors and warnings that happen when running `cargo build` under a system with GCC 15.

As an example, this is what I was getting:

```
$ cargo build
   Compiling onig_sys v69.8.1
   Compiling lla_plugin_interface v0.5.7 (~/dev/repos/github.com/chaqchase/lla/lla_plugin_interface)
warning: onig_sys@69.8.1: oniguruma/src/regparse.c: In function ‘onig_st_init_strend_table_with_size’:
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:588:5: error: initialization of ‘int (*)(void)’ from incompatible pointer type ‘int (*)(st_str_end_key *, st_str_end_key *)’ [-Wincompatible-pointer-types]
warning: onig_sys@69.8.1:   588 |     str_end_cmp,
warning: onig_sys@69.8.1:       |     ^~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:588:5: note: (near initialization for ‘hashType.compare’)
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:550:1: note: ‘str_end_cmp’ declared here
warning: onig_sys@69.8.1:   550 | str_end_cmp(st_str_end_key* x, st_str_end_key* y)
warning: onig_sys@69.8.1:       | ^~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:589:5: error: initialization of ‘int (*)(void)’ from incompatible pointer type ‘int (*)(st_str_end_key *)’ [-Wincompatible-pointer-types]
warning: onig_sys@69.8.1:   589 |     str_end_hash,
warning: onig_sys@69.8.1:       |     ^~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:589:5: note: (near initialization for ‘hashType.hash’)
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:571:1: note: ‘str_end_hash’ declared here
warning: onig_sys@69.8.1:   571 | str_end_hash(st_str_end_key* x)
warning: onig_sys@69.8.1:       | ^~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c: In function ‘onig_st_init_callout_name_table_with_size’:
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:678:5: error: initialization of ‘int (*)(void)’ from incompatible pointer type ‘int (*)(st_callout_name_key *, st_callout_name_key *)’ [-Wincompatible-pointer-types]
warning: onig_sys@69.8.1:   678 |     callout_name_table_cmp,
warning: onig_sys@69.8.1:       |     ^~~~~~~~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:678:5: note: (near initialization for ‘hashType.compare’)
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:637:1: note: ‘callout_name_table_cmp’ declared here
warning: onig_sys@69.8.1:   637 | callout_name_table_cmp(st_callout_name_key* x, st_callout_name_key* y)
warning: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:679:5: error: initialization of ‘int (*)(void)’ from incompatible pointer type ‘int (*)(st_callout_name_key *)’ [-Wincompatible-pointer-types]
warning: onig_sys@69.8.1:   679 |     callout_name_table_hash,
warning: onig_sys@69.8.1:       |     ^~~~~~~~~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:679:5: note: (near initialization for ‘hashType.hash’)
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:660:1: note: ‘callout_name_table_hash’ declared here
warning: onig_sys@69.8.1:   660 | callout_name_table_hash(st_callout_name_key* x)
warning: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c: In function ‘names_clear’:
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:804:24: error: passing argument 2 of ‘onig_st_foreach’ from incompatible pointer type [-Wincompatible-pointer-types]
warning: onig_sys@69.8.1:   804 |     onig_st_foreach(t, i_free_name_entry, 0);
warning: onig_sys@69.8.1:       |                        ^~~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1:       |                        |
warning: onig_sys@69.8.1:       |                        int (*)(OnigUChar *, NameEntry *, void *) {aka int (*)(unsigned char *, NameEntry *, void *)}
warning: onig_sys@69.8.1: In file included from oniguruma/src/regparse.c:37:
warning: onig_sys@69.8.1: oniguruma/src/st.h:55:31: note: expected ‘int (*)(void)’ but argument is of type ‘int (*)(OnigUChar *, NameEntry *, void *)’ {aka ‘int (*)(unsigned char *, NameEntry *, void *)’}
warning: onig_sys@69.8.1:    55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
warning: onig_sys@69.8.1:       |                               ^~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/st.h:35:18: note: in definition of macro ‘_’
warning: onig_sys@69.8.1:    35 | # define _(args) args
warning: onig_sys@69.8.1:       |                  ^~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:789:1: note: ‘i_free_name_entry’ declared here
warning: onig_sys@69.8.1:   789 | i_free_name_entry(UChar* key, NameEntry* e, void* arg ARG_UNUSED)
warning: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c: In function ‘onig_foreach_name’:
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:873:24: error: passing argument 2 of ‘onig_st_foreach’ from incompatible pointer type [-Wincompatible-pointer-types]
warning: onig_sys@69.8.1:   873 |     onig_st_foreach(t, i_names, (HashDataType )&narg);
warning: onig_sys@69.8.1:       |                        ^~~~~~~
warning: onig_sys@69.8.1:       |                        |
warning: onig_sys@69.8.1:       |                        int (*)(OnigUChar *, NameEntry *, INamesArg *) {aka int (*)(unsigned char *, NameEntry *, INamesArg *)}
warning: onig_sys@69.8.1: oniguruma/src/st.h:55:31: note: expected ‘int (*)(void)’ but argument is of type ‘int (*)(OnigUChar *, NameEntry *, INamesArg *)’ {aka ‘int (*)(unsigned char *, NameEntry *, INamesArg *)’}
warning: onig_sys@69.8.1:    55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
warning: onig_sys@69.8.1:       |                               ^~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/st.h:35:18: note: in definition of macro ‘_’
warning: onig_sys@69.8.1:    35 | # define _(args) args
warning: onig_sys@69.8.1:       |                  ^~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:846:1: note: ‘i_names’ declared here
warning: onig_sys@69.8.1:   846 | i_names(UChar* key ARG_UNUSED, NameEntry* e, INamesArg* arg)
warning: onig_sys@69.8.1:       | ^~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c: In function ‘onig_renumber_name_table’:
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:901:24: error: passing argument 2 of ‘onig_st_foreach’ from incompatible pointer type [-Wincompatible-pointer-types]
warning: onig_sys@69.8.1:   901 |     onig_st_foreach(t, i_renumber_name, (HashDataType )map);
warning: onig_sys@69.8.1:       |                        ^~~~~~~~~~~~~~~
warning: onig_sys@69.8.1:       |                        |
warning: onig_sys@69.8.1:       |                        int (*)(OnigUChar *, NameEntry *, GroupNumMap *) {aka int (*)(unsigned char *, NameEntry *, GroupNumMap *)}
warning: onig_sys@69.8.1: oniguruma/src/st.h:55:31: note: expected ‘int (*)(void)’ but argument is of type ‘int (*)(OnigUChar *, NameEntry *, GroupNumMap *)’ {aka ‘int (*)(unsigned char *, NameEntry *, GroupNumMap *)’}
warning: onig_sys@69.8.1:    55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
warning: onig_sys@69.8.1:       |                               ^~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/st.h:35:18: note: in definition of macro ‘_’
warning: onig_sys@69.8.1:    35 | # define _(args) args
warning: onig_sys@69.8.1:       |                  ^~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:879:1: note: ‘i_renumber_name’ declared here
warning: onig_sys@69.8.1:   879 | i_renumber_name(UChar* key ARG_UNUSED, NameEntry* e, GroupNumMap* map)
warning: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c: In function ‘callout_name_table_clear’:
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:1386:24: error: passing argument 2 of ‘onig_st_foreach’ from incompatible pointer type [-Wincompatible-pointer-types]
warning: onig_sys@69.8.1:  1386 |     onig_st_foreach(t, i_free_callout_name_entry, 0);
warning: onig_sys@69.8.1:       |                        ^~~~~~~~~~~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1:       |                        |
warning: onig_sys@69.8.1:       |                        int (*)(st_callout_name_key *, CalloutNameEntry *, void *)
warning: onig_sys@69.8.1: oniguruma/src/st.h:55:31: note: expected ‘int (*)(void)’ but argument is of type ‘int (*)(st_callout_name_key *, CalloutNameEntry *, void *)’
warning: onig_sys@69.8.1:    55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
warning: onig_sys@69.8.1:       |                               ^~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/st.h:35:18: note: in definition of macro ‘_’
warning: onig_sys@69.8.1:    35 | # define _(args) args
warning: onig_sys@69.8.1:       |                  ^~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:1370:1: note: ‘i_free_callout_name_entry’ declared here
warning: onig_sys@69.8.1:  1370 | i_free_callout_name_entry(st_callout_name_key* key, CalloutNameEntry* e,
warning: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c: In function ‘setup_ext_callout_list_values’:
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:1884:56: error: passing argument 2 of ‘onig_st_foreach’ from incompatible pointer type [-Wincompatible-pointer-types]
warning: onig_sys@69.8.1:  1884 |     onig_st_foreach((CalloutTagTable *)ext->tag_table, i_callout_callout_list_set,
warning: onig_sys@69.8.1:       |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1:       |                                                        |
warning: onig_sys@69.8.1:       |                                                        int (*)(OnigUChar *, CalloutTagVal,  void *) {aka int (*)(unsigned char *, long int,  void *)}
warning: onig_sys@69.8.1: oniguruma/src/st.h:55:31: note: expected ‘int (*)(void)’ but argument is of type ‘int (*)(OnigUChar *, CalloutTagVal,  void *)’ {aka ‘int (*)(unsigned char *, long int,  void *)’}
warning: onig_sys@69.8.1:    55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
warning: onig_sys@69.8.1:       |                               ^~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/st.h:35:18: note: in definition of macro ‘_’
warning: onig_sys@69.8.1:    35 | # define _(args) args
warning: onig_sys@69.8.1:       |                  ^~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:1866:1: note: ‘i_callout_callout_list_set’ declared here
warning: onig_sys@69.8.1:  1866 | i_callout_callout_list_set(UChar* key, CalloutTagVal e, void* arg)
warning: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c: In function ‘callout_tag_table_clear’:
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:1932:24: error: passing argument 2 of ‘onig_st_foreach’ from incompatible pointer type [-Wincompatible-pointer-types]
warning: onig_sys@69.8.1:  1932 |     onig_st_foreach(t, i_free_callout_tag_entry, 0);
warning: onig_sys@69.8.1:       |                        ^~~~~~~~~~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1:       |                        |
warning: onig_sys@69.8.1:       |                        int (*)(OnigUChar *, CalloutTagVal,  void *) {aka int (*)(unsigned char *, long int,  void *)}
warning: onig_sys@69.8.1: oniguruma/src/st.h:55:31: note: expected ‘int (*)(void)’ but argument is of type ‘int (*)(OnigUChar *, CalloutTagVal,  void *)’ {aka ‘int (*)(unsigned char *, long int,  void *)’}
warning: onig_sys@69.8.1:    55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
warning: onig_sys@69.8.1:       |                               ^~~~~~~~~~~~~~~~
warning: onig_sys@69.8.1: oniguruma/src/st.h:35:18: note: in definition of macro ‘_’
warning: onig_sys@69.8.1:    35 | # define _(args) args
warning: onig_sys@69.8.1:       |                  ^~~~
warning: onig_sys@69.8.1: oniguruma/src/regparse.c:1922:1: note: ‘i_free_callout_tag_entry’ declared here
warning: onig_sys@69.8.1:  1922 | i_free_callout_tag_entry(UChar* key, CalloutTagVal e, void* arg ARG_UNUSED)
warning: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~~~~~~~~~~
error: failed to run custom build command for `onig_sys v69.8.1`

Caused by:
  process didn't exit successfully: `~/dev/repos/github.com/chaqchase/lla/target/debug/build/onig_sys-440d884879dffef1/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=RUSTONIG_DYNAMIC_LIBONIG
  cargo:rerun-if-env-changed=RUSTONIG_STATIC_LIBONIG
  cargo:rerun-if-env-changed=RUSTONIG_SYSTEM_LIBONIG
  OUT_DIR = Some(~/dev/repos/github.com/chaqchase/lla/target/debug/build/onig_sys-266edf9d252d79eb/out)
  OPT_LEVEL = Some(0)
  TARGET = Some(x86_64-unknown-linux-gnu)
  HOST = Some(x86_64-unknown-linux-gnu)
  cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-gnu
  CC_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CC_x86_64_unknown_linux_gnu
  CC_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CC
  HOST_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  RUSTC_WRAPPER = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some(true)
  CARGO_CFG_TARGET_FEATURE = Some(fxsr,sse,sse2)
  cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
  CFLAGS_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
  CFLAGS_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:warning=oniguruma/src/regparse.c: In function ‘onig_st_init_strend_table_with_size’:
  cargo:warning=oniguruma/src/regparse.c:588:5: error: initialization of ‘int (*)(void)’ from incompatible pointer type ‘int (*)(st_str_end_key *, st_str_end_key *)’ [-Wincompatible-pointer-types]
  cargo:warning=  588 |     str_end_cmp,
  cargo:warning=      |     ^~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:588:5: note: (near initialization for ‘hashType.compare’)
  cargo:warning=oniguruma/src/regparse.c:550:1: note: ‘str_end_cmp’ declared here
  cargo:warning=  550 | str_end_cmp(st_str_end_key* x, st_str_end_key* y)
  cargo:warning=      | ^~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:589:5: error: initialization of ‘int (*)(void)’ from incompatible pointer type ‘int (*)(st_str_end_key *)’ [-Wincompatible-pointer-types]
  cargo:warning=  589 |     str_end_hash,
  cargo:warning=      |     ^~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:589:5: note: (near initialization for ‘hashType.hash’)
  cargo:warning=oniguruma/src/regparse.c:571:1: note: ‘str_end_hash’ declared here
  cargo:warning=  571 | str_end_hash(st_str_end_key* x)
  cargo:warning=      | ^~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function ‘onig_st_init_callout_name_table_with_size’:
  cargo:warning=oniguruma/src/regparse.c:678:5: error: initialization of ‘int (*)(void)’ from incompatible pointer type ‘int (*)(st_callout_name_key *, st_callout_name_key *)’ [-Wincompatible-pointer-types]
  cargo:warning=  678 |     callout_name_table_cmp,
  cargo:warning=      |     ^~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:678:5: note: (near initialization for ‘hashType.compare’)
  cargo:warning=oniguruma/src/regparse.c:637:1: note: ‘callout_name_table_cmp’ declared here
  cargo:warning=  637 | callout_name_table_cmp(st_callout_name_key* x, st_callout_name_key* y)
  cargo:warning=      | ^~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:679:5: error: initialization of ‘int (*)(void)’ from incompatible pointer type ‘int (*)(st_callout_name_key *)’ [-Wincompatible-pointer-types]
  cargo:warning=  679 |     callout_name_table_hash,
  cargo:warning=      |     ^~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:679:5: note: (near initialization for ‘hashType.hash’)
  cargo:warning=oniguruma/src/regparse.c:660:1: note: ‘callout_name_table_hash’ declared here
  cargo:warning=  660 | callout_name_table_hash(st_callout_name_key* x)
  cargo:warning=      | ^~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function ‘names_clear’:
  cargo:warning=oniguruma/src/regparse.c:804:24: error: passing argument 2 of ‘onig_st_foreach’ from incompatible pointer type [-Wincompatible-pointer-types]
  cargo:warning=  804 |     onig_st_foreach(t, i_free_name_entry, 0);
  cargo:warning=      |                        ^~~~~~~~~~~~~~~~~
  cargo:warning=      |                        |
  cargo:warning=      |                        int (*)(OnigUChar *, NameEntry *, void *) {aka int (*)(unsigned char *, NameEntry *, void *)}
  cargo:warning=In file included from oniguruma/src/regparse.c:37:
  cargo:warning=oniguruma/src/st.h:55:31: note: expected ‘int (*)(void)’ but argument is of type ‘int (*)(OnigUChar *, NameEntry *, void *)’ {aka ‘int (*)(unsigned char *, NameEntry *, void *)’}
  cargo:warning=   55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
  cargo:warning=      |                               ^~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/st.h:35:18: note: in definition of macro ‘_’
  cargo:warning=   35 | # define _(args) args
  cargo:warning=      |                  ^~~~
  cargo:warning=oniguruma/src/regparse.c:789:1: note: ‘i_free_name_entry’ declared here
  cargo:warning=  789 | i_free_name_entry(UChar* key, NameEntry* e, void* arg ARG_UNUSED)
  cargo:warning=      | ^~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function ‘onig_foreach_name’:
  cargo:warning=oniguruma/src/regparse.c:873:24: error: passing argument 2 of ‘onig_st_foreach’ from incompatible pointer type [-Wincompatible-pointer-types]
  cargo:warning=  873 |     onig_st_foreach(t, i_names, (HashDataType )&narg);
  cargo:warning=      |                        ^~~~~~~
  cargo:warning=      |                        |
  cargo:warning=      |                        int (*)(OnigUChar *, NameEntry *, INamesArg *) {aka int (*)(unsigned char *, NameEntry *, INamesArg *)}
  cargo:warning=oniguruma/src/st.h:55:31: note: expected ‘int (*)(void)’ but argument is of type ‘int (*)(OnigUChar *, NameEntry *, INamesArg *)’ {aka ‘int (*)(unsigned char *, NameEntry *, INamesArg *)’}
  cargo:warning=   55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
  cargo:warning=      |                               ^~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/st.h:35:18: note: in definition of macro ‘_’
  cargo:warning=   35 | # define _(args) args
  cargo:warning=      |                  ^~~~
  cargo:warning=oniguruma/src/regparse.c:846:1: note: ‘i_names’ declared here
  cargo:warning=  846 | i_names(UChar* key ARG_UNUSED, NameEntry* e, INamesArg* arg)
  cargo:warning=      | ^~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function ‘onig_renumber_name_table’:
  cargo:warning=oniguruma/src/regparse.c:901:24: error: passing argument 2 of ‘onig_st_foreach’ from incompatible pointer type [-Wincompatible-pointer-types]
  cargo:warning=  901 |     onig_st_foreach(t, i_renumber_name, (HashDataType )map);
  cargo:warning=      |                        ^~~~~~~~~~~~~~~
  cargo:warning=      |                        |
  cargo:warning=      |                        int (*)(OnigUChar *, NameEntry *, GroupNumMap *) {aka int (*)(unsigned char *, NameEntry *, GroupNumMap *)}
  cargo:warning=oniguruma/src/st.h:55:31: note: expected ‘int (*)(void)’ but argument is of type ‘int (*)(OnigUChar *, NameEntry *, GroupNumMap *)’ {aka ‘int (*)(unsigned char *, NameEntry *, GroupNumMap *)’}
  cargo:warning=   55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
  cargo:warning=      |                               ^~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/st.h:35:18: note: in definition of macro ‘_’
  cargo:warning=   35 | # define _(args) args
  cargo:warning=      |                  ^~~~
  cargo:warning=oniguruma/src/regparse.c:879:1: note: ‘i_renumber_name’ declared here
  cargo:warning=  879 | i_renumber_name(UChar* key ARG_UNUSED, NameEntry* e, GroupNumMap* map)
  cargo:warning=      | ^~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function ‘callout_name_table_clear’:
  cargo:warning=oniguruma/src/regparse.c:1386:24: error: passing argument 2 of ‘onig_st_foreach’ from incompatible pointer type [-Wincompatible-pointer-types]
  cargo:warning= 1386 |     onig_st_foreach(t, i_free_callout_name_entry, 0);
  cargo:warning=      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=      |                        |
  cargo:warning=      |                        int (*)(st_callout_name_key *, CalloutNameEntry *, void *)
  cargo:warning=oniguruma/src/st.h:55:31: note: expected ‘int (*)(void)’ but argument is of type ‘int (*)(st_callout_name_key *, CalloutNameEntry *, void *)’
  cargo:warning=   55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
  cargo:warning=      |                               ^~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/st.h:35:18: note: in definition of macro ‘_’
  cargo:warning=   35 | # define _(args) args
  cargo:warning=      |                  ^~~~
  cargo:warning=oniguruma/src/regparse.c:1370:1: note: ‘i_free_callout_name_entry’ declared here
  cargo:warning= 1370 | i_free_callout_name_entry(st_callout_name_key* key, CalloutNameEntry* e,
  cargo:warning=      | ^~~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function ‘setup_ext_callout_list_values’:
  cargo:warning=oniguruma/src/regparse.c:1884:56: error: passing argument 2 of ‘onig_st_foreach’ from incompatible pointer type [-Wincompatible-pointer-types]
  cargo:warning= 1884 |     onig_st_foreach((CalloutTagTable *)ext->tag_table, i_callout_callout_list_set,
  cargo:warning=      |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=      |                                                        |
  cargo:warning=      |                                                        int (*)(OnigUChar *, CalloutTagVal,  void *) {aka int (*)(unsigned char *, long int,  void *)}
  cargo:warning=oniguruma/src/st.h:55:31: note: expected ‘int (*)(void)’ but argument is of type ‘int (*)(OnigUChar *, CalloutTagVal,  void *)’ {aka ‘int (*)(unsigned char *, long int,  void *)’}
  cargo:warning=   55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
  cargo:warning=      |                               ^~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/st.h:35:18: note: in definition of macro ‘_’
  cargo:warning=   35 | # define _(args) args
  cargo:warning=      |                  ^~~~
  cargo:warning=oniguruma/src/regparse.c:1866:1: note: ‘i_callout_callout_list_set’ declared here
  cargo:warning= 1866 | i_callout_callout_list_set(UChar* key, CalloutTagVal e, void* arg)
  cargo:warning=      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function ‘callout_tag_table_clear’:
  cargo:warning=oniguruma/src/regparse.c:1932:24: error: passing argument 2 of ‘onig_st_foreach’ from incompatible pointer type [-Wincompatible-pointer-types]
  cargo:warning= 1932 |     onig_st_foreach(t, i_free_callout_tag_entry, 0);
  cargo:warning=      |                        ^~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=      |                        |
  cargo:warning=      |                        int (*)(OnigUChar *, CalloutTagVal,  void *) {aka int (*)(unsigned char *, long int,  void *)}
  cargo:warning=oniguruma/src/st.h:55:31: note: expected ‘int (*)(void)’ but argument is of type ‘int (*)(OnigUChar *, CalloutTagVal,  void *)’ {aka ‘int (*)(unsigned char *, long int,  void *)’}
  cargo:warning=   55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
  cargo:warning=      |                               ^~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/st.h:35:18: note: in definition of macro ‘_’
  cargo:warning=   35 | # define _(args) args
  cargo:warning=      |                  ^~~~
  cargo:warning=oniguruma/src/regparse.c:1922:1: note: ‘i_free_callout_tag_entry’ declared here
  cargo:warning= 1922 | i_free_callout_tag_entry(UChar* key, CalloutTagVal e, void* arg ARG_UNUSED)
  cargo:warning=      | ^~~~~~~~~~~~~~~~~~~~~~~~

  --- stderr


  error occurred: Command "cc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "-I" "~/dev/repos/github.com/chaqchase/lla/target/debug/build/onig_sys-266edf9d252d79eb/out" "-I" "oniguruma/src" "-DHAVE_UNISTD_H=1" "-DHAVE_SYS_TYPES_H=1" "-DHAVE_SYS_TIME_H=1" "-o" "~/dev/repos/github.com/chaqchase/lla/target/debug/build/onig_sys-266edf9d252d79eb/out/c77b18e714869709-regparse.o" "-c" "oniguruma/src/regparse.c" with args cc did not execute successfully (status code exit status: 1).
```

**Note:** Technically, you can get around this issue by installing the oniguruma library (e.g. `sudo apt install libonig-dev`) and telling `onig_sys` to use that instead (which should speed up the build, too), for example: `RUSTONIG_SYSTEM_LIBONIG=1 cargo build`. But, I thought the version bump was more practical.