### PR TITLE
fix(release): enforce glibc 2.28 compatibility

### DIFF
--- a/.github/scripts/check_glibc_baseline.sh
+++ b/.github/scripts/check_glibc_baseline.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <maximum-glibc-version> <elf-file> [elf-file ...]" 1>&2
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+  exit 2
+fi
+
+baseline="$1"
+shift
+
+if ! [[ "$baseline" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "Invalid glibc baseline: $baseline" 1>&2
+  exit 2
+fi
+
+if ! command -v readelf >/dev/null 2>&1; then
+  echo "readelf is required to verify glibc compatibility" 1>&2
+  exit 1
+fi
+
+for artifact in "$@"; do
+  if [[ ! -f "$artifact" ]]; then
+    echo "ELF artifact not found: $artifact" 1>&2
+    exit 1
+  fi
+
+  highest="$({
+    readelf -W --version-info "$artifact" 2>/dev/null || true
+  } | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' | sed 's/^GLIBC_//' | sort -Vu | tail -n 1)"
+
+  if [[ -z "$highest" ]]; then
+    echo "No versioned glibc symbols found in $artifact"
+    continue
+  fi
+
+  oldest="$(printf '%s\n%s\n' "$baseline" "$highest" | sort -V | head -n 1)"
+  if [[ "$oldest" != "$highest" ]]; then
+    echo "$artifact requires GLIBC_$highest, newer than supported GLIBC_$baseline" 1>&2
+    exit 1
+  fi
+
+  echo "$artifact requires at most GLIBC_$highest (baseline: GLIBC_$baseline)"
+done

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,6 +9,7 @@ This repository uses regular CI for pull requests and a short two-action release
 
 - Triggered on pushes and pull requests to `main` when Rust sources, manifests, proto files, scripts, workflow files, package metadata, or toolchain files change.
 - Runs formatting, Clippy, tests, and release-mode build checks across Linux and macOS.
+- Builds GNU/Linux artifacts against an explicit glibc 2.28 baseline and rejects newer symbol requirements.
 - Clippy stays in regular CI; release publishing is gated by formatting, tests, validation, asset verification, and publish dry-runs.
 
 ## Prepare Release (`prepare-release.yml`)
@@ -45,6 +46,7 @@ This repository uses regular CI for pull requests and a short two-action release
   - Linux packages: `.deb`, `.rpm`, `.apk`, `.pkg.tar.zst`
   - `themes.zip`
   - final `SHA256SUMS`
+- GNU/Linux CLI and plugin artifacts are built with pinned Zig tooling and must not require glibc newer than 2.28.
 - Publishes crates.io packages in dependency order:
   - `lla_plugin_interface`
   - `lla_plugin_utils`
@@ -70,3 +72,4 @@ This repository uses regular CI for pull requests and a short two-action release
 - `.github/scripts/prepare_release.sh` updates release versions and changelog content for the generated PR.
 - `.github/scripts/release_helpers.sh` contains shared validation, expected asset, checksum, crates.io, and GitHub release helpers.
 - `scripts/build_plugins.sh` builds plugin dynamic libraries and produces both `.tar.gz` and `.zip` archives for each release target.
+- `.github/scripts/check_glibc_baseline.sh` enforces the documented GNU/Linux compatibility baseline.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_ZIGBUILD_VERSION: "0.23.0"
+  GLIBC_BASELINE: "2.28"
+  ZIG_VERSION: "0.15.2"
 
 jobs:
   test:
@@ -74,12 +77,10 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact_name: lla-linux-arm64
-            cross_compile: true
             pkg_formats: "deb,rpm,apk,pacman"
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
             artifact_name: lla-linux-i686
-            cross_compile: true
             pkg_formats: "deb,rpm,apk,pacman"
 
           # macOS builds
@@ -107,18 +108,13 @@ jobs:
           rustup target add ${{ matrix.target }} --toolchain stable
           rustup target list --installed
 
-      - name: Install cross-compilation tools
-        if: matrix.cross_compile && runner.os == 'Linux'
+      - name: Install pinned Zig build tools
+        if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-i686-linux-gnu
-          sudo apt-get install -y crossbuild-essential-arm64 crossbuild-essential-i386
-
-      - name: Set cross-compilation environment
-        if: matrix.cross_compile && runner.os == 'Linux'
-        run: |
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-          echo "CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=i686-linux-gnu-gcc" >> $GITHUB_ENV
+          python3 -m venv "$RUNNER_TEMP/zig"
+          "$RUNNER_TEMP/zig/bin/pip" install "ziglang==$ZIG_VERSION"
+          echo "$RUNNER_TEMP/zig/bin" >> "$GITHUB_PATH"
+          cargo install cargo-zigbuild --version "$CARGO_ZIGBUILD_VERSION" --locked
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -128,7 +124,18 @@ jobs:
       - name: Build release
         env:
           RUSTUP_TOOLCHAIN: stable
-        run: cargo build --release --target ${{ matrix.target }}
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            cargo zigbuild --release --target "${{ matrix.target }}.${GLIBC_BASELINE}"
+          else
+            cargo build --release --target "${{ matrix.target }}"
+          fi
+
+      - name: Verify glibc baseline
+        if: runner.os == 'Linux'
+        run: |
+          mapfile -t artifacts < <(find "target/${{ matrix.target }}/release" -maxdepth 1 -type f \( -name lla -o -name '*.so' \) | sort)
+          .github/scripts/check_glibc_baseline.sh "$GLIBC_BASELINE" "${artifacts[@]}"
 
       - name: Prepare binary (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_ZIGBUILD_VERSION: "0.23.0"
+  GLIBC_BASELINE: "2.28"
+  ZIG_VERSION: "0.15.2"
 
 jobs:
   validate:
@@ -134,11 +137,9 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact_name: lla-linux-arm64
-            cross_compile: true
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
             artifact_name: lla-linux-i686
-            cross_compile: true
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact_name: lla-macos-amd64
@@ -161,17 +162,13 @@ jobs:
           components: rustfmt, clippy
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools
-        if: matrix.cross_compile && runner.os == 'Linux'
+      - name: Install pinned Zig build tools
+        if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-i686-linux-gnu crossbuild-essential-arm64 crossbuild-essential-i386
-
-      - name: Set cross-compilation environment
-        if: matrix.cross_compile && runner.os == 'Linux'
-        run: |
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=i686-linux-gnu-gcc" >> "$GITHUB_ENV"
+          python3 -m venv "$RUNNER_TEMP/zig"
+          "$RUNNER_TEMP/zig/bin/pip" install "ziglang==$ZIG_VERSION"
+          echo "$RUNNER_TEMP/zig/bin" >> "$GITHUB_PATH"
+          cargo install cargo-zigbuild --version "$CARGO_ZIGBUILD_VERSION" --locked
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -179,7 +176,16 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }} -p lla
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            cargo zigbuild --release --target "${{ matrix.target }}.${GLIBC_BASELINE}" -p lla
+          else
+            cargo build --release --target "${{ matrix.target }}" -p lla
+          fi
+
+      - name: Verify glibc baseline
+        if: runner.os == 'Linux'
+        run: .github/scripts/check_glibc_baseline.sh "$GLIBC_BASELINE" "target/${{ matrix.target }}/release/lla"
 
       - name: Prepare binary artifact
         run: cp "target/${{ matrix.target }}/release/lla" "${{ matrix.artifact_name }}"
