### PR TITLE
Prepare v0.5.8 with configurable long date format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8] - 2026-07-04
+
 ### Added
 
 - Long format now supports custom absolute date formatting with `--date-format` and `[formatters.long].date_format`, making year-inclusive timestamps possible without changing the default output.
@@ -14,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - No-color symbolic permissions now render as normal 10-character permission strings instead of repeating permission blocks in long-style output.
+
 
 ## [0.5.7] - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Long format now supports custom absolute date formatting with `--date-format` and `[formatters.long].date_format`, making year-inclusive timestamps possible without changing the default output.
+
+### Fixed
+
+- No-color symbolic permissions now render as normal 10-character permission strings instead of repeating permission blocks in long-style output.
+
 ## [0.5.7] - 2026-05-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "brew"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -220,7 +220,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "categorizer"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "colored",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "code_complexity"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "colored",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "code_snippet_extractor"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "arboard",
  "base64 0.21.7",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "dirs_meta"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "colored",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "duplicate_file_detector"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "colored",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "file_copier"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "colored",
  "dialoguer",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "file_hash"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "colored",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "file_meta"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "file_mover"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "colored",
  "dialoguer",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "file_organizer"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "chrono",
  "colored",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "file_remover"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "colored",
  "dialoguer",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "file_tagger"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "colored",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "flush_dns"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -860,7 +860,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "folder_cleaner"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "chrono",
  "colored",
@@ -1011,7 +1011,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git_status"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "colored",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "google_meet"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "arboard",
  "bytes",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "google_search"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "arboard",
  "bytes",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "hackernews"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "arboard",
  "bytes",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "jwt"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "keyword_search"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "arboard",
  "bytes",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "kill_process"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "colored",
  "console",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "last_git_commit"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "colored",
@@ -1592,7 +1592,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lla"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "atty",
  "chrono",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_interface"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "prost",
  "prost-build",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_utils"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -1738,7 +1738,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "npm"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "arboard",
  "bytes",
@@ -2285,7 +2285,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remove_paywall"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "arboard",
  "bytes",
@@ -2611,7 +2611,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sizeviz"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "colored",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "speed_test"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "youtube"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "arboard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["lla", "lla_plugin_interface", "lla_plugin_utils", "plugins/*"]
 [workspace.package]
 description = "Blazing Fast and highly customizable ls Replacement with Superpowers"
 authors = ["Achaq <hi@achaq.dev>"]
