### PR TITLE
Prepare v0.5.9 with plugins directory warning fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Existing configs with a missing plugins directory now recreate that directory during load instead of warning and falling back to defaults.
+
 ## [0.5.8] - 2026-07-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9] - 2026-07-04
+
 ### Fixed
 
 - Existing configs with a missing plugins directory now recreate that directory during load instead of warning and falling back to defaults.
+
 
 ## [0.5.8] - 2026-07-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "brew"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -220,7 +220,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "categorizer"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "colored",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "code_complexity"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "colored",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "code_snippet_extractor"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "arboard",
  "base64 0.21.7",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "dirs_meta"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "colored",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "duplicate_file_detector"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "colored",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "file_copier"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "colored",
  "dialoguer",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "file_hash"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "colored",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "file_meta"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "file_mover"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "colored",
  "dialoguer",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "file_organizer"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "chrono",
  "colored",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "file_remover"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "colored",
  "dialoguer",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "file_tagger"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "colored",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "flush_dns"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -860,7 +860,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "folder_cleaner"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "chrono",
  "colored",
@@ -1011,7 +1011,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git_status"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "colored",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "google_meet"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "arboard",
  "bytes",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "google_search"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "arboard",
  "bytes",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "hackernews"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "arboard",
  "bytes",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "jwt"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "keyword_search"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "arboard",
  "bytes",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "kill_process"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "colored",
  "console",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "last_git_commit"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "colored",
@@ -1592,7 +1592,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lla"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "atty",
  "chrono",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_interface"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "prost",
  "prost-build",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_utils"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -1738,7 +1738,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "npm"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "arboard",
  "bytes",
@@ -2285,7 +2285,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remove_paywall"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "arboard",
  "bytes",
@@ -2611,7 +2611,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sizeviz"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "colored",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "speed_test"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "youtube"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "arboard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["lla", "lla_plugin_interface", "lla_plugin_utils", "plugins/*"]
 [workspace.package]
 description = "Blazing Fast and highly customizable ls Replacement with Superpowers"
 authors = ["Achaq <hi@achaq.dev>"]
-version = "0.5.8"
+version = "0.5.9"
 categories = ["utilities", "file-system", "cli", "file-management"]
 edition = "2021"
 license = "MIT"

--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -29,8 +29,8 @@ walkdir.workspace = true
 tempfile.workspace = true
 users.workspace = true
 parking_lot.workspace = true
-lla_plugin_interface = { version = "0.5.8", path = "../lla_plugin_interface" }
-lla_plugin_utils = { version = "0.5.8", path = "../lla_plugin_utils" }
+lla_plugin_interface = { version = "0.5.9", path = "../lla_plugin_interface" }
+lla_plugin_utils = { version = "0.5.9", path = "../lla_plugin_utils" }
 once_cell.workspace = true
 dashmap.workspace = true
 unicode-width.workspace = true