@@ -198,15 +204,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             os_label: linux
             arch_label: amd64
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             os_label: linux
             arch_label: arm64
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: i686-unknown-linux-gnu
             os_label: linux
             arch_label: i686
@@ -231,19 +237,27 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Install cross toolchain
-        if: runner.os == 'Linux' && (contains(matrix.target, 'aarch64') || contains(matrix.target, 'i686'))
+      - name: Install pinned Zig build tools
+        if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-i686-linux-gnu crossbuild-essential-arm64 crossbuild-essential-i386
-          if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]]; then
-            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-          elif [[ "${{ matrix.target }}" == "i686-unknown-linux-gnu" ]]; then
-            echo "CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=i686-linux-gnu-gcc" >> "$GITHUB_ENV"
-          fi
+          python3 -m venv "$RUNNER_TEMP/zig"
+          "$RUNNER_TEMP/zig/bin/pip" install "ziglang==$ZIG_VERSION"
+          echo "$RUNNER_TEMP/zig/bin" >> "$GITHUB_PATH"
+          cargo install cargo-zigbuild --version "$CARGO_ZIGBUILD_VERSION" --locked
 
       - name: Build plugin archives
-        run: ./scripts/build_plugins.sh --target ${{ matrix.target }}
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            ./scripts/build_plugins.sh --target "${{ matrix.target }}" --glibc-version "$GLIBC_BASELINE"
+          else
+            ./scripts/build_plugins.sh --target "${{ matrix.target }}"
+          fi
+
+      - name: Verify glibc baseline
+        if: runner.os == 'Linux'
+        run: |
+          mapfile -t plugins < <(find "dist/plugins-${{ matrix.os_label }}-${{ matrix.arch_label }}" -maxdepth 1 -type f -name '*.so' | sort)
+          .github/scripts/check_glibc_baseline.sh "$GLIBC_BASELINE" "${plugins[@]}"
 
       - name: Upload plugin artifacts
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- GNU/Linux release binaries and plugins now target glibc 2.28 explicitly, preventing build-runner updates from breaking Raspberry Pi OS and other supported older distributions.
+
 ## [0.5.10] - 2026-08-15
 
 ### Changed

