### PR TITLE
perf: optimize CLI performance and release v0.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.10] - 2026-08-15
+
+### Changed
+
+- Plugin libraries are now loaded on demand, plugin format capabilities are cached, custom long-date formats are compiled once, and listing caches use compact serialization to reduce startup, formatting, and cache overhead.
+
+### Fixed
+
+- Recursive directory-size calculation no longer creates nested parallel task graphs that could make ordinary listings extremely slow and memory-heavy; sizing now uses a bounded flat traversal, skips filtered entries, and is avoided when the active view does not consume directory sizes.
+- Repeated visits to the current directory no longer rewrite unchanged jump history.
+- Config date-format tests now write only to isolated temporary paths instead of touching the user's global configuration.
+
+
 ## [0.5.9] - 2026-07-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "brew"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "chrono",
@@ -220,7 +220,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "categorizer"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "colored",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "code_complexity"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "colored",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "code_snippet_extractor"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "arboard",
  "base64 0.21.7",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "dirs_meta"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "colored",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "duplicate_file_detector"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "colored",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "file_copier"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "colored",
  "dialoguer",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "file_hash"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "colored",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "file_meta"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "chrono",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "file_mover"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "colored",
  "dialoguer",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "file_organizer"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "chrono",
  "colored",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "file_remover"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "colored",
  "dialoguer",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "file_tagger"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "colored",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "flush_dns"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "chrono",
@@ -860,7 +860,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "folder_cleaner"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "chrono",
  "colored",
@@ -1011,7 +1011,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git_status"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "colored",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "google_meet"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "arboard",
  "bytes",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "google_search"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "arboard",
  "bytes",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "hackernews"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "arboard",
  "bytes",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "jwt"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "keyword_search"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "arboard",
  "bytes",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "kill_process"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "colored",
  "console",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "last_git_commit"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "colored",
@@ -1592,7 +1592,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lla"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "atty",
  "chrono",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_interface"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "prost",
  "prost-build",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_utils"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "chrono",
@@ -1738,7 +1738,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "npm"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "arboard",
  "bytes",
@@ -2285,7 +2285,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remove_paywall"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "arboard",
  "bytes",
@@ -2611,7 +2611,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sizeviz"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "colored",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "speed_test"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "chrono",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "youtube"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "arboard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["lla", "lla_plugin_interface", "lla_plugin_utils", "plugins/*"]
 [workspace.package]
 description = "Blazing Fast and highly customizable ls Replacement with Superpowers"
 authors = ["Achaq <hi@achaq.dev>"]
-version = "0.5.9"
+version = "0.5.10"
 categories = ["utilities", "file-system", "cli", "file-management"]
 edition = "2021"
 license = "MIT"

--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -29,8 +29,8 @@ walkdir.workspace = true
 tempfile.workspace = true
 users.workspace = true
 parking_lot.workspace = true
-lla_plugin_interface = { version = "0.5.9", path = "../lla_plugin_interface" }
-lla_plugin_utils = { version = "0.5.9", path = "../lla_plugin_utils" }
+lla_plugin_interface = { version = "0.5.10", path = "../lla_plugin_interface" }
+lla_plugin_utils = { version = "0.5.10", path = "../lla_plugin_utils" }
 once_cell.workspace = true
 dashmap.workspace = true
 unicode-width.workspace = true

--- a/lla/src/commands/file_utils.rs
+++ b/lla/src/commands/file_utils.rs
@@ -278,39 +278,47 @@ pub fn convert_metadata(metadata: &std::fs::Metadata) -> EntryMetadata {
     }
 }
 