--- a/lla/src/config/mod.rs
+++ b/lla/src/config/mod.rs
@@ -404,6 +404,7 @@ impl Config {
         if path.exists() {
             let contents = fs::read_to_string(path)?;
             let config: Config = toml::from_str(&contents)?;
+            config.ensure_plugins_dir()?;
             config.validate()?;
             Ok(config)
         } else {
@@ -1735,6 +1736,21 @@ mod tests {
             .unwrap();
 
         assert_eq!(config.formatters.long.date_format, "%Y-%m-%d %H:%M");
+    }
+
+    #[test]
+    fn loading_existing_config_creates_missing_plugins_dir() {
+        let config_dir = tempfile::tempdir().unwrap();
+        let plugins_dir = config_dir.path().join("missing-plugins");
+        let config_path = config_dir.path().join("config.toml");
+        let mut config = Config::default();
+        config.plugins_dir = plugins_dir.clone();
+        fs::write(&config_path, config.generate_config_content()).unwrap();
+
+        let loaded = Config::load(&config_path).unwrap();
+
+        assert_eq!(loaded.plugins_dir, plugins_dir);
+        assert!(loaded.plugins_dir.is_dir());
     }
 
     #[test]

--- a/lla_plugin_utils/Cargo.toml
+++ b/lla_plugin_utils/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.8" }
+lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.9" }
 serde = { workspace = true }
 colored = { workspace = true }
 toml = { workspace = true }

--- a/plugins/brew/Cargo.toml
+++ b/plugins/brew/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brew"
 description = "Homebrew package manager plugin - install, uninstall, upgrade, and search packages"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/categorizer/Cargo.toml
+++ b/plugins/categorizer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "categorizer"
 description = "Categorizes files based on their extensions and metadata"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/code_complexity/Cargo.toml
+++ b/plugins/code_complexity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "code_complexity"
 description = "Analyzes code complexity and provides metrics"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/code_snippet_extractor/Cargo.toml
+++ b/plugins/code_snippet_extractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code_snippet_extractor"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 description = "Extract and manage code snippets with tagging support"
 

--- a/plugins/dirs_meta/Cargo.toml
+++ b/plugins/dirs_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dirs_meta"
 description = "Analyzes directories and shows metadata"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/duplicate_file_detector/Cargo.toml
+++ b/plugins/duplicate_file_detector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "duplicate_file_detector"
 description = "Detects duplicate files by comparing their content hashes"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_copier/Cargo.toml
+++ b/plugins/file_copier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_copier"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for copying files and directories"
 

--- a/plugins/file_hash/Cargo.toml
+++ b/plugins/file_hash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_hash"
 description = "Displays the hash of each file"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_meta/Cargo.toml
+++ b/plugins/file_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_meta"
 description = "Displays the file metadata of each file"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_mover/Cargo.toml
+++ b/plugins/file_mover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_mover"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for moving files and directories"
 

--- a/plugins/file_organizer/Cargo.toml
+++ b/plugins/file_organizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_organizer"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 description = "A plugin for lla that organizes files using various strategies"
 

--- a/plugins/file_remover/Cargo.toml
+++ b/plugins/file_remover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_remover"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 description = "A plugin for lla that provides interactive file and directory removal"
 

--- a/plugins/file_tagger/Cargo.toml
+++ b/plugins/file_tagger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_tagger"
 description = "Add and manage tags for files"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/flush_dns/Cargo.toml
+++ b/plugins/flush_dns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flush_dns"
 description = "Flush DNS cache on macOS, Linux, and Windows"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/folder_cleaner/Cargo.toml
+++ b/plugins/folder_cleaner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "folder_cleaner"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 description = "Safety-first folder organization and cleanup plugin for lla"
 

--- a/plugins/git_status/Cargo.toml
+++ b/plugins/git_status/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "git_status"
 description = "Shows Git repository status information"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_meet/Cargo.toml
+++ b/plugins/google_meet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_meet"
 description = "Google Meet plugin for creating meeting rooms and managing links"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_search/Cargo.toml
+++ b/plugins/google_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_search"
 description = "Google search with autosuggestions, search history management, and clipboard fallback"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/hackernews/Cargo.toml
+++ b/plugins/hackernews/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hackernews"
 description = "Hacker News plugin - browse top stories, best stories, new stories, ask HN, and show HN"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/jwt/Cargo.toml
+++ b/plugins/jwt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jwt"
 description = "JWT decoder and analyzer with search and validation capabilities"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/keyword_search/Cargo.toml
+++ b/plugins/keyword_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "keyword_search"
 description = "Searches file contents for user-specified keywords"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/kill_process/Cargo.toml
+++ b/plugins/kill_process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kill_process"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 description = "A plugin for lla that allows killing processes with an interactive interface"
 

--- a/plugins/last_git_commit/Cargo.toml
+++ b/plugins/last_git_commit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "last_git_commit"
 description = "A plugin for the lla that provides the last git commit hash"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/npm/Cargo.toml
+++ b/plugins/npm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "npm"
 description = "NPM package search with bundlephobia integration and favorites management"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/remove_paywall/Cargo.toml
+++ b/plugins/remove_paywall/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "remove_paywall"
 description = "Remove paywalls from URLs using services like 12ft.io, archive.is, and removepaywall.com"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/sizeviz/Cargo.toml
+++ b/plugins/sizeviz/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sizeviz"
 description = "File size visualizer plugin for lla"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/speed_test/Cargo.toml
+++ b/plugins/speed_test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "speed_test"
 description = "Internet speed test plugin - test download/upload speeds and latency"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]

--- a/plugins/youtube/Cargo.toml
+++ b/plugins/youtube/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "youtube"
 description = "YouTube search plugin with autosuggestions and history management"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Prepare the v0.5.9 patch release with a focused fix for existing configs whose configured `plugins_dir` was deleted or points at a missing directory.

## Root cause

`Config::load` validated existing config files before ensuring `plugins_dir` existed. That made normal listing commands print a warning and fall back to defaults when the configured plugins directory was missing, even though the directory can be safely recreated.

## Changes

- Recreate the configured plugins directory during config load before validation.
- Add regression coverage for loading an existing config with a missing plugins directory.
- Promote the changelog entry and workspace versions for v0.5.9.

## Validation

- `RELEASE_VERSION=0.5.9 .github/scripts/prepare_release.sh`
- `cargo metadata --format-version 1 >/dev/null`
- `validate_release_versions 0.5.9`
- `validate_changelog_section 0.5.9`
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `git diff --check`
- Smoke test with a temp `HOME` and missing `plugins_dir`: no warning emitted and the directory was recreated.