-version = "0.5.7"
+version = "0.5.8"
 categories = ["utilities", "file-system", "cli", "file-management"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -151,16 +151,23 @@ Options and tweaks:
   lla -l --relative-dates
   ```
 
+- Show the year in long-format dates:
+
+  ```bash
+  lla -l --date-format "%Y-%m-%d %H:%M"
+  ```
+
 To make these defaults, add to your config (`~/.config/lla/config.toml`):
 
 ```toml
 [formatters.long]
 hide_group = true
 relative_dates = true
+date_format = "%Y-%m-%d %H:%M"
 columns = ["permissions", "size", "modified", "user", "group", "name", "field:git_status", "field:tags"]
 ```
 
-The `columns` array lets you control the precise column order. Use built-in keys (`permissions`, `size`, `modified`, `user`, `group`, `name`, `path`, `plugins`) or reference any plugin-provided field with the `field:<name>` prefix (e.g., `field:git_status`, `field:complexity_score`).
+The `date_format` value uses Chrono strftime syntax. The default is `%b %d %H:%M`, preserving the existing `Aug 16 00:18` style. The `columns` array lets you control the precise column order. Use built-in keys (`permissions`, `size`, `modified`, `user`, `group`, `name`, `path`, `plugins`) or reference any plugin-provided field with the `field:<name>` prefix (e.g., `field:git_status`, `field:complexity_score`).
 
 #### Tree Structure
 
@@ -561,6 +568,7 @@ lla --csv
 | `--include-dirs`      | Include recursive directory sizes in metadata (expensive on large directory trees)   | `lla -l --include-dirs`         |
 | `--no-color`          | Disable all colors in the output                                                      | `lla --no-color`                |
 | `--permission-format` | Set the format for displaying permissions (symbolic, octal, binary, verbose, compact) | `lla --permission-format octal` |
+| `--date-format`       | Format absolute dates in long view using Chrono strftime syntax                       | `lla -l --date-format "%Y-%m-%d %H:%M"` |
 
 ### Sort & Filter Options
 

--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -29,8 +29,8 @@ walkdir.workspace = true
 tempfile.workspace = true
 users.workspace = true
 parking_lot.workspace = true
-lla_plugin_interface = { version = "0.5.7", path = "../lla_plugin_interface" }
-lla_plugin_utils = { version = "0.5.7", path = "../lla_plugin_utils" }
+lla_plugin_interface = { version = "0.5.8", path = "../lla_plugin_interface" }
+lla_plugin_utils = { version = "0.5.8", path = "../lla_plugin_utils" }
 once_cell.workspace = true
 dashmap.workspace = true
 unicode-width.workspace = true

--- a/lla/src/commands/args.rs
+++ b/lla/src/commands/args.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, ShortcutCommand};
+use crate::config::{validate_long_date_format, Config, ShortcutCommand};
 use crate::error::{LlaError, Result};
 use crate::filter::{parse_size_range, parse_time_range, NumericRange, TimeRange};
 use clap::{App, Arg, ArgGroup, ArgMatches, SubCommand};
@@ -53,6 +53,7 @@ pub struct Args {
     pub permission_format: String,
     pub hide_group: bool,
     pub relative_dates: bool,
+    pub date_format: String,
     pub output_mode: OutputMode,
     pub command: Option<Command>,
     pub search: Option<String>,
@@ -533,6 +534,12 @@ impl Args {
                     .long("relative-dates")
                     .help("Show relative dates (e.g., '2h ago') in long format"),
             )
+            .arg(
+                Arg::with_name("date-format")
+                    .long("date-format")
+                    .takes_value(true)
+                    .help("Format absolute dates in long format using chrono strftime syntax (e.g., '%Y-%m-%d %H:%M')"),
+            )
             .subcommand(
                 SubCommand::with_name("install")
                     .about("Install a plugin")
@@ -846,6 +853,7 @@ impl Args {
                     permission_format: config.permission_format.clone(),
                     hide_group: config.formatters.long.hide_group,
                     relative_dates: config.formatters.long.relative_dates,
+                    date_format: config.formatters.long.date_format.clone(),
                     output_mode: OutputMode::Human,
                     command: Some(Command::Shortcut(ShortcutAction::Run(
                         potential_shortcut.clone(),
@@ -1168,6 +1176,12 @@ impl Args {
             .transpose()?
             .unwrap_or_default();
 
+        let date_format = matches
+            .value_of("date-format")
+            .unwrap_or(&config.formatters.long.date_format)
+            .to_string();
+        validate_long_date_format("date-format", &date_format)?;
+
         Ok(Args {
             directory: matches.value_of("directory").unwrap_or(".").to_string(),
             depth: matches
@@ -1252,6 +1266,7 @@ impl Args {
             hide_group: matches.is_present("hide-group") || config.formatters.long.hide_group,
             relative_dates: matches.is_present("relative-dates")
                 || config.formatters.long.relative_dates,
+            date_format,
             output_mode: {
                 let pretty = matches.is_present("pretty");
                 if matches.is_present("json") {

--- a/lla/src/commands/file_utils.rs
+++ b/lla/src/commands/file_utils.rs
@@ -841,6 +841,7 @@ pub fn create_formatter(args: &Args, config: &Config) -> Box<dyn FileFormatter> 
             args.permission_format.clone(),
             args.hide_group,
             args.relative_dates,
+            args.date_format.clone(),
             columns,
         ))
     } else if args.tree_format {
@@ -1056,6 +1057,7 @@ mod tests {
             permission_format: "symbolic".to_string(),
             hide_group: false,
             relative_dates: false,
+            date_format: crate::config::DEFAULT_LONG_DATE_FORMAT.to_string(),
             output_mode: OutputMode::Human,
             command: None,
             search: None,

--- a/lla/src/commands/init_wizard.rs
+++ b/lla/src/commands/init_wizard.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{validate_long_date_format, Config};
 use crate::error::Result;
 use crate::theme;
 use colored::*;
@@ -237,6 +237,15 @@ pub fn run_wizard() -> Result<()> {
         .with_prompt("Show relative timestamps (e.g., 2h ago) in long view?")
         .default(config.formatters.long.relative_dates)
         .interact()?;
+    let date_format: String = Input::with_theme(&ui_theme)
+        .with_prompt("Date format for absolute timestamps in long view")
+        .with_initial_text(config.formatters.long.date_format.clone())
+        .allow_empty(false)
+        .validate_with(|value: &String| -> std::result::Result<(), String> {
+            validate_long_date_format("formatters.long.date_format", value)
+                .map_err(|err| err.to_string())
+        })
+        .interact_text()?;
 
     const BASE_LONG_COLUMN_CHOICES: [(&str, &str); 8] = [
         ("Permissions", "permissions"),
@@ -357,6 +366,7 @@ pub fn run_wizard() -> Result<()> {
     config.filter.respect_gitignore = respect_gitignore;
     config.formatters.long.hide_group = hide_group;
     config.formatters.long.relative_dates = relative_dates;
+    config.formatters.long.date_format = date_format;
     config.formatters.long.columns = long_columns.clone();
     config.listers.recursive.max_entries = recursive_limit;
     config.enabled_plugins = selected_plugins;

--- a/lla/src/config/mod.rs
+++ b/lla/src/config/mod.rs
@@ -1726,7 +1726,9 @@ mod tests {
 
     #[test]
     fn config_set_updates_long_date_format() {
+        let plugins_dir = tempfile::tempdir().unwrap();
         let mut config = Config::default();
+        config.plugins_dir = plugins_dir.path().to_path_buf();
 
         config
             .set_value("formatters.long.date_format", "%Y-%m-%d %H:%M")

--- a/lla/src/config/mod.rs
+++ b/lla/src/config/mod.rs
@@ -1,6 +1,7 @@
 use crate::commands::args::ConfigAction;
 use crate::error::{ConfigErrorKind, LlaError, Result};
 use crate::theme::{load_theme, Theme};
+use chrono::format::{Item, StrftimeItems};
 use colored::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -10,6 +11,8 @@ use std::fmt::Display;
 use std::fs;
 use std::path::{Path, PathBuf};
 use toml::Value as TomlValue;
+
+pub const DEFAULT_LONG_DATE_FORMAT: &str = "%b %d %H:%M";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TreeFormatterConfig {
@@ -104,6 +107,8 @@ pub struct LongFormatterConfig {
     pub hide_group: bool,
     #[serde(default)]
     pub relative_dates: bool,
+    #[serde(default = "default_long_date_format")]
+    pub date_format: String,
     #[serde(default = "default_long_columns")]
     pub columns: Vec<String>,
 }
@@ -113,9 +118,14 @@ impl Default for LongFormatterConfig {
         Self {
             hide_group: false,
             relative_dates: false,
+            date_format: default_long_date_format(),
             columns: default_long_columns(),
         }
     }
+}
+
+fn default_long_date_format() -> String {
+    DEFAULT_LONG_DATE_FORMAT.to_string()
 }
 
 fn default_long_columns() -> Vec<String> {
@@ -127,6 +137,24 @@ fn default_long_columns() -> Vec<String> {
         "group".to_string(),
         "name".to_string(),
     ]
+}
+
+pub fn validate_long_date_format(key: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        return Err(LlaError::Config(ConfigErrorKind::InvalidValue(
+            key.to_string(),
+            "must not be empty".to_string(),
+        )));
+    }
+
+    if StrftimeItems::new(value).any(|item| matches!(item, Item::Error)) {
+        return Err(LlaError::Config(ConfigErrorKind::InvalidValue(
+            key.to_string(),
+            "must be a valid chrono strftime format".to_string(),
+        )));
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -558,6 +586,11 @@ hide_group = {}
 # Default: false
 relative_dates = {}
 
+# Date/time format for absolute dates in long format
+# Uses chrono strftime syntax (e.g., "%Y-%m-%d %H:%M" to show the year)
+# Default: "%b %d %H:%M"
+date_format = "{}"
+
 # Column order for long view (use built-in keys or field:<custom_field> for plugin data)
 columns = {}
 
@@ -631,6 +664,7 @@ editor = {}"#,
             self.formatters.grid.max_width,
             self.formatters.long.hide_group,
             self.formatters.long.relative_dates,
+            self.formatters.long.date_format,
             long_columns,
             table_columns,
             self.listers.recursive.max_entries.unwrap_or(0),
@@ -871,6 +905,11 @@ editor = {}"#,
             }
         }
 
+        validate_long_date_format(
+            "formatters.long.date_format",
+            &self.formatters.long.date_format,
+        )?;
+
         if let Some(max_entries) = self.listers.recursive.max_entries {
             if max_entries > 100_000 {
                 return Err(LlaError::Config(ConfigErrorKind::InvalidValue(
@@ -1095,6 +1134,10 @@ editor = {}"#,
                     ))
                 })?;
                 self.formatters.long.columns = columns;
+            }
+            ["formatters", "long", "date_format"] => {
+                validate_long_date_format(key, value)?;
+                self.formatters.long.date_format = value.to_string();
             }
             ["formatters", "table", "columns"] => {
                 let columns: Vec<String> = serde_json::from_str(value).map_err(|_| {
@@ -1413,6 +1456,7 @@ fn print_config_summary(config_path: &Path, config: &Config) {
             "absolute",
         ),
     );
+    print_row("Long date format", &config.formatters.long.date_format);
     print_row(
         "Hide group",
         format_toggle(config.formatters.long.hide_group, "hidden", "visible"),
@@ -1658,5 +1702,42 @@ fn json_value_to_string(value: &JsonValue) -> String {
                 .collect();
             format!("{{{}}}", items.join(", "))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn long_date_format_defaults_to_existing_output_shape() {
+        let config = Config::default();
+
+        assert_eq!(config.formatters.long.date_format, DEFAULT_LONG_DATE_FORMAT);
+    }
+
+    #[test]
+    fn generated_config_includes_long_date_format() {
+        let content = Config::default().generate_config_content();
+
+        assert!(content.contains("date_format = \"%b %d %H:%M\""));
+        assert!(content.contains("%Y-%m-%d %H:%M"));
+    }
+
+    #[test]
+    fn config_set_updates_long_date_format() {
+        let mut config = Config::default();
+
+        config
+            .set_value("formatters.long.date_format", "%Y-%m-%d %H:%M")
+            .unwrap();
+
+        assert_eq!(config.formatters.long.date_format, "%Y-%m-%d %H:%M");
+    }
+
+    #[test]
+    fn long_date_format_rejects_empty_and_invalid_formats() {
+        assert!(validate_long_date_format("formatters.long.date_format", "").is_err());
+        assert!(validate_long_date_format("formatters.long.date_format", "%Q").is_err());
     }
 }

--- a/lla/src/formatter/long.rs
+++ b/lla/src/formatter/long.rs
@@ -1,5 +1,6 @@
 use super::column_config::ColumnKey;
 use super::FileFormatter;
+use crate::config::DEFAULT_LONG_DATE_FORMAT;
 use crate::error::Result;
 use crate::plugin::PluginManager;
 use crate::utils::color::*;
@@ -25,6 +26,7 @@ pub struct LongFormatter {
     pub permission_format: String,
     pub hide_group: bool,
     pub relative_dates: bool,
+    pub date_format: String,
     columns: Vec<ColumnKey>,
     has_plugins_column: bool,
 }
@@ -35,6 +37,7 @@ impl LongFormatter {
         permission_format: String,
         hide_group: bool,
         relative_dates: bool,
+        date_format: String,
         columns: Vec<ColumnKey>,
     ) -> Self {
         let filtered_columns: Vec<ColumnKey> = columns
@@ -54,6 +57,7 @@ impl LongFormatter {
             permission_format,
             hide_group,
             relative_dates,
+            date_format,
             columns: final_columns,
             has_plugins_column,
         }
@@ -200,8 +204,21 @@ impl LongFormatter {
         if self.relative_dates {
             colorize_date_relative(&time).to_string()
         } else {
-            colorize_date(&time).to_string()
+            colorize_date_with_format(&time, &self.date_format).to_string()
         }
+    }
+}
+
+impl Default for LongFormatter {
+    fn default() -> Self {
+        Self::new(
+            false,
+            "symbolic".to_string(),
+            false,
+            false,
+            DEFAULT_LONG_DATE_FORMAT.to_string(),
+            vec![ColumnKey::Name],
+        )
     }
 }
 
@@ -262,5 +279,70 @@ fn pad_right(value: &str, width: usize) -> String {
         value.to_string()
     } else {
         format!("{}{}", value, " ".repeat(width - visible))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Local};
+
+    fn plain(value: &str) -> String {
+        let stripped = strip_ansi_escapes::strip(value).unwrap_or_default();
+        String::from_utf8_lossy(&stripped).into_owned()
+    }
+
+    fn expected(seconds: u64, format: &str) -> String {
+        let time = SystemTime::UNIX_EPOCH + Duration::from_secs(seconds);
+        let datetime: DateTime<Local> = time.into();
+        datetime.format(format).to_string()
+    }
+
+    #[test]
+    fn default_timestamp_format_is_unchanged() {
+        let formatter = LongFormatter::default();
+        let seconds = 1_700_000_000;
+
+        assert_eq!(
+            plain(&formatter.format_timestamp(seconds)),
+            expected(seconds, DEFAULT_LONG_DATE_FORMAT)
+        );
+    }
+
+    #[test]
+    fn custom_timestamp_format_can_include_year() {
+        let mut formatter = LongFormatter::default();
+        formatter.date_format = "%Y-%m-%d %H:%M".to_string();
+        let seconds = 1_700_000_000;
+
+        assert_eq!(
+            plain(&formatter.format_timestamp(seconds)),
+            expected(seconds, "%Y-%m-%d %H:%M")
+        );
+    }
+
+    #[test]
+    fn relative_dates_take_precedence_over_custom_format() {
+        let mut formatter = LongFormatter::default();
+        formatter.relative_dates = true;
+        formatter.date_format = "%Y-%m-%d %H:%M".to_string();
+        let seconds = 1_700_000_000;
+
+        let rendered = plain(&formatter.format_timestamp(seconds));
+
+        assert_ne!(rendered, expected(seconds, "%Y-%m-%d %H:%M"));
+        assert!(
+            rendered.contains("ago") || rendered.contains("from now") || rendered == "now",
+            "unexpected relative date output: {}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn zero_timestamp_renders_placeholder() {
+        let mut formatter = LongFormatter::default();
+        formatter.date_format = "%Y-%m-%d %H:%M".to_string();
+
+        assert_eq!(formatter.format_timestamp(0), "-");
     }
 }

--- a/lla/src/utils/color.rs
+++ b/lla/src/utils/color.rs
@@ -458,49 +458,20 @@ fn triplet(mode: u32, shift: u32) -> String {
     format!("{}{}{}", r, w, x)
 }
 
-fn triplet_no_color(mode: u32, _shift: u32) -> String {
-    let file_type = if mode & 0o170000 == 0o120000 {
-        "l"
-    } else if mode & 0o170000 == 0o040000 {
-        "d"
+fn triplet_no_color(mode: u32, shift: u32) -> String {
+    let r = if mode >> (shift + 2) & 1u32 != 0 {
+        "r"
     } else {
         "-"
     };
-    let read = |shift| {
-        if mode >> shift & 0o4u32 != 0u32 {
-            "r"
-        } else {
-            "-"
-        }
+    let w = if mode >> (shift + 1) & 1u32 != 0 {
+        "w"
+    } else {
+        "-"
     };
-    let write = |shift| {
-        if mode >> shift & 0o2u32 != 0u32 {
-            "w"
-        } else {
-            "-"
-        }
-    };
-    let exec = |shift| {
-        if mode >> shift & 0o1u32 != 0u32 {
-            "x"
-        } else {
-            "-"
-        }
-    };
+    let x = if mode >> shift & 1u32 != 0 { "x" } else { "-" };
 
-    format!(
-        "{}{}{}{}{}{}{}{}{}{}",
-        file_type,
-        read(6),
-        write(6),
-        exec(6),
-        read(3),
-        write(3),
-        exec(3),
-        read(0),
-        write(0),
-        exec(0)
-    )
+    format!("{}{}{}", r, w, x)
 }
 
 pub fn colorize_date(date: &std::time::SystemTime) -> ColoredString {
@@ -576,4 +547,38 @@ pub fn colorize_symlink_target(path: &Path) -> ColoredString {
         .color(get_color(&theme.colors.symlink))
         .italic()
         .underline()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_color_symbolic_permissions_for_directory_are_not_duplicated() {
+        assert_eq!(
+            format_permissions_no_color(0o040755, Some("symbolic")),
+            "drwxr-xr-x"
+        );
+    }
+
+    #[test]
+    fn no_color_symbolic_permissions_for_regular_file_are_not_duplicated() {
+        assert_eq!(
+            format_permissions_no_color(0o100644, Some("symbolic")),
+            "-rw-r--r--"
+        );
+    }
+
+    #[test]
+    fn no_color_non_symbolic_permission_formats_are_unchanged() {
+        assert_eq!(format_permissions_no_color(0o100644, Some("octal")), "-644");
+        assert_eq!(
+            format_permissions_no_color(0o100644, Some("binary")),
+            "-110100100"
+        );
+        assert_eq!(
+            format_permissions_no_color(0o100644, Some("compact")),
+            "644"
+        );
+    }
 }

--- a/lla/src/utils/color.rs
+++ b/lla/src/utils/color.rs
@@ -504,8 +504,12 @@ fn triplet_no_color(mode: u32, _shift: u32) -> String {
 }
 
 pub fn colorize_date(date: &std::time::SystemTime) -> ColoredString {
+    colorize_date_with_format(date, "%b %d %H:%M")
+}
+
+pub fn colorize_date_with_format(date: &std::time::SystemTime, format: &str) -> ColoredString {
     let datetime: chrono::DateTime<chrono::Local> = (*date).into();
-    let formatted = datetime.format("%b %d %H:%M").to_string();
+    let formatted = datetime.format(format).to_string();
 
     if is_no_color() {
         formatted.normal()

--- a/lla_plugin_utils/Cargo.toml
+++ b/lla_plugin_utils/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.7" }
+lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.8" }
 serde = { workspace = true }
 colored = { workspace = true }
 toml = { workspace = true }

--- a/plugins/brew/Cargo.toml
+++ b/plugins/brew/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brew"
 description = "Homebrew package manager plugin - install, uninstall, upgrade, and search packages"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/categorizer/Cargo.toml
+++ b/plugins/categorizer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "categorizer"
 description = "Categorizes files based on their extensions and metadata"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/code_complexity/Cargo.toml
+++ b/plugins/code_complexity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "code_complexity"
 description = "Analyzes code complexity and provides metrics"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/code_snippet_extractor/Cargo.toml
+++ b/plugins/code_snippet_extractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code_snippet_extractor"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 description = "Extract and manage code snippets with tagging support"
 

--- a/plugins/dirs_meta/Cargo.toml
+++ b/plugins/dirs_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dirs_meta"
 description = "Analyzes directories and shows metadata"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/duplicate_file_detector/Cargo.toml
+++ b/plugins/duplicate_file_detector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "duplicate_file_detector"
 description = "Detects duplicate files by comparing their content hashes"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_copier/Cargo.toml
+++ b/plugins/file_copier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_copier"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for copying files and directories"
 

--- a/plugins/file_hash/Cargo.toml
+++ b/plugins/file_hash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_hash"
 description = "Displays the hash of each file"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_meta/Cargo.toml
+++ b/plugins/file_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_meta"
 description = "Displays the file metadata of each file"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_mover/Cargo.toml
+++ b/plugins/file_mover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_mover"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for moving files and directories"
 

--- a/plugins/file_organizer/Cargo.toml
+++ b/plugins/file_organizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_organizer"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 description = "A plugin for lla that organizes files using various strategies"
 

--- a/plugins/file_remover/Cargo.toml
+++ b/plugins/file_remover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_remover"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 description = "A plugin for lla that provides interactive file and directory removal"
 

--- a/plugins/file_tagger/Cargo.toml
+++ b/plugins/file_tagger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_tagger"
 description = "Add and manage tags for files"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/flush_dns/Cargo.toml
+++ b/plugins/flush_dns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flush_dns"
 description = "Flush DNS cache on macOS, Linux, and Windows"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/folder_cleaner/Cargo.toml
+++ b/plugins/folder_cleaner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "folder_cleaner"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 description = "Safety-first folder organization and cleanup plugin for lla"
 

--- a/plugins/git_status/Cargo.toml
+++ b/plugins/git_status/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "git_status"
 description = "Shows Git repository status information"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_meet/Cargo.toml
+++ b/plugins/google_meet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_meet"
 description = "Google Meet plugin for creating meeting rooms and managing links"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_search/Cargo.toml
+++ b/plugins/google_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_search"
 description = "Google search with autosuggestions, search history management, and clipboard fallback"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/hackernews/Cargo.toml
+++ b/plugins/hackernews/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hackernews"
 description = "Hacker News plugin - browse top stories, best stories, new stories, ask HN, and show HN"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/jwt/Cargo.toml
+++ b/plugins/jwt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jwt"
 description = "JWT decoder and analyzer with search and validation capabilities"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/keyword_search/Cargo.toml
+++ b/plugins/keyword_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "keyword_search"
 description = "Searches file contents for user-specified keywords"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/kill_process/Cargo.toml
+++ b/plugins/kill_process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kill_process"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 description = "A plugin for lla that allows killing processes with an interactive interface"
 

--- a/plugins/last_git_commit/Cargo.toml
+++ b/plugins/last_git_commit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "last_git_commit"
 description = "A plugin for the lla that provides the last git commit hash"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/npm/Cargo.toml
+++ b/plugins/npm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "npm"
 description = "NPM package search with bundlephobia integration and favorites management"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/remove_paywall/Cargo.toml
+++ b/plugins/remove_paywall/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "remove_paywall"
 description = "Remove paywalls from URLs using services like 12ft.io, archive.is, and removepaywall.com"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/sizeviz/Cargo.toml
+++ b/plugins/sizeviz/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sizeviz"
 description = "File size visualizer plugin for lla"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/speed_test/Cargo.toml
+++ b/plugins/speed_test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "speed_test"
 description = "Internet speed test plugin - test download/upload speeds and latency"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]

--- a/plugins/youtube/Cargo.toml
+++ b/plugins/youtube/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "youtube"
 description = "YouTube search plugin with autosuggestions and history management"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Add a configurable long-view date format via `--date-format` and `[formatters.long].date_format`
- Keep the existing `%b %d %H:%M` output by default while allowing formats like `%Y-%m-%d %H:%M`
- Preserve `--relative-dates` precedence over custom absolute date formatting
- Fix the related `--no-color` symbolic permission regression in long/table/fuzzy output
- Prepare release `v0.5.8` by bumping workspace/plugin versions, internal dependency versions, `Cargo.lock`, and `CHANGELOG.md`

Closes #162.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo run -p lla -- -la --no-color --date-format "%Y-%m-%d %H:%M" lla/src`
- `git diff --check`
- GitHub Actions CI: all 7 checks passing on run 28713748401

## Release

This PR is labeled `release`. After it merges to `main`, the release workflow should use the prepared workspace version `0.5.8` to publish `v0.5.8`.