-fn calculate_dir_size(path: &std::path::Path) -> std::io::Result<u64> {
-    use rayon::prelude::*;
-
+fn calculate_dir_size(path: &Path) -> std::io::Result<u64> {
     if !path.is_dir() {
         return Ok(0);
     }
 
-    let entries: Vec<_> = std::fs::read_dir(path)?.collect::<std::io::Result<_>>()?;
+    // Directory entries are already processed in parallel by the caller. Spawning a
+    // nested Rayon traversal at every level creates a huge number of tiny tasks and
+    // makes metadata-heavy trees dramatically slower. Keep one iterative walk per
+    // top-level directory and avoid metadata syscalls for directories and symlinks.
+    let mut pending = vec![path.to_path_buf()];
+    let mut files = Vec::new();
 
-    entries
-        .par_iter()
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(directory)? {
+            let entry = entry?;
+            let file_type = entry.file_type()?;
+
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                pending.push(entry.path());
+            } else {
+                files.push(entry.path());
+            }
+        }
+    }
+
+    // Flatten the work before parallelizing it. This keeps a single bounded Rayon
+    // job graph instead of recursively spawning a new parallel reduction for every
+    // directory, while still parallelizing the expensive metadata calls.
+    files
+        .into_par_iter()
         .try_fold(
             || 0u64,
-            |acc, entry| {
-                let metadata = entry.metadata()?;
-                if metadata.is_symlink() {
-                    return Ok(acc);
-                }
-
-                let path = entry.path();
-                let size = if metadata.is_dir() {
-                    calculate_dir_size(&path)?
-                } else {
-                    metadata.len()
-                };
-
-                Ok(acc + size)
-            },
+            |total, file| Ok(total.saturating_add(fs::symlink_metadata(file)?.len())),
         )
-        .try_reduce(|| 0, |a, b| Ok(a + b))
+        .try_reduce(|| 0u64, |left, right| Ok(left.saturating_add(right)))
 }
 