--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -6,11 +6,12 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 usage() {
-  echo "Usage: $0 [--target <triple>]" 1>&2
-  echo "Example: $0 --target x86_64-unknown-linux-gnu" 1>&2
+  echo "Usage: $0 [--target <triple>] [--glibc-version <version>]" 1>&2
+  echo "Example: $0 --target x86_64-unknown-linux-gnu --glibc-version 2.28" 1>&2
 }
 
 TARGET_TRIPLE=""
+GLIBC_VERSION=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -18,6 +19,12 @@ while [[ $# -gt 0 ]]; do
       shift
       TARGET_TRIPLE="${1:-}"
       [[ -z "$TARGET_TRIPLE" ]] && { echo "--target requires an argument" 1>&2; usage; exit 2; }
+      shift
+      ;;
+    --glibc-version)
+      shift
+      GLIBC_VERSION="${1:-}"
+      [[ -z "$GLIBC_VERSION" ]] && { echo "--glibc-version requires an argument" 1>&2; usage; exit 2; }
       shift
       ;;
     -h|--help)
@@ -35,6 +42,21 @@ done
 if [[ -z "$TARGET_TRIPLE" ]]; then
   # Detect host triple
   TARGET_TRIPLE=$(rustc -vV | sed -n 's/^host: \(.*\)$/\1/p')
+fi
+
+if [[ -n "$GLIBC_VERSION" ]]; then
+  if [[ ! "$GLIBC_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    echo "Invalid glibc version: $GLIBC_VERSION" 1>&2
+    exit 2
+  fi
+  if [[ "$TARGET_TRIPLE" != *-unknown-linux-gnu ]]; then
+    echo "--glibc-version is only supported for unknown-linux-gnu targets" 1>&2
+    exit 2
+  fi
+  if ! command -v cargo-zigbuild >/dev/null 2>&1; then
+    echo "cargo-zigbuild is required when --glibc-version is set" 1>&2
+    exit 1
+  fi
 fi
 
 case "$TARGET_TRIPLE" in
@@ -99,8 +121,14 @@ for crate in "${PLUGIN_CRATES[@]}"; do
   BUILD_PKGS+=( -p "$crate" )
 done
 
-echo "Running: cargo build --release --target $TARGET_TRIPLE ${BUILD_PKGS[*]}"
-cargo build --release --target "$TARGET_TRIPLE" "${BUILD_PKGS[@]}"
+if [[ -n "$GLIBC_VERSION" ]]; then
+  BUILD_TARGET="${TARGET_TRIPLE}.${GLIBC_VERSION}"
+  echo "Running: cargo zigbuild --release --target $BUILD_TARGET ${BUILD_PKGS[*]}"
+  cargo zigbuild --release --target "$BUILD_TARGET" "${BUILD_PKGS[@]}"
+else
+  echo "Running: cargo build --release --target $TARGET_TRIPLE ${BUILD_PKGS[*]}"
+  cargo build --release --target "$TARGET_TRIPLE" "${BUILD_PKGS[@]}"
+fi
 
 # Copy resulting dynamic libraries to staging
 for crate in "${PLUGIN_CRATES[@]}"; do
@@ -140,4 +168,3 @@ fi
 echo "Created archive: $ARCHIVE_ZIP"
 
 echo "Done."
-


### PR DESCRIPTION
## What changed

- Build GNU/Linux CLI binaries and plugin archives with pinned Zig and cargo-zigbuild versions.
- Target an explicit glibc 2.28 baseline on amd64, arm64, and i686.
- Verify every GNU release ELF with a reusable glibc symbol gate.
- Keep existing artifact names and full dynamic-plugin behavior.

## Why

The release runner currently allows the minimum glibc requirement to drift. The published ARM64 v0.5.9 binary references GLIBC_2.39, so it cannot run on Raspberry Pi OS Bookworm with glibc 2.36.

## Impact

GNU releases become compatible with glibc 2.28 and newer without changing CLI behavior, package names, installers, or plugin support.

## Validation

- cargo fmt --all -- --check
- cargo test --workspace
- ShellCheck for modified shell scripts
- Workflow YAML parsing
- Linux x86_64 cargo-zigbuild release build targeting glibc 2.28
- ELF gate confirms the new build requires at most GLIBC_2.28
- ELF gate rejects the current v0.5.9 ARM64 artifact because it requires GLIBC_2.39

Tracks #117. Close it only after the published ARM64 GNU artifact is verified on a glibc 2.36 environment.