### PR TITLE
feat(release): publish static musl binaries

### DIFF
--- a/.github/scripts/release_helpers.sh
+++ b/.github/scripts/release_helpers.sh
@@ -152,7 +152,9 @@ write_expected_assets() {
 
   cat > "$output_file" <<EOF
 lla-linux-amd64
+lla-linux-amd64-musl
 lla-linux-arm64
+lla-linux-arm64-musl
 lla-linux-i686
 lla-macos-amd64
 lla-macos-arm64

--- a/.github/scripts/smoke_test_musl.sh
+++ b/.github/scripts/smoke_test_musl.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <lla-musl-binary>" 1>&2
+  exit 2
+fi
+
+binary="$(realpath "$1")"
+if [[ ! -x "$binary" ]]; then
+  echo "Musl binary is not executable: $binary" 1>&2
+  exit 1
+fi
+
+fixture_dir="$(mktemp -d)"
+trap 'rm -rf "$fixture_dir"' EXIT
+export HOME="$fixture_dir/home"
+mkdir -p "$HOME" "$fixture_dir/files/subdir"
+printf 'needle in a haystack\n' > "$fixture_dir/files/example.txt"
+printf 'another file\n' > "$fixture_dir/files/subdir/other.txt"
+tar -C "$fixture_dir/files" -czf "$fixture_dir/example.tar.gz" .
+
+"$binary" init --default >/dev/null
+config_file="$HOME/.config/lla/config.toml"
+sed 's/enabled_plugins = \[\]/enabled_plugins = ["missing_plugin"]/' \
+  "$config_file" >"$config_file.tmp"
+mv "$config_file.tmp" "$config_file"
+
+"$binary" "$fixture_dir/files" >/dev/null 2>"$fixture_dir/default.stderr"
+[[ ! -s "$fixture_dir/default.stderr" ]]
+"$binary" "$fixture_dir/files" --long >/dev/null 2>"$fixture_dir/long.stderr"
+[[ ! -s "$fixture_dir/long.stderr" ]]
+"$binary" "$fixture_dir/files" --table >/dev/null 2>"$fixture_dir/table.stderr"
+[[ ! -s "$fixture_dir/table.stderr" ]]
+"$binary" "$fixture_dir/files" --json >"$fixture_dir/listing.json" 2>"$fixture_dir/json.stderr"
+[[ ! -s "$fixture_dir/json.stderr" ]]
+grep -q 'example.txt' "$fixture_dir/listing.json"
+"$binary" "$fixture_dir/files" --csv >"$fixture_dir/listing.csv" 2>"$fixture_dir/csv.stderr"
+[[ ! -s "$fixture_dir/csv.stderr" ]]
+grep -q 'example.txt' "$fixture_dir/listing.csv"
+"$binary" "$fixture_dir/files" --filter '*.txt' >/dev/null
+"$binary" "$fixture_dir/files" --search needle >"$fixture_dir/search.txt"
+grep -q 'needle' "$fixture_dir/search.txt"
+"$binary" "$fixture_dir/example.tar.gz" --long >"$fixture_dir/archive.txt"
+grep -q 'example.txt' "$fixture_dir/archive.txt"
+"$binary" config show-effective >/dev/null
+"$binary" theme preview default >/dev/null
+
+plugin_output="$fixture_dir/plugin-error.txt"
+assert_plugin_unavailable() {
+  if "$binary" "$@" >"$plugin_output" 2>&1; then
+    echo "Static musl plugin command unexpectedly succeeded: $*" 1>&2
+    exit 1
+  fi
+  grep -qF \
+    'Dynamic plugins are unavailable in the static musl build; use a GNU build for plugin support.' \
+    "$plugin_output"
+}
+
+assert_plugin_unavailable install --prebuilt
+assert_plugin_unavailable list-plugins
+assert_plugin_unavailable "$fixture_dir/files" --enable-plugin missing_plugin
+
+echo "Static musl smoke tests passed"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,12 +41,15 @@ This repository uses regular CI for pull requests and a short two-action release
   - `cargo fmt --all -- --check`
   - `cargo test --workspace`
 - Builds and verifies all release assets before publishing:
-  - CLI binaries: `lla-linux-*`, `lla-macos-*`
+  - full-featured CLI binaries: `lla-linux-{amd64,arm64,i686}`, `lla-macos-*`
+  - core-only static musl binaries: `lla-linux-{amd64,arm64}-musl`
   - plugin archives: `plugins-*.tar.gz` and `plugins-*.zip`
   - Linux packages: `.deb`, `.rpm`, `.apk`, `.pkg.tar.zst`
   - `themes.zip`
   - final `SHA256SUMS`
 - GNU/Linux CLI and plugin artifacts are built with pinned Zig tooling and must not require glibc newer than 2.28.
+- Musl binaries must have no ELF interpreter or dynamic dependencies and pass core CLI smoke tests in amd64 and arm64 Alpine containers.
+- amd64 and arm64 APK packages contain static musl binaries; the i686 APK remains a legacy GNU-based package.
 - Publishes crates.io packages in dependency order:
   - `lla_plugin_interface`
   - `lla_plugin_utils`
@@ -73,3 +76,4 @@ This repository uses regular CI for pull requests and a short two-action release
 - `.github/scripts/release_helpers.sh` contains shared validation, expected asset, checksum, crates.io, and GitHub release helpers.
 - `scripts/build_plugins.sh` builds plugin dynamic libraries and produces both `.tar.gz` and `.zip` archives for each release target.
 - `.github/scripts/check_glibc_baseline.sh` enforces the documented GNU/Linux compatibility baseline.
+- `.github/scripts/smoke_test_musl.sh` exercises core features and the explicit plugin error inside Alpine.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,15 +73,28 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact_name: lla-linux-amd64
+            libc: gnu
             pkg_formats: "deb,rpm,apk,pacman"
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact_name: lla-linux-arm64
+            libc: gnu
             pkg_formats: "deb,rpm,apk,pacman"
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
             artifact_name: lla-linux-i686
+            libc: gnu
             pkg_formats: "deb,rpm,apk,pacman"
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            artifact_name: lla-linux-amd64-musl
+            libc: musl
+            pkg_formats: "apk"
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            artifact_name: lla-linux-arm64-musl
+            libc: musl
+            pkg_formats: "apk"
 
           # macOS builds
           - os: macos-latest
@@ -125,17 +138,33 @@ jobs:
         env:
           RUSTUP_TOOLCHAIN: stable
         run: |
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
+          if [[ "${{ matrix.libc }}" == "musl" ]]; then
+            cargo zigbuild --release --target "${{ matrix.target }}" -p lla --no-default-features
+          elif [[ "${{ runner.os }}" == "Linux" ]]; then
             cargo zigbuild --release --target "${{ matrix.target }}.${GLIBC_BASELINE}"
           else
             cargo build --release --target "${{ matrix.target }}"
           fi
 
       - name: Verify glibc baseline
-        if: runner.os == 'Linux'
+        if: matrix.libc == 'gnu'
         run: |
           mapfile -t artifacts < <(find "target/${{ matrix.target }}/release" -maxdepth 1 -type f \( -name lla -o -name '*.so' \) | sort)
           .github/scripts/check_glibc_baseline.sh "$GLIBC_BASELINE" "${artifacts[@]}"
+
+      - name: Verify static musl linkage
+        if: matrix.libc == 'musl'
+        run: |
+          binary="target/${{ matrix.target }}/release/lla"
+          file "$binary" | grep -q "statically linked"
+          if readelf -W -l "$binary" | grep -q 'INTERP'; then
+            echo "Static musl binary unexpectedly contains an ELF interpreter" 1>&2
+            exit 1
+          fi
+          if readelf -W -d "$binary" 2>/dev/null | grep -q 'NEEDED'; then
+            echo "Static musl binary unexpectedly contains dynamic dependencies" 1>&2
+            exit 1
+          fi
 
       - name: Prepare binary (Unix)
         if: runner.os != 'Windows'
@@ -147,3 +176,35 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_name }}
+
+  musl_smoke:
+    name: Musl Smoke (${{ matrix.arch }})
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            artifact_name: lla-linux-amd64-musl
+          - arch: arm64
+            platform: linux/arm64
+            artifact_name: lla-linux-arm64-musl
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - name: Download musl artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: musl-artifact
+
+      - name: Run Alpine smoke tests
+        run: |
+          chmod +x "musl-artifact/${{ matrix.artifact_name }}"
+          docker run --rm --platform "${{ matrix.platform }}" \
+            -v "$PWD:/work" -w /work alpine:3.23 \
+            sh -c 'apk add --no-cache bash ripgrep >/dev/null && .github/scripts/smoke_test_musl.sh "musl-artifact/${{ matrix.artifact_name }}"'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,12 +134,23 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact_name: lla-linux-amd64
+            libc: gnu
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact_name: lla-linux-arm64
+            libc: gnu
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
             artifact_name: lla-linux-i686
+            libc: gnu
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            artifact_name: lla-linux-amd64-musl
+            libc: musl
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            artifact_name: lla-linux-arm64-musl
+            libc: musl
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact_name: lla-macos-amd64
@@ -177,15 +188,31 @@ jobs:
 
       - name: Build release binary
         run: |
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
+          if [[ "${{ matrix.libc }}" == "musl" ]]; then
+            cargo zigbuild --release --target "${{ matrix.target }}" -p lla --no-default-features
+          elif [[ "${{ runner.os }}" == "Linux" ]]; then
             cargo zigbuild --release --target "${{ matrix.target }}.${GLIBC_BASELINE}" -p lla
           else
             cargo build --release --target "${{ matrix.target }}" -p lla
           fi
 
       - name: Verify glibc baseline
-        if: runner.os == 'Linux'
+        if: matrix.libc == 'gnu'
         run: .github/scripts/check_glibc_baseline.sh "$GLIBC_BASELINE" "target/${{ matrix.target }}/release/lla"
+
+      - name: Verify static musl linkage
+        if: matrix.libc == 'musl'
+        run: |
+          binary="target/${{ matrix.target }}/release/lla"
+          file "$binary" | grep -q "statically linked"
+          if readelf -W -l "$binary" | grep -q 'INTERP'; then
+            echo "Static musl binary unexpectedly contains an ELF interpreter" 1>&2
+            exit 1
+          fi
+          if readelf -W -d "$binary" 2>/dev/null | grep -q 'NEEDED'; then
+            echo "Static musl binary unexpectedly contains dynamic dependencies" 1>&2
+            exit 1
+          fi
 
       - name: Prepare binary artifact
         run: cp "target/${{ matrix.target }}/release/lla" "${{ matrix.artifact_name }}"
@@ -267,6 +294,40 @@ jobs:
             dist/plugins-${{ matrix.os_label }}-${{ matrix.arch_label }}.tar.gz
             dist/plugins-${{ matrix.os_label }}-${{ matrix.arch_label }}.zip
 
+  test_musl:
+    name: Test Musl (${{ matrix.arch }})
+    needs: [validate, build_core]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            artifact_name: lla-linux-amd64-musl
+          - arch: arm64
+            platform: linux/arm64
+            artifact_name: lla-linux-arm64-musl
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.release_tag }}
+
+      - uses: docker/setup-qemu-action@v3
+
+      - name: Download musl artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: core-${{ matrix.artifact_name }}
+          path: musl-artifact
+
+      - name: Run Alpine smoke tests
+        run: |
+          chmod +x "musl-artifact/${{ matrix.artifact_name }}"
+          docker run --rm --platform "${{ matrix.platform }}" \
+            -v "$PWD:/work" -w /work alpine:3.23 \
+            sh -c 'apk add --no-cache bash ripgrep >/dev/null && .github/scripts/smoke_test_musl.sh "musl-artifact/${{ matrix.artifact_name }}"'
+
   build_packages:
     name: Build OS Packages
     needs: [validate, build_core]
@@ -297,31 +358,34 @@ jobs:
           set -euo pipefail
           mkdir -p packages
 
-          for binary in core_binaries/lla-linux-*; do
+          for binary in core_binaries/lla-linux-amd64 core_binaries/lla-linux-arm64 core_binaries/lla-linux-i686; do
             [ -f "$binary" ] || continue
             artifact_name="$(basename "$binary")"
 
             case "$artifact_name" in
-              *amd64)
+              lla-linux-amd64)
                 ARCH="amd64"
                 DEB_ARCH="amd64"
                 RPM_ARCH="x86_64"
                 APK_ARCH="x86_64"
                 PACMAN_ARCH="x86_64"
+                APK_BINARY="core_binaries/lla-linux-amd64-musl"
                 ;;
-              *arm64)
+              lla-linux-arm64)
                 ARCH="arm64"
                 DEB_ARCH="arm64"
                 RPM_ARCH="aarch64"
                 APK_ARCH="aarch64"
                 PACMAN_ARCH="aarch64"
+                APK_BINARY="core_binaries/lla-linux-arm64-musl"
                 ;;
-              *i686)
+              lla-linux-i686)
                 ARCH="386"
                 DEB_ARCH="i386"
                 RPM_ARCH="i686"
                 APK_ARCH="x86"
                 PACMAN_ARCH="i686"
+                APK_BINARY="$binary"
                 ;;
               *)
                 echo "Skipping unsupported artifact $artifact_name"
@@ -338,10 +402,19 @@ jobs:
 
             nfpm pkg --config "$tmp_config" --packager deb --target "packages/lla_${VERSION}_${DEB_ARCH}.deb"
             nfpm pkg --config "$tmp_config" --packager rpm --target "packages/lla-${VERSION}-1.${RPM_ARCH}.rpm"
-            nfpm pkg --config "$tmp_config" --packager apk --target "packages/lla-${VERSION}-r0.${APK_ARCH}.apk"
             nfpm pkg --config "$tmp_config" --packager archlinux --target "packages/lla-${VERSION}-1-${PACMAN_ARCH}.pkg.tar.zst"
 
             rm -f "$tmp_config"
+
+            if [[ ! -f "$APK_BINARY" ]]; then
+              echo "Missing APK binary: $APK_BINARY" 1>&2
+              exit 1
+            fi
+            export BINARY_PATH="$APK_BINARY"
+            apk_config="$(mktemp)"
+            envsubst < nfpm.yaml > "$apk_config"
+            nfpm pkg --config "$apk_config" --packager apk --target "packages/lla-${VERSION}-r0.${APK_ARCH}.apk"
+            rm -f "$apk_config"
           done
 
       - name: Upload package artifacts
@@ -370,7 +443,7 @@ jobs:
 
   collect_assets:
     name: Verify Release Assets
-    needs: [validate, quality, build_core, build_plugins, build_packages, package_themes]
+    needs: [validate, quality, build_core, build_plugins, test_musl, build_packages, package_themes]
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Static core-only musl binaries are now published for Linux amd64 and arm64, with automatic musl selection in the shell installer and in-app upgrades.
+
 ### Fixed
 
 - GNU/Linux release binaries and plugins now target glibc 2.28 explicitly, preventing build-runner updates from breaking Raspberry Pi OS and other supported older distributions.
+- amd64 and arm64 Alpine packages now contain native static musl binaries instead of GNU binaries.
 
 ## [0.5.10] - 2026-08-15
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ sudo chown root:root lla
 sudo mv lla /usr/local/bin/lla
 ```
 
+Linux releases provide full-featured GNU binaries for amd64, arm64, and i686.
+Static musl binaries are also available as `lla-linux-amd64-musl` and
+`lla-linux-arm64-musl`; the install script selects them automatically on musl systems.
+Static musl builds include all core listing, formatting, search, archive, theme,
+configuration, and upgrade features, but do not support dynamically loaded plugins.
+The 32-bit x86 `.apk` remains a legacy GNU-based package.
+
 ### Upgrading
 
 Upgrade to the latest (or a specific) release without leaving the terminal:
@@ -681,6 +688,9 @@ respect_gitignore = true
 | Show only regular files, excluding dot files | `lla --files-only --no-dotfiles`  |
 
 ### Plugin Management
+
+> Dynamic plugins require a GNU/Linux or macOS build. Static musl builds return a
+> clear unsupported-build error for plugin installation, management, and actions.
 
 #### Installation
 

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,25 @@ detect_platform() {
             ;;
     esac
 
-    PLATFORM="lla-${OS}-${ARCH}"
+    LIBC=""
+    if [ "$OS" = "linux" ]; then
+        if { command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl; } \
+            || compgen -G '/lib/ld-musl-*.so.1' >/dev/null; then
+            LIBC="musl"
+            if [ "$ARCH" = "i686" ]; then
+                print_error "Static musl binaries are available only for amd64 and arm64"
+                exit 1
+            fi
+        else
+            LIBC="gnu"
+        fi
+    fi
+
+    if [ "$LIBC" = "musl" ]; then
+        PLATFORM="lla-${OS}-${ARCH}-musl"
+    else
+        PLATFORM="lla-${OS}-${ARCH}"
+    fi
 }
 
 get_latest_version() {
@@ -139,4 +157,6 @@ main() {
     install_binary
 }
 
-main
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["cli", "ls", "blazing-fast"]
 categories = ["command-line-utilities"]
 exclude = ["docs"]
 
+[features]
+default = ["dynamic-plugins"]
+dynamic-plugins = ["dep:libloading"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -23,7 +26,7 @@ colored.workspace = true
 rayon.workspace = true
 chrono.workspace = true
 chrono-humanize = "0.2"
-libloading.workspace = true
+libloading = { workspace = true, optional = true }
 serde_json.workspace = true
 walkdir.workspace = true
 tempfile.workspace = true

--- a/lla/src/commands/command_handler.rs
+++ b/lla/src/commands/command_handler.rs
@@ -8,7 +8,7 @@ use crate::commands::search::run_search;
 use crate::config::{self, Config, ShortcutCommand};
 use crate::error::{LlaError, Result};
 use crate::installer::PluginInstaller;
-use crate::plugin::PluginManager;
+use crate::plugin::{PluginManager, DYNAMIC_PLUGINS_AVAILABLE, DYNAMIC_PLUGINS_UNAVAILABLE};
 use crate::utils::color::ColorState;
 use clap_complete;
 use colored::*;
@@ -16,6 +16,28 @@ use dialoguer::{Input, Select};
 use lla_plugin_utils::ui::components::LlaDialoguerTheme;
 use std::fs::{self, create_dir_all, File};
 use std::io::Write;
+
+fn command_requires_dynamic_plugins(args: &Args) -> bool {
+    let plugin_command = matches!(
+        &args.command,
+        Some(
+            Command::Install(_)
+                | Command::Update(_)
+                | Command::ListPlugins
+                | Command::Use
+                | Command::PluginAction(_, _, _)
+                | Command::Clean
+                | Command::Shortcut(
+                    ShortcutAction::Add(_, _) | ShortcutAction::Create | ShortcutAction::Run(_, _),
+                )
+        )
+    );
+
+    plugin_command
+        || !args.enable_plugin.is_empty()
+        || !args.disable_plugin.is_empty()
+        || !args.search_pipelines.is_empty()
+}
 
 fn install_completion(
     shell: clap_complete::Shell,
@@ -141,6 +163,10 @@ pub fn handle_command(
     plugin_manager: &mut PluginManager,
     config_error: Option<LlaError>,
 ) -> Result<()> {
+    if !DYNAMIC_PLUGINS_AVAILABLE && command_requires_dynamic_plugins(args) {
+        return Err(LlaError::Plugin(DYNAMIC_PLUGINS_UNAVAILABLE.to_string()));
+    }
+
     let color_state = ColorState::new(args);
 
     match &args.command {

--- a/lla/src/config/mod.rs
+++ b/lla/src/config/mod.rs
@@ -787,6 +787,7 @@ editor = {}"#,
         })
     }
 
+    #[cfg(feature = "dynamic-plugins")]
     pub fn enable_plugin(&mut self, plugin_name: &str) -> Result<()> {
         self.ensure_plugins_dir().map_err(|e| {
             LlaError::Config(ConfigErrorKind::InvalidPath(format!(
@@ -801,6 +802,7 @@ editor = {}"#,
         Ok(())
     }
 
+    #[cfg(feature = "dynamic-plugins")]
     pub fn disable_plugin(&mut self, plugin_name: &str) -> Result<()> {
         self.enabled_plugins.retain(|name| name != plugin_name);
         self.save(&Self::get_config_path())?;
@@ -920,6 +922,7 @@ editor = {}"#,
             }
         }
 
+        #[cfg(feature = "dynamic-plugins")]
         for plugin in &self.enabled_plugins {
             let possible_names = [
                 format!("lib{}.dylib", plugin),
@@ -1769,5 +1772,29 @@ mod tests {
     fn long_date_format_rejects_empty_and_invalid_formats() {
         assert!(validate_long_date_format("formatters.long.date_format", "").is_err());
         assert!(validate_long_date_format("formatters.long.date_format", "%Q").is_err());
+    }
+
+    #[cfg(feature = "dynamic-plugins")]
+    #[test]
+    fn dynamic_build_rejects_missing_enabled_plugins() {
+        let config_dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.plugins_dir = config_dir.path().join("plugins");
+        fs::create_dir(&config.plugins_dir).unwrap();
+        config.enabled_plugins = vec!["missing_plugin".to_string()];
+
+        assert!(config.validate().is_err());
+    }
+
+    #[cfg(not(feature = "dynamic-plugins"))]
+    #[test]
+    fn static_build_ignores_enabled_plugins_during_validation() {
+        let config_dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.plugins_dir = config_dir.path().join("plugins");
+        fs::create_dir(&config.plugins_dir).unwrap();
+        config.enabled_plugins = vec!["missing_plugin".to_string()];
+
+        assert!(config.validate().is_ok());
     }
 }

--- a/lla/src/installer.rs
+++ b/lla/src/installer.rs
@@ -7,12 +7,14 @@ use console::Term;
 use dialoguer::MultiSelect;
 use flate2::read::GzDecoder;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+#[cfg(feature = "dynamic-plugins")]
 use libloading::Library;
-use lla_plugin_interface::{
-    proto::{plugin_message::Message, PluginMessage},
-    PluginApi, CURRENT_PLUGIN_API_VERSION,
-};
+#[cfg(feature = "dynamic-plugins")]
+use lla_plugin_interface::proto::{plugin_message::Message, PluginMessage};
+#[cfg(feature = "dynamic-plugins")]
+use lla_plugin_interface::{PluginApi, CURRENT_PLUGIN_API_VERSION};
 use lla_plugin_utils::ui::components::{BoxComponent, BoxStyle, LlaDialoguerTheme};
+#[cfg(feature = "dynamic-plugins")]
 use prost::Message as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -23,6 +25,7 @@ use std::io::{BufRead, Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+#[cfg(feature = "dynamic-plugins")]
 use std::ptr;
 use std::time::{Duration, Instant, SystemTime};
 use tar::Archive;
@@ -111,51 +114,70 @@ struct CliBinaryTarget {
     os_label: &'static str,
     arch_label: &'static str,
     display_os: &'static str,
+    musl: bool,
 }
 
 impl CliBinaryTarget {
     fn detect() -> Result<Self> {
         use std::env::consts::{ARCH, OS};
 
-        match (OS, ARCH) {
+        Self::for_platform(OS, ARCH, cfg!(target_env = "musl"))
+    }
+
+    fn for_platform(os: &str, arch: &str, musl: bool) -> Result<Self> {
+        if musl && os == "linux" && arch != "x86_64" && arch != "aarch64" {
+            return Err(LlaError::Other(format!(
+                "Unsupported platform for static musl CLI upgrades: {}-{} (supported: Linux on amd64 and arm64)",
+                os, arch
+            )));
+        }
+
+        match (os, arch) {
             ("macos", "x86_64") => Ok(Self {
                 os_label: "macos",
                 arch_label: "amd64",
                 display_os: "macOS",
+                musl: false,
             }),
             ("macos", "aarch64") => Ok(Self {
                 os_label: "macos",
                 arch_label: "arm64",
                 display_os: "macOS",
+                musl: false,
             }),
             ("linux", "x86_64") => Ok(Self {
                 os_label: "linux",
                 arch_label: "amd64",
                 display_os: "Linux",
+                musl,
             }),
             ("linux", "aarch64") => Ok(Self {
                 os_label: "linux",
                 arch_label: "arm64",
                 display_os: "Linux",
+                musl,
             }),
             ("linux", arch) if arch == "i686" || arch == "x86" => Ok(Self {
                 os_label: "linux",
                 arch_label: "i686",
                 display_os: "Linux",
+                musl: false,
             }),
             _ => Err(LlaError::Other(format!(
                 "Unsupported platform for CLI upgrades: {}-{} (supported: macOS/Linux on amd64, arm64, i686)",
-                OS, ARCH
+                os, arch
             ))),
         }
     }
 
     fn asset_name(&self) -> String {
-        format!("lla-{}-{}", self.os_label, self.arch_label)
+        let musl_suffix = if self.musl { "-musl" } else { "" };
+        format!("lla-{}-{}{}", self.os_label, self.arch_label, musl_suffix)
     }
 
     fn human_label(&self) -> String {
-        format!("{} ({})", self.display_os, self.arch_label)
+        let libc = if self.musl { " musl" } else { "" };
+        format!("{}{} ({})", self.display_os, libc, self.arch_label)
     }
 }
 
@@ -1315,6 +1337,7 @@ impl PluginInstaller {
         Ok(plugins)
     }
 
+    #[cfg(feature = "dynamic-plugins")]
     fn load_prebuilt_plugin(path: &Path) -> Result<PrebuiltPlugin> {
         unsafe {
             let library = Library::new(path).map_err(|err| {
@@ -1376,6 +1399,13 @@ impl PluginInstaller {
                 description,
             })
         }
+    }
+
+    #[cfg(not(feature = "dynamic-plugins"))]
+    fn load_prebuilt_plugin(_path: &Path) -> Result<PrebuiltPlugin> {
+        Err(LlaError::Plugin(
+            crate::plugin::DYNAMIC_PLUGINS_UNAVAILABLE.to_string(),
+        ))
     }
 
     fn select_prebuilt_plugins(&self, plugins: &[PrebuiltPlugin]) -> Result<Vec<PrebuiltPlugin>> {
@@ -1473,6 +1503,7 @@ impl PluginInstaller {
         self.update_plugin_metadata(&plugin.name, metadata)
     }
 
+    #[cfg(feature = "dynamic-plugins")]
     unsafe fn send_plugin_request(
         api: *mut PluginApi,
         message: PluginMessage,
@@ -1489,6 +1520,7 @@ impl PluginInstaller {
             .map_err(|err| LlaError::Plugin(format!("Failed to decode plugin response: {}", err)))
     }
 
+    #[cfg(feature = "dynamic-plugins")]
     unsafe fn query_plugin_string(
         api: *mut PluginApi,
         message: PluginMessage,
@@ -2692,5 +2724,49 @@ impl PluginInstaller {
         } else {
             Err(LlaError::Plugin("No plugins were updated".to_string()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CliBinaryTarget, PluginInstaller};
+    use std::io::Write;
+
+    #[test]
+    fn cli_asset_names_distinguish_gnu_and_musl() {
+        let gnu = CliBinaryTarget::for_platform("linux", "aarch64", false).unwrap();
+        let musl = CliBinaryTarget::for_platform("linux", "aarch64", true).unwrap();
+        let musl_amd64 = CliBinaryTarget::for_platform("linux", "x86_64", true).unwrap();
+
+        assert_eq!(gnu.asset_name(), "lla-linux-arm64");
+        assert_eq!(musl.asset_name(), "lla-linux-arm64-musl");
+        assert_eq!(musl_amd64.asset_name(), "lla-linux-amd64-musl");
+        assert_eq!(musl.human_label(), "Linux musl (arm64)");
+    }
+
+    #[test]
+    fn cli_asset_names_preserve_macos_and_i686_gnu() {
+        let macos = CliBinaryTarget::for_platform("macos", "aarch64", false).unwrap();
+        let i686 = CliBinaryTarget::for_platform("linux", "i686", false).unwrap();
+
+        assert_eq!(macos.asset_name(), "lla-macos-arm64");
+        assert_eq!(i686.asset_name(), "lla-linux-i686");
+    }
+
+    #[test]
+    fn static_musl_upgrade_rejects_i686() {
+        let error = CliBinaryTarget::for_platform("linux", "i686", true).unwrap_err();
+        assert!(error.to_string().contains("static musl CLI upgrades"));
+    }
+
+    #[test]
+    fn cli_checksum_calculation_remains_available_without_plugins() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"abc").unwrap();
+
+        assert_eq!(
+            PluginInstaller::calculate_sha256(file.path()).unwrap(),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
     }
 }

--- a/lla/src/main.rs
+++ b/lla/src/main.rs
@@ -5,6 +5,10 @@ mod filter;
 mod formatter;
 mod installer;
 mod lister;
+#[cfg(feature = "dynamic-plugins")]
+mod plugin;
+#[cfg(not(feature = "dynamic-plugins"))]
+#[path = "plugin/static.rs"]
 mod plugin;
 mod sorter;
 mod theme;
@@ -14,7 +18,7 @@ use commands::args::{Args, Command};
 use commands::command_handler::handle_command;
 use config::Config;
 use error::{LlaError, Result};
-use plugin::PluginManager;
+use plugin::{PluginManager, DYNAMIC_PLUGINS_AVAILABLE, DYNAMIC_PLUGINS_UNAVAILABLE};
 use std::collections::HashSet;
 use utils::color::set_theme;
 
@@ -34,6 +38,9 @@ fn run() -> Result<()> {
     theme::set_no_color(args.no_color);
 
     if let Some(Command::Clean) = args.command {
+        if !DYNAMIC_PLUGINS_AVAILABLE {
+            return Err(LlaError::Plugin(DYNAMIC_PLUGINS_UNAVAILABLE.to_string()));
+        }
         println!("🔄 Starting plugin cleaning...");
         let mut plugin_manager = PluginManager::new(config.clone());
         return plugin_manager.clean_plugins();

--- a/lla/src/plugin/mod.rs
+++ b/lla/src/plugin/mod.rs
@@ -16,6 +16,10 @@ use std::path::{Path, PathBuf};
 type DecorationCache = DashMap<(String, String), HashMap<String, String>>;
 static DECORATION_CACHE: Lazy<DecorationCache> = Lazy::new(DashMap::new);
 
+pub const DYNAMIC_PLUGINS_AVAILABLE: bool = true;
+pub const DYNAMIC_PLUGINS_UNAVAILABLE: &str =
+    "Dynamic plugins are unavailable in the static musl build; use a GNU build for plugin support.";
+
 fn normalize_plugin_format(format: &str) -> Option<&'static str> {
     match format {
         "default" => Some("default"),

--- a/lla/src/plugin/static.rs
+++ b/lla/src/plugin/static.rs
@@ -1,0 +1,72 @@
+use crate::config::Config;
+use crate::error::{LlaError, Result};
+use lla_plugin_interface::{proto, ActionInfo};
+use std::collections::HashSet;
+use std::path::Path;
+
+pub const DYNAMIC_PLUGINS_AVAILABLE: bool = false;
+pub const DYNAMIC_PLUGINS_UNAVAILABLE: &str =
+    "Dynamic plugins are unavailable in the static musl build; use a GNU build for plugin support.";
+
+pub struct PluginManager {
+    pub enabled_plugins: HashSet<String>,
+}
+
+impl PluginManager {
+    pub fn new(_config: Config) -> Self {
+        Self {
+            enabled_plugins: HashSet::new(),
+        }
+    }
+
+    pub fn perform_plugin_action(
+        &mut self,
+        _plugin_name: &str,
+        _action: &str,
+        _args: &[String],
+    ) -> Result<()> {
+        Err(unavailable())
+    }
+
+    pub fn list_plugins(&mut self) -> Vec<(String, String, String)> {
+        Vec::new()
+    }
+
+    pub fn get_plugin_actions(&mut self, _plugin_name: &str) -> Result<Vec<ActionInfo>> {
+        Err(unavailable())
+    }
+
+    pub fn discover_plugins<P: AsRef<Path>>(&mut self, _plugin_dir: P) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn discover_plugins_named<P: AsRef<Path>>(
+        &mut self,
+        _plugin_dir: P,
+        _names: &HashSet<String>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn enable_plugin(&mut self, _name: &str) -> Result<()> {
+        Err(unavailable())
+    }
+
+    pub fn disable_plugin(&mut self, _name: &str) -> Result<()> {
+        Err(unavailable())
+    }
+
+    pub fn decorate_entry(&mut self, _entry: &mut proto::DecoratedEntry, _format: &str) {}
+
+    pub fn format_fields(&mut self, _entry: &proto::DecoratedEntry, _format: &str) -> Vec<String> {
+        Vec::new()
+    }
+
+    pub fn clean_plugins(&mut self) -> Result<()> {
+        Err(unavailable())
+    }
+}
+
+fn unavailable() -> LlaError {
+    LlaError::Plugin(DYNAMIC_PLUGINS_UNAVAILABLE.to_string())
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,8 +3,10 @@ channel = "stable"
 components = ["rustfmt", "clippy"]
 targets = [
     "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
     "x86_64-apple-darwin",
     "aarch64-unknown-linux-gnu",
+    "aarch64-unknown-linux-musl",
     "aarch64-apple-darwin",
     "x86_64-pc-windows-msvc",
 ]


### PR DESCRIPTION
## Summary
- add default-enabled dynamic-plugins Cargo feature and core-only no-default build mode
- publish static amd64/arm64 musl binaries and use them for native APK packages
- detect musl in the shell installer and preserve musl asset selection during in-app upgrades
- keep plugin CLI surfaces visible with an explicit unsupported-build error
- validate static ELF linkage and run core smoke coverage in Alpine for both architectures

## Compatibility
- stacked on #167, which establishes the shared glibc 2.28 GNU baseline
- GNU and macOS artifact names and features remain unchanged
- i686 stays GNU-only, including its documented legacy APK

## Validation
- cargo test --workspace
- cargo test -p lla --no-default-features
- cargo fmt --all -- --check
- shell syntax and ShellCheck for changed executable scripts
- workflow YAML parse and git diff checks
- x86_64 and arm64 musl release builds verified with no ELF interpreter or NEEDED libraries
- Alpine 3.23 smoke suite passed on linux/amd64 and linux/arm64, including clean JSON/CSV with configured plugins and explicit plugin-command failures

Tracks #141. Close it only after the published amd64 and arm64 artifacts are verified on Alpine.