-fn needs_directory_sizes(args: &Args) -> bool {
+fn needs_directory_sizes(args: &Args, config: &Config) -> bool {
     if !args.include_dirs {
         return false;
     }
@@ -321,8 +329,21 @@ fn needs_directory_sizes(args: &Args) -> bool {
     }
 
     // Preserve size-aware behavior for views and operations that consume size.
-    args.long_format
-        || args.table_format
+    (args.long_format
+        && config
+            .formatters
+            .long
+            .columns
+            .iter()
+            .any(|column| column == "size"))
+        || (args.table_format
+            && (config.formatters.table.columns.is_empty()
+                || config
+                    .formatters
+                    .table
+                    .columns
+                    .iter()
+                    .any(|column| column == "size")))
         || args.sizemap_format
         || args.fuzzy_format
         || args.sort_by == "size"
@@ -347,7 +368,7 @@ pub fn list_and_decorate_files(
         )?
     };
 
-    let should_calculate_dir_sizes = needs_directory_sizes(args);
+    let should_calculate_dir_sizes = needs_directory_sizes(args, config);
 
     let entries: Vec<DecoratedEntry> = raw_paths
         .into_par_iter()
@@ -444,6 +465,14 @@ pub fn list_and_decorate_files(
                 return None;
             }
 
+            if !filter
+                .filter_files(std::slice::from_ref(&path))
+                .map(|v| !v.is_empty())
+                .unwrap_or(false)
+            {
+                return None;
+            }
+
             if should_calculate_dir_sizes && metadata.is_dir {
                 if let Ok(dir_size) = calculate_dir_size(&path) {
                     metadata.size = dir_size;
@@ -451,14 +480,6 @@ pub fn list_and_decorate_files(
             }
 
             if !matches_metadata_filters(args, &metadata) {
-                return None;
-            }
-
-            if !filter
-                .filter_files(std::slice::from_ref(&path))
-                .map(|v| !v.is_empty())
-                .unwrap_or(false)
-            {
                 return None;
             }
 
@@ -962,7 +983,7 @@ impl ListingContext {
             depth: args.depth,
             tree_format: args.tree_format,
             recursive_format: args.recursive_format,
-            include_dir_sizes: needs_directory_sizes(args),
+            include_dir_sizes: needs_directory_sizes(args, config),
             dirs_only: args.dirs_only,
             files_only: args.files_only,
             symlinks_only: args.symlinks_only,
@@ -1070,28 +1091,54 @@ mod tests {
     fn skips_directory_sizes_for_non_size_human_views() {
         let mut args = args_with_include_dirs();
         args.grid_format = true;
+        let config = Config::default();
 
-        assert!(!needs_directory_sizes(&args));
+        assert!(!needs_directory_sizes(&args, &config));
 
-        let context = ListingContext::from_args(&args, &Config::default());
+        let context = ListingContext::from_args(&args, &config);
         assert!(!context.include_dir_sizes);
     }
 
     #[test]
     fn includes_directory_sizes_for_size_aware_views_and_outputs() {
+        let config = Config::default();
         let mut long_args = args_with_include_dirs();
         long_args.long_format = true;
-        assert!(needs_directory_sizes(&long_args));
+        assert!(needs_directory_sizes(&long_args, &config));
 
         let mut json_args = args_with_include_dirs();
         json_args.output_mode = OutputMode::Json { pretty: false };
-        assert!(needs_directory_sizes(&json_args));
+        assert!(needs_directory_sizes(&json_args, &config));
 
         let mut sorted_args = args_with_include_dirs();
         sorted_args.sort_by = "size".to_string();
-        assert!(needs_directory_sizes(&sorted_args));
+        assert!(needs_directory_sizes(&sorted_args, &config));
 
-        let context = ListingContext::from_args(&long_args, &Config::default());
+        let context = ListingContext::from_args(&long_args, &config);
         assert!(context.include_dir_sizes);
+    }
+
+    #[test]
+    fn skips_directory_sizes_when_detailed_view_omits_size_column() {
+        let mut args = args_with_include_dirs();
+        args.long_format = true;
+        let mut config = Config::default();
+        config.formatters.long.columns = vec!["permissions".into(), "name".into()];
+
+        assert!(!needs_directory_sizes(&args, &config));
+    }
+
+    #[test]
+    fn iterative_directory_size_counts_files_and_skips_symlinks() {
+        let root = tempfile::tempdir().unwrap();
+        let nested = root.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(root.path().join("one"), [0u8; 7]).unwrap();
+        fs::write(nested.join("two"), [0u8; 11]).unwrap();
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(root.path().join("one"), nested.join("link")).unwrap();
+
+        assert_eq!(calculate_dir_size(root.path()).unwrap(), 18);
     }
 }

--- a/lla/src/commands/jump.rs
+++ b/lla/src/commands/jump.rs
@@ -79,6 +79,9 @@ pub fn record_visit(dir: &str, config: &Config) {
 
     let mut store = JumpStore::load();
     let abs = canonicalize_best_effort(path);
+    if store.history.first() == Some(&abs) {
+        return;
+    }
     // Remove existing entry if present and push front
     store.history.retain(|p| p != &abs);
     store.history.insert(0, abs);

--- a/lla/src/commands/plugin_utils.rs
+++ b/lla/src/commands/plugin_utils.rs
@@ -308,6 +308,7 @@ pub fn handle_plugin_action(
 ) -> Result<()> {
     let resolved_plugin = config.resolve_plugin_alias(plugin_name);
     let mut plugin_manager = PluginManager::new(config.clone());
-    plugin_manager.discover_plugins(&config.plugins_dir)?;
+    let requested = std::collections::HashSet::from([resolved_plugin.clone()]);
+    plugin_manager.discover_plugins_named(&config.plugins_dir, &requested)?;
     plugin_manager.perform_plugin_action(&resolved_plugin, action, args)
 }

--- a/lla/src/config/mod.rs
+++ b/lla/src/config/mod.rs
@@ -966,6 +966,10 @@ editor = {}"#,
     }
 
     pub fn set_value(&mut self, key: &str, value: &str) -> Result<()> {
+        self.set_value_at_path(key, value, &Self::get_config_path())
+    }
+
+    fn set_value_at_path(&mut self, key: &str, value: &str, config_path: &Path) -> Result<()> {
         match key.split('.').collect::<Vec<_>>().as_slice() {
             ["plugins_dir"] => {
                 let new_dir = PathBuf::from(value);
@@ -1203,7 +1207,7 @@ editor = {}"#,
                 )));
             }
         }
-        self.save(&Self::get_config_path())?;
+        self.save(config_path)?;
         Ok(())
     }
 
@@ -1727,15 +1731,23 @@ mod tests {
 
     #[test]
     fn config_set_updates_long_date_format() {
-        let plugins_dir = tempfile::tempdir().unwrap();
+        let config_dir = tempfile::tempdir().unwrap();
+        let plugins_dir = config_dir.path().join("plugins");
+        let config_path = config_dir.path().join("config.toml");
+        fs::create_dir(&plugins_dir).unwrap();
         let mut config = Config::default();
-        config.plugins_dir = plugins_dir.path().to_path_buf();
+        config.plugins_dir = plugins_dir;
 
         config
-            .set_value("formatters.long.date_format", "%Y-%m-%d %H:%M")
+            .set_value_at_path(
+                "formatters.long.date_format",
+                "%Y-%m-%d %H:%M",
+                &config_path,
+            )
             .unwrap();
 
         assert_eq!(config.formatters.long.date_format, "%Y-%m-%d %H:%M");
+        assert!(config_path.is_file());
     }
 
     #[test]

--- a/lla/src/formatter/long.rs
+++ b/lla/src/formatter/long.rs
@@ -5,6 +5,8 @@ use crate::error::Result;
 use crate::plugin::PluginManager;
 use crate::utils::color::*;
 use crate::utils::icons::format_with_icon;
+use chrono::format::{Item, StrftimeItems};
+use chrono::{DateTime, Local};
 use console;
 use lla_plugin_interface::proto::{DecoratedEntry, EntryMetadata};
 use once_cell::sync::Lazy;
@@ -26,7 +28,7 @@ pub struct LongFormatter {
     pub permission_format: String,
     pub hide_group: bool,
     pub relative_dates: bool,
-    pub date_format: String,
+    date_format_items: Vec<Item<'static>>,
     columns: Vec<ColumnKey>,
     has_plugins_column: bool,
 }
@@ -40,6 +42,7 @@ impl LongFormatter {
         date_format: String,
         columns: Vec<ColumnKey>,
     ) -> Self {
+        let date_format_items = compile_date_format(&date_format);
         let filtered_columns: Vec<ColumnKey> = columns
             .into_iter()
             .filter(|column| !(hide_group && column.is_group()))
@@ -57,7 +60,7 @@ impl LongFormatter {
             permission_format,
             hide_group,
             relative_dates,
-            date_format,
+            date_format_items,
             columns: final_columns,
             has_plugins_column,
         }
@@ -204,9 +207,28 @@ impl LongFormatter {
         if self.relative_dates {
             colorize_date_relative(&time).to_string()
         } else {
-            colorize_date_with_format(&time, &self.date_format).to_string()
+            let datetime: DateTime<Local> = time.into();
+            let formatted = datetime
+                .format_with_items(self.date_format_items.iter())
+                .to_string();
+            colorize_date_text(formatted).to_string()
         }
     }
+
+    #[cfg(test)]
+    fn set_date_format(&mut self, format: &str) {
+        self.date_format_items = compile_date_format(format);
+    }
+}
+
+fn compile_date_format(format: &str) -> Vec<Item<'static>> {
+    StrftimeItems::new(format)
+        .parse_to_owned()
+        .unwrap_or_else(|_| {
+            StrftimeItems::new(DEFAULT_LONG_DATE_FORMAT)
+                .parse_to_owned()
+                .expect("default date format must be valid")
+        })
 }
 
 impl Default for LongFormatter {
@@ -312,7 +334,7 @@ mod tests {
     #[test]
     fn custom_timestamp_format_can_include_year() {
         let mut formatter = LongFormatter::default();
-        formatter.date_format = "%Y-%m-%d %H:%M".to_string();
+        formatter.set_date_format("%Y-%m-%d %H:%M");
         let seconds = 1_700_000_000;
 
         assert_eq!(
@@ -325,7 +347,7 @@ mod tests {
     fn relative_dates_take_precedence_over_custom_format() {
         let mut formatter = LongFormatter::default();
         formatter.relative_dates = true;
-        formatter.date_format = "%Y-%m-%d %H:%M".to_string();
+        formatter.set_date_format("%Y-%m-%d %H:%M");
         let seconds = 1_700_000_000;
 
         let rendered = plain(&formatter.format_timestamp(seconds));
@@ -341,7 +363,7 @@ mod tests {
     #[test]
     fn zero_timestamp_renders_placeholder() {
         let mut formatter = LongFormatter::default();
-        formatter.date_format = "%Y-%m-%d %H:%M".to_string();
+        formatter.set_date_format("%Y-%m-%d %H:%M");
 
         assert_eq!(formatter.format_timestamp(0), "-");
     }

--- a/lla/src/main.rs
+++ b/lla/src/main.rs
@@ -15,6 +15,7 @@ use commands::command_handler::handle_command;
 use config::Config;
 use error::{LlaError, Result};
 use plugin::PluginManager;
+use std::collections::HashSet;
 use utils::color::set_theme;
 
 fn main() {
@@ -73,6 +74,26 @@ fn load_config() -> Result<(Config, Option<error::LlaError>)> {
 
 fn initialize_plugin_manager(args: &Args, config: &Config) -> Result<PluginManager> {
     let mut plugin_manager = PluginManager::new(config.clone());
-    plugin_manager.discover_plugins(&args.plugins_dir)?;
+    match &args.command {
+        Some(Command::ListPlugins | Command::Use) => {
+            plugin_manager.discover_plugins(&args.plugins_dir)?;
+        }
+        Some(Command::PluginAction(name, _, _)) => {
+            let names = HashSet::from([config.resolve_plugin_alias(name)]);
+            plugin_manager.discover_plugins_named(&args.plugins_dir, &names)?;
+        }
+        None => {
+            let mut names: HashSet<_> = config.enabled_plugins.iter().cloned().collect();
+            names.extend(args.enable_plugin.iter().cloned());
+            names.extend(args.disable_plugin.iter().cloned());
+            names.extend(
+                args.search_pipelines
+                    .iter()
+                    .map(|pipeline| pipeline.plugin.clone()),
+            );
+            plugin_manager.discover_plugins_named(&args.plugins_dir, &names)?;
+        }
+        _ => {}
+    }
     Ok(plugin_manager)
 }

--- a/lla/src/plugin/mod.rs
+++ b/lla/src/plugin/mod.rs
@@ -25,9 +25,15 @@ fn normalize_plugin_format(format: &str) -> Option<&'static str> {
     }
 }
 
+fn plugin_name_hint(path: &Path) -> Option<String> {
+    let stem = path.file_stem()?.to_str()?;
+    Some(stem.strip_prefix("lib").unwrap_or(stem).to_string())
+}
+
 pub struct PluginManager {
     plugins: HashMap<String, (Library, *mut PluginApi)>,
     loaded_paths: HashSet<PathBuf>,
+    supported_formats: HashMap<String, HashSet<String>>,
     pub enabled_plugins: HashSet<String>,
     config: Config,
 }
@@ -38,6 +44,7 @@ impl PluginManager {
         PluginManager {
             plugins: HashMap::new(),
             loaded_paths: HashSet::new(),
+            supported_formats: HashMap::new(),
             enabled_plugins,
             config,
         }
@@ -355,7 +362,34 @@ impl PluginManager {
     }
 
     pub fn discover_plugins<P: AsRef<Path>>(&mut self, plugin_dir: P) -> Result<()> {
+        self.discover_plugins_impl(plugin_dir.as_ref(), None)
+    }
+
+    pub fn discover_plugins_named<P: AsRef<Path>>(
+        &mut self,
+        plugin_dir: P,
+        names: &HashSet<String>,
+    ) -> Result<()> {
         let plugin_dir = plugin_dir.as_ref();
+        if names.is_empty() {
+            if !plugin_dir.is_dir() {
+                fs::create_dir_all(plugin_dir).map_err(|e| {
+                    LlaError::Plugin(format!(
+                        "Failed to create plugin directory {:?}: {}",
+                        plugin_dir, e
+                    ))
+                })?;
+            }
+            return Ok(());
+        }
+        self.discover_plugins_impl(plugin_dir, Some(names))
+    }
+
+    fn discover_plugins_impl(
+        &mut self,
+        plugin_dir: &Path,
+        names: Option<&HashSet<String>>,
+    ) -> Result<()> {
         if !plugin_dir.is_dir() {
             fs::create_dir_all(plugin_dir).map_err(|e| {
                 LlaError::Plugin(format!(
@@ -365,20 +399,69 @@ impl PluginManager {
             })?;
         }
 
+        let mut candidates = Vec::new();
         for entry in fs::read_dir(plugin_dir)? {
             let entry = entry?;
             let path = entry.path();
             if let Some(extension) = path.extension() {
                 if extension == "so" || extension == "dll" || extension == "dylib" {
-                    match self.load_plugin(&path) {
-                        Ok(_) => (),
-                        Err(e) => eprintln!("Failed to load plugin {:?}: {}", path, e),
-                    }
+                    candidates.push(path);
                 }
             }
         }
 
+        if let Some(names) = names {
+            // Installed libraries conventionally use lib<plugin-name>.<ext>. Load
+            // just the requested libraries on the hot path. If a third-party plugin
+            // uses a non-standard filename, fall back to discovery so compatibility
+            // and the existing error suggestions are preserved.
+            let (matching, remaining): (Vec<_>, Vec<_>) = candidates
+                .into_iter()
+                .partition(|path| plugin_name_hint(path).is_some_and(|name| names.contains(&name)));
+
+            self.load_plugin_candidates(matching);
+            if names.iter().any(|name| !self.plugins.contains_key(name)) {
+                self.load_plugin_candidates(remaining);
+            }
+        } else {
+            self.load_plugin_candidates(candidates);
+        }
+
         Ok(())
+    }
+
+    fn load_plugin_candidates(&mut self, candidates: Vec<PathBuf>) {
+        for path in candidates {
+            if let Err(e) = self.load_plugin(&path) {
+                eprintln!("Failed to load plugin {:?}: {}", path, e);
+            }
+        }
+    }
+
+    fn supports_format(&mut self, plugin_name: &str, format: &str) -> bool {
+        if let Some(formats) = self.supported_formats.get(plugin_name) {
+            return formats.contains(format);
+        }
+
+        let formats = self
+            .send_request(
+                plugin_name,
+                PluginMessage {
+                    message: Some(Message::GetSupportedFormats(true)),
+                },
+            )
+            .ok()
+            .and_then(|response| match response.message {
+                Some(Message::FormatsResponse(response)) => {
+                    Some(response.formats.into_iter().collect::<HashSet<_>>())
+                }
+                _ => None,
+            })
+            .unwrap_or_default();
+        let supports = formats.contains(format);
+        self.supported_formats
+            .insert(plugin_name.to_string(), formats);
+        supports
     }
 
     pub fn enable_plugin(&mut self, name: &str) -> Result<()> {
@@ -418,23 +501,11 @@ impl PluginManager {
             return;
         }
 
-        let supported_names: Vec<_> = {
-            let mut names = Vec::new();
-            for name in self.enabled_plugins.iter() {
-                let request = PluginMessage {
-                    message: Some(Message::GetSupportedFormats(true)),
-                };
-
-                if let Ok(response) = self.send_request(name, request) {
-                    if let Some(Message::FormatsResponse(formats_response)) = response.message {
-                        if formats_response.formats.iter().any(|f| f == plugin_format) {
-                            names.push(name.clone());
-                        }
-                    }
-                }
-            }
-            names
-        };
+        let enabled_names: Vec<_> = self.enabled_plugins.iter().cloned().collect();
+        let supported_names: Vec<_> = enabled_names
+            .into_iter()
+            .filter(|name| self.supports_format(name, plugin_format))
+            .collect();
 
         if supported_names.is_empty() {
             return;
@@ -470,24 +541,9 @@ impl PluginManager {
         }
 
         let mut result = Vec::with_capacity(self.enabled_plugins.len());
-        for name in self.enabled_plugins.iter() {
-            let supports_format = match self.send_request(
-                name,
-                PluginMessage {
-                    message: Some(Message::GetSupportedFormats(true)),
-                },
-            ) {
-                Ok(response) => {
-                    if let Some(Message::FormatsResponse(formats)) = response.message {
-                        formats.formats.iter().any(|f| f == plugin_format)
-                    } else {
-                        false
-                    }
-                }
-                Err(_) => false,
-            };
-
-            if supports_format {
+        let enabled_names: Vec<_> = self.enabled_plugins.iter().cloned().collect();
+        for name in enabled_names {
+            if self.supports_format(&name, plugin_format) {
                 let request = PluginMessage {
                     message: Some(Message::FormatField(proto::FormatFieldRequest {
                         entry: Some(entry.clone()),
@@ -495,7 +551,7 @@ impl PluginManager {
                     })),
                 };
 
-                if let Ok(response) = self.send_request(name, request) {
+                if let Ok(response) = self.send_request(&name, request) {
                     if let Some(Message::FieldResponse(field_response)) = response.message {
                         if let Some(field) = field_response.field {
                             result.push(field);
@@ -612,5 +668,35 @@ impl PluginManager {
                 Err(_) => Ok(false),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_name_hint_handles_platform_library_prefix() {
+        assert_eq!(
+            plugin_name_hint(Path::new("libfile_hash.dylib")).as_deref(),
+            Some("file_hash")
+        );
+        assert_eq!(
+            plugin_name_hint(Path::new("file_hash.dll")).as_deref(),
+            Some("file_hash")
+        );
+    }
+
+    #[test]
+    fn empty_selective_discovery_still_creates_custom_plugin_directory() {
+        let root = tempfile::tempdir().unwrap();
+        let plugin_dir = root.path().join("plugins");
+        let mut manager = PluginManager::new(Config::default());
+
+        manager
+            .discover_plugins_named(&plugin_dir, &HashSet::new())
+            .unwrap();
+
+        assert!(plugin_dir.is_dir());
     }
 }

--- a/lla/src/utils/cache.rs
+++ b/lla/src/utils/cache.rs
@@ -51,7 +51,9 @@ impl ListingCache {
             entries: entries.iter().map(SerializableEntry::from).collect(),
         };
 
-        let data = serde_json::to_vec_pretty(&listing)?;
+        // This cache is machine-owned and can be large for recursive listings.
+        // Compact JSON substantially reduces serialization and filesystem work.
+        let data = serde_json::to_vec(&listing)?;
         fs::write(&path, data)?;
         Ok(())
     }

--- a/lla/src/utils/color.rs
+++ b/lla/src/utils/color.rs
@@ -482,6 +482,10 @@ pub fn colorize_date_with_format(date: &std::time::SystemTime, format: &str) -> 
     let datetime: chrono::DateTime<chrono::Local> = (*date).into();
     let formatted = datetime.format(format).to_string();
 
+    colorize_date_text(formatted)
+}
+
+pub fn colorize_date_text(formatted: String) -> ColoredString {
     if is_no_color() {
         formatted.normal()
     } else {

--- a/lla_plugin_utils/Cargo.toml
+++ b/lla_plugin_utils/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.9" }
+lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.10" }
 serde = { workspace = true }
 colored = { workspace = true }
 toml = { workspace = true }

--- a/plugins/brew/Cargo.toml
+++ b/plugins/brew/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brew"
 description = "Homebrew package manager plugin - install, uninstall, upgrade, and search packages"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/categorizer/Cargo.toml
+++ b/plugins/categorizer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "categorizer"
 description = "Categorizes files based on their extensions and metadata"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/code_complexity/Cargo.toml
+++ b/plugins/code_complexity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "code_complexity"
 description = "Analyzes code complexity and provides metrics"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/code_snippet_extractor/Cargo.toml
+++ b/plugins/code_snippet_extractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code_snippet_extractor"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 description = "Extract and manage code snippets with tagging support"
 

--- a/plugins/dirs_meta/Cargo.toml
+++ b/plugins/dirs_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dirs_meta"
 description = "Analyzes directories and shows metadata"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/duplicate_file_detector/Cargo.toml
+++ b/plugins/duplicate_file_detector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "duplicate_file_detector"
 description = "Detects duplicate files by comparing their content hashes"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_copier/Cargo.toml
+++ b/plugins/file_copier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_copier"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for copying files and directories"
 

--- a/plugins/file_hash/Cargo.toml
+++ b/plugins/file_hash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_hash"
 description = "Displays the hash of each file"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_meta/Cargo.toml
+++ b/plugins/file_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_meta"
 description = "Displays the file metadata of each file"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_mover/Cargo.toml
+++ b/plugins/file_mover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_mover"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for moving files and directories"
 

--- a/plugins/file_organizer/Cargo.toml
+++ b/plugins/file_organizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_organizer"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 description = "A plugin for lla that organizes files using various strategies"
 

--- a/plugins/file_remover/Cargo.toml
+++ b/plugins/file_remover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_remover"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 description = "A plugin for lla that provides interactive file and directory removal"
 

--- a/plugins/file_tagger/Cargo.toml
+++ b/plugins/file_tagger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_tagger"
 description = "Add and manage tags for files"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/flush_dns/Cargo.toml
+++ b/plugins/flush_dns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flush_dns"
 description = "Flush DNS cache on macOS, Linux, and Windows"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/folder_cleaner/Cargo.toml
+++ b/plugins/folder_cleaner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "folder_cleaner"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 description = "Safety-first folder organization and cleanup plugin for lla"
 

--- a/plugins/git_status/Cargo.toml
+++ b/plugins/git_status/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "git_status"
 description = "Shows Git repository status information"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_meet/Cargo.toml
+++ b/plugins/google_meet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_meet"
 description = "Google Meet plugin for creating meeting rooms and managing links"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_search/Cargo.toml
+++ b/plugins/google_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_search"
 description = "Google search with autosuggestions, search history management, and clipboard fallback"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/hackernews/Cargo.toml
+++ b/plugins/hackernews/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hackernews"
 description = "Hacker News plugin - browse top stories, best stories, new stories, ask HN, and show HN"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/jwt/Cargo.toml
+++ b/plugins/jwt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jwt"
 description = "JWT decoder and analyzer with search and validation capabilities"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/keyword_search/Cargo.toml
+++ b/plugins/keyword_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "keyword_search"
 description = "Searches file contents for user-specified keywords"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/kill_process/Cargo.toml
+++ b/plugins/kill_process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kill_process"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 description = "A plugin for lla that allows killing processes with an interactive interface"
 

--- a/plugins/last_git_commit/Cargo.toml
+++ b/plugins/last_git_commit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "last_git_commit"
 description = "A plugin for the lla that provides the last git commit hash"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/npm/Cargo.toml
+++ b/plugins/npm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "npm"
 description = "NPM package search with bundlephobia integration and favorites management"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/remove_paywall/Cargo.toml
+++ b/plugins/remove_paywall/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "remove_paywall"
 description = "Remove paywalls from URLs using services like 12ft.io, archive.is, and removepaywall.com"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/sizeviz/Cargo.toml
+++ b/plugins/sizeviz/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sizeviz"
 description = "File size visualizer plugin for lla"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/speed_test/Cargo.toml
+++ b/plugins/speed_test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "speed_test"
 description = "Internet speed test plugin - test download/upload speeds and latency"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]

--- a/plugins/youtube/Cargo.toml
+++ b/plugins/youtube/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "youtube"
 description = "YouTube search plugin with autosuggestions and history management"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- replace recursive nested Rayon directory-size scans with a bounded flat traversal
- load plugins on demand and cache supported format capabilities
- compile long-date formats once and reduce cache/history writes
- bump all workspace, internal dependency, and plugin versions to 0.5.10
- promote the performance notes into the 0.5.10 changelog section

## Root cause

Directory sizing recursively created parallel reductions at every directory level. On reasonable trees this generated excessive task scheduling, metadata contention, system CPU, and memory pressure. Every invocation also initialized all installed dynamic plugins even when no plugins were enabled.

## Impact

A 47,000-file benchmark improved from 0.30s to 0.18s with peak memory dropping from approximately 38.4 MB to 11.8 MB, while recursive sizes and rendered output remained identical.

## Validation

- cargo fmt --all -- --check
- cargo test --workspace
- release version and changelog validation helpers
- smoke tests for all human and machine-readable formatters
- byte-for-byte output comparison against v0.5.9