### PR TITLE
chore(release): prepare v0.5.11 portable Linux artifacts

### DIFF
--- a/.github/scripts/check_glibc_baseline.sh
+++ b/.github/scripts/check_glibc_baseline.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <maximum-glibc-version> <elf-file> [elf-file ...]" 1>&2
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+  exit 2
+fi
+
+baseline="$1"
+shift
+
+if ! [[ "$baseline" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "Invalid glibc baseline: $baseline" 1>&2
+  exit 2
+fi
+
+if ! command -v readelf >/dev/null 2>&1; then
+  echo "readelf is required to verify glibc compatibility" 1>&2
+  exit 1
+fi
+
+for artifact in "$@"; do
+  if [[ ! -f "$artifact" ]]; then
+    echo "ELF artifact not found: $artifact" 1>&2
+    exit 1
+  fi
+
+  highest="$({
+    readelf -W --version-info "$artifact" 2>/dev/null || true
+  } | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' | sed 's/^GLIBC_//' | sort -Vu | tail -n 1)"
+
+  if [[ -z "$highest" ]]; then
+    echo "No versioned glibc symbols found in $artifact"
+    continue
+  fi
+
+  oldest="$(printf '%s\n%s\n' "$baseline" "$highest" | sort -V | head -n 1)"
+  if [[ "$oldest" != "$highest" ]]; then
+    echo "$artifact requires GLIBC_$highest, newer than supported GLIBC_$baseline" 1>&2
+    exit 1
+  fi
+
+  echo "$artifact requires at most GLIBC_$highest (baseline: GLIBC_$baseline)"
+done

--- a/.github/scripts/release_helpers.sh
+++ b/.github/scripts/release_helpers.sh
@@ -152,7 +152,9 @@ write_expected_assets() {
 
   cat > "$output_file" <<EOF
 lla-linux-amd64
+lla-linux-amd64-musl
 lla-linux-arm64
+lla-linux-arm64-musl
 lla-linux-i686
 lla-macos-amd64
 lla-macos-arm64

--- a/.github/scripts/smoke_test_musl.sh
+++ b/.github/scripts/smoke_test_musl.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <lla-musl-binary>" 1>&2
+  exit 2
+fi
+
+binary="$(realpath "$1")"
+if [[ ! -x "$binary" ]]; then
+  echo "Musl binary is not executable: $binary" 1>&2
+  exit 1
+fi
+
+fixture_dir="$(mktemp -d)"
+trap 'rm -rf "$fixture_dir"' EXIT
+export HOME="$fixture_dir/home"
+mkdir -p "$HOME" "$fixture_dir/files/subdir"
+printf 'needle in a haystack\n' > "$fixture_dir/files/example.txt"
+printf 'another file\n' > "$fixture_dir/files/subdir/other.txt"
+tar -C "$fixture_dir/files" -czf "$fixture_dir/example.tar.gz" .
+
+"$binary" init --default >/dev/null
+config_file="$HOME/.config/lla/config.toml"
+sed 's/enabled_plugins = \[\]/enabled_plugins = ["missing_plugin"]/' \
+  "$config_file" >"$config_file.tmp"
+mv "$config_file.tmp" "$config_file"
+
+"$binary" "$fixture_dir/files" >/dev/null 2>"$fixture_dir/default.stderr"
+[[ ! -s "$fixture_dir/default.stderr" ]]
+"$binary" "$fixture_dir/files" --long >/dev/null 2>"$fixture_dir/long.stderr"
+[[ ! -s "$fixture_dir/long.stderr" ]]
+"$binary" "$fixture_dir/files" --table >/dev/null 2>"$fixture_dir/table.stderr"
+[[ ! -s "$fixture_dir/table.stderr" ]]
+"$binary" "$fixture_dir/files" --json >"$fixture_dir/listing.json" 2>"$fixture_dir/json.stderr"
+[[ ! -s "$fixture_dir/json.stderr" ]]
+grep -q 'example.txt' "$fixture_dir/listing.json"
+"$binary" "$fixture_dir/files" --csv >"$fixture_dir/listing.csv" 2>"$fixture_dir/csv.stderr"
+[[ ! -s "$fixture_dir/csv.stderr" ]]
+grep -q 'example.txt' "$fixture_dir/listing.csv"
+"$binary" "$fixture_dir/files" --filter '*.txt' >/dev/null
+"$binary" "$fixture_dir/files" --search needle >"$fixture_dir/search.txt"
+grep -q 'needle' "$fixture_dir/search.txt"
+"$binary" "$fixture_dir/example.tar.gz" --long >"$fixture_dir/archive.txt"
+grep -q 'example.txt' "$fixture_dir/archive.txt"
+"$binary" config show-effective >/dev/null
+"$binary" theme preview default >/dev/null
+
+plugin_output="$fixture_dir/plugin-error.txt"
+assert_plugin_unavailable() {
+  if "$binary" "$@" >"$plugin_output" 2>&1; then
+    echo "Static musl plugin command unexpectedly succeeded: $*" 1>&2
+    exit 1
+  fi
+  grep -qF \
+    'Dynamic plugins are unavailable in the static musl build; use a GNU build for plugin support.' \
+    "$plugin_output"
+}
+
+assert_plugin_unavailable install --prebuilt
+assert_plugin_unavailable list-plugins
+assert_plugin_unavailable "$fixture_dir/files" --enable-plugin missing_plugin
+
+echo "Static musl smoke tests passed"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,12 +41,15 @@ This repository uses regular CI for pull requests and a short two-action release
   - `cargo fmt --all -- --check`
   - `cargo test --workspace`
 - Builds and verifies all release assets before publishing:
-  - CLI binaries: `lla-linux-*`, `lla-macos-*`
+  - full-featured CLI binaries: `lla-linux-{amd64,arm64,i686}`, `lla-macos-*`
+  - core-only static musl binaries: `lla-linux-{amd64,arm64}-musl`
   - plugin archives: `plugins-*.tar.gz` and `plugins-*.zip`
   - Linux packages: `.deb`, `.rpm`, `.apk`, `.pkg.tar.zst`
   - `themes.zip`
   - final `SHA256SUMS`
 - GNU/Linux CLI and plugin artifacts are built with pinned Zig tooling and must not require glibc newer than 2.28.
+- Musl binaries must have no ELF interpreter or dynamic dependencies and pass core CLI smoke tests in amd64 and arm64 Alpine containers.
+- amd64 and arm64 APK packages contain static musl binaries; the i686 APK remains a legacy GNU-based package.
 - Publishes crates.io packages in dependency order:
   - `lla_plugin_interface`
   - `lla_plugin_utils`
@@ -73,3 +76,4 @@ This repository uses regular CI for pull requests and a short two-action release
 - `.github/scripts/release_helpers.sh` contains shared validation, expected asset, checksum, crates.io, and GitHub release helpers.
 - `scripts/build_plugins.sh` builds plugin dynamic libraries and produces both `.tar.gz` and `.zip` archives for each release target.
 - `.github/scripts/check_glibc_baseline.sh` enforces the documented GNU/Linux compatibility baseline.
+- `.github/scripts/smoke_test_musl.sh` exercises core features and the explicit plugin error inside Alpine.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,6 +9,7 @@ This repository uses regular CI for pull requests and a short two-action release
 
 - Triggered on pushes and pull requests to `main` when Rust sources, manifests, proto files, scripts, workflow files, package metadata, or toolchain files change.
 - Runs formatting, Clippy, tests, and release-mode build checks across Linux and macOS.
+- Builds GNU/Linux artifacts against an explicit glibc 2.28 baseline and rejects newer symbol requirements.
 - Clippy stays in regular CI; release publishing is gated by formatting, tests, validation, asset verification, and publish dry-runs.
 
 ## Prepare Release (`prepare-release.yml`)
@@ -45,6 +46,7 @@ This repository uses regular CI for pull requests and a short two-action release
   - Linux packages: `.deb`, `.rpm`, `.apk`, `.pkg.tar.zst`
   - `themes.zip`
   - final `SHA256SUMS`
+- GNU/Linux CLI and plugin artifacts are built with pinned Zig tooling and must not require glibc newer than 2.28.
 - Publishes crates.io packages in dependency order:
   - `lla_plugin_interface`
   - `lla_plugin_utils`
@@ -70,3 +72,4 @@ This repository uses regular CI for pull requests and a short two-action release
 - `.github/scripts/prepare_release.sh` updates release versions and changelog content for the generated PR.
 - `.github/scripts/release_helpers.sh` contains shared validation, expected asset, checksum, crates.io, and GitHub release helpers.
 - `scripts/build_plugins.sh` builds plugin dynamic libraries and produces both `.tar.gz` and `.zip` archives for each release target.
+- `.github/scripts/check_glibc_baseline.sh` enforces the documented GNU/Linux compatibility baseline.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_ZIGBUILD_VERSION: "0.23.0"
+  GLIBC_BASELINE: "2.28"
+  ZIG_VERSION: "0.15.2"
 
 jobs:
   test:
@@ -74,12 +77,10 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact_name: lla-linux-arm64
-            cross_compile: true
             pkg_formats: "deb,rpm,apk,pacman"
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
             artifact_name: lla-linux-i686
-            cross_compile: true
             pkg_formats: "deb,rpm,apk,pacman"
 
           # macOS builds
@@ -107,18 +108,13 @@ jobs:
           rustup target add ${{ matrix.target }} --toolchain stable
           rustup target list --installed
 
-      - name: Install cross-compilation tools
-        if: matrix.cross_compile && runner.os == 'Linux'
+      - name: Install pinned Zig build tools
+        if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-i686-linux-gnu
-          sudo apt-get install -y crossbuild-essential-arm64 crossbuild-essential-i386
-
-      - name: Set cross-compilation environment
-        if: matrix.cross_compile && runner.os == 'Linux'
-        run: |
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-          echo "CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=i686-linux-gnu-gcc" >> $GITHUB_ENV
+          python3 -m venv "$RUNNER_TEMP/zig"
+          "$RUNNER_TEMP/zig/bin/pip" install "ziglang==$ZIG_VERSION"
+          echo "$RUNNER_TEMP/zig/bin" >> "$GITHUB_PATH"
+          cargo install cargo-zigbuild --version "$CARGO_ZIGBUILD_VERSION" --locked
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -128,7 +124,18 @@ jobs:
       - name: Build release
         env:
           RUSTUP_TOOLCHAIN: stable
-        run: cargo build --release --target ${{ matrix.target }}
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            cargo zigbuild --release --target "${{ matrix.target }}.${GLIBC_BASELINE}"
+          else
+            cargo build --release --target "${{ matrix.target }}"
+          fi
+
+      - name: Verify glibc baseline
+        if: runner.os == 'Linux'
+        run: |
+          mapfile -t artifacts < <(find "target/${{ matrix.target }}/release" -maxdepth 1 -type f \( -name lla -o -name '*.so' \) | sort)
+          .github/scripts/check_glibc_baseline.sh "$GLIBC_BASELINE" "${artifacts[@]}"
 
       - name: Prepare binary (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,15 +73,28 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact_name: lla-linux-amd64
+            libc: gnu
             pkg_formats: "deb,rpm,apk,pacman"
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact_name: lla-linux-arm64
+            libc: gnu
             pkg_formats: "deb,rpm,apk,pacman"
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
             artifact_name: lla-linux-i686
+            libc: gnu
             pkg_formats: "deb,rpm,apk,pacman"
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            artifact_name: lla-linux-amd64-musl
+            libc: musl
+            pkg_formats: "apk"
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            artifact_name: lla-linux-arm64-musl
+            libc: musl
+            pkg_formats: "apk"
 
           # macOS builds
           - os: macos-latest
@@ -125,17 +138,33 @@ jobs:
         env:
           RUSTUP_TOOLCHAIN: stable
         run: |
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
+          if [[ "${{ matrix.libc }}" == "musl" ]]; then
+            cargo zigbuild --release --target "${{ matrix.target }}" -p lla --no-default-features
+          elif [[ "${{ runner.os }}" == "Linux" ]]; then
             cargo zigbuild --release --target "${{ matrix.target }}.${GLIBC_BASELINE}"
           else
             cargo build --release --target "${{ matrix.target }}"
           fi
 
       - name: Verify glibc baseline
-        if: runner.os == 'Linux'
+        if: matrix.libc == 'gnu'
         run: |
           mapfile -t artifacts < <(find "target/${{ matrix.target }}/release" -maxdepth 1 -type f \( -name lla -o -name '*.so' \) | sort)
           .github/scripts/check_glibc_baseline.sh "$GLIBC_BASELINE" "${artifacts[@]}"
+
+      - name: Verify static musl linkage
+        if: matrix.libc == 'musl'
+        run: |
+          binary="target/${{ matrix.target }}/release/lla"
+          file "$binary" | grep -q "statically linked"
+          if readelf -W -l "$binary" | grep -q 'INTERP'; then
+            echo "Static musl binary unexpectedly contains an ELF interpreter" 1>&2
+            exit 1
+          fi
+          if readelf -W -d "$binary" 2>/dev/null | grep -q 'NEEDED'; then
+            echo "Static musl binary unexpectedly contains dynamic dependencies" 1>&2
+            exit 1
+          fi
 
       - name: Prepare binary (Unix)
         if: runner.os != 'Windows'
@@ -147,3 +176,35 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_name }}
+
+  musl_smoke:
+    name: Musl Smoke (${{ matrix.arch }})
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            artifact_name: lla-linux-amd64-musl
+          - arch: arm64
+            platform: linux/arm64
+            artifact_name: lla-linux-arm64-musl
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - name: Download musl artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: musl-artifact
+
+      - name: Run Alpine smoke tests
+        run: |
+          chmod +x "musl-artifact/${{ matrix.artifact_name }}"
+          docker run --rm --platform "${{ matrix.platform }}" \
+            -v "$PWD:/work" -w /work alpine:3.23 \
+            sh -c 'apk add --no-cache bash ripgrep >/dev/null && .github/scripts/smoke_test_musl.sh "musl-artifact/${{ matrix.artifact_name }}"'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_ZIGBUILD_VERSION: "0.23.0"
+  GLIBC_BASELINE: "2.28"
+  ZIG_VERSION: "0.15.2"
 
 jobs:
   validate:
@@ -134,11 +137,9 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact_name: lla-linux-arm64
-            cross_compile: true
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
             artifact_name: lla-linux-i686
-            cross_compile: true
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact_name: lla-macos-amd64
@@ -161,17 +162,13 @@ jobs:
           components: rustfmt, clippy
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools
-        if: matrix.cross_compile && runner.os == 'Linux'
+      - name: Install pinned Zig build tools
+        if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-i686-linux-gnu crossbuild-essential-arm64 crossbuild-essential-i386
-
-      - name: Set cross-compilation environment
-        if: matrix.cross_compile && runner.os == 'Linux'
-        run: |
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=i686-linux-gnu-gcc" >> "$GITHUB_ENV"
+          python3 -m venv "$RUNNER_TEMP/zig"
+          "$RUNNER_TEMP/zig/bin/pip" install "ziglang==$ZIG_VERSION"
+          echo "$RUNNER_TEMP/zig/bin" >> "$GITHUB_PATH"
+          cargo install cargo-zigbuild --version "$CARGO_ZIGBUILD_VERSION" --locked
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -179,7 +176,16 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }} -p lla
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            cargo zigbuild --release --target "${{ matrix.target }}.${GLIBC_BASELINE}" -p lla
+          else
+            cargo build --release --target "${{ matrix.target }}" -p lla
+          fi
+
+      - name: Verify glibc baseline
+        if: runner.os == 'Linux'
+        run: .github/scripts/check_glibc_baseline.sh "$GLIBC_BASELINE" "target/${{ matrix.target }}/release/lla"
 
       - name: Prepare binary artifact
         run: cp "target/${{ matrix.target }}/release/lla" "${{ matrix.artifact_name }}"
@@ -198,15 +204,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             os_label: linux
             arch_label: amd64
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             os_label: linux
             arch_label: arm64
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: i686-unknown-linux-gnu
             os_label: linux
             arch_label: i686
@@ -231,19 +237,27 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Install cross toolchain
-        if: runner.os == 'Linux' && (contains(matrix.target, 'aarch64') || contains(matrix.target, 'i686'))
+      - name: Install pinned Zig build tools
+        if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-i686-linux-gnu crossbuild-essential-arm64 crossbuild-essential-i386
-          if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]]; then
-            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-          elif [[ "${{ matrix.target }}" == "i686-unknown-linux-gnu" ]]; then
-            echo "CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=i686-linux-gnu-gcc" >> "$GITHUB_ENV"
-          fi
+          python3 -m venv "$RUNNER_TEMP/zig"
+          "$RUNNER_TEMP/zig/bin/pip" install "ziglang==$ZIG_VERSION"
+          echo "$RUNNER_TEMP/zig/bin" >> "$GITHUB_PATH"
+          cargo install cargo-zigbuild --version "$CARGO_ZIGBUILD_VERSION" --locked
 
       - name: Build plugin archives
-        run: ./scripts/build_plugins.sh --target ${{ matrix.target }}
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            ./scripts/build_plugins.sh --target "${{ matrix.target }}" --glibc-version "$GLIBC_BASELINE"
+          else
+            ./scripts/build_plugins.sh --target "${{ matrix.target }}"
+          fi
+
+      - name: Verify glibc baseline
+        if: runner.os == 'Linux'
+        run: |
+          mapfile -t plugins < <(find "dist/plugins-${{ matrix.os_label }}-${{ matrix.arch_label }}" -maxdepth 1 -type f -name '*.so' | sort)
+          .github/scripts/check_glibc_baseline.sh "$GLIBC_BASELINE" "${plugins[@]}"
 
       - name: Upload plugin artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,12 +134,23 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact_name: lla-linux-amd64
+            libc: gnu
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact_name: lla-linux-arm64
+            libc: gnu
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
             artifact_name: lla-linux-i686
+            libc: gnu
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            artifact_name: lla-linux-amd64-musl
+            libc: musl
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            artifact_name: lla-linux-arm64-musl
+            libc: musl
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact_name: lla-macos-amd64
@@ -177,15 +188,31 @@ jobs:
 
       - name: Build release binary
         run: |
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
+          if [[ "${{ matrix.libc }}" == "musl" ]]; then
+            cargo zigbuild --release --target "${{ matrix.target }}" -p lla --no-default-features
+          elif [[ "${{ runner.os }}" == "Linux" ]]; then
             cargo zigbuild --release --target "${{ matrix.target }}.${GLIBC_BASELINE}" -p lla
           else
             cargo build --release --target "${{ matrix.target }}" -p lla
           fi
 
       - name: Verify glibc baseline
-        if: runner.os == 'Linux'
+        if: matrix.libc == 'gnu'
         run: .github/scripts/check_glibc_baseline.sh "$GLIBC_BASELINE" "target/${{ matrix.target }}/release/lla"
+
+      - name: Verify static musl linkage
+        if: matrix.libc == 'musl'
+        run: |
+          binary="target/${{ matrix.target }}/release/lla"
+          file "$binary" | grep -q "statically linked"
+          if readelf -W -l "$binary" | grep -q 'INTERP'; then
+            echo "Static musl binary unexpectedly contains an ELF interpreter" 1>&2
+            exit 1
+          fi
+          if readelf -W -d "$binary" 2>/dev/null | grep -q 'NEEDED'; then
+            echo "Static musl binary unexpectedly contains dynamic dependencies" 1>&2
+            exit 1
+          fi
 
       - name: Prepare binary artifact
         run: cp "target/${{ matrix.target }}/release/lla" "${{ matrix.artifact_name }}"
@@ -267,6 +294,40 @@ jobs:
             dist/plugins-${{ matrix.os_label }}-${{ matrix.arch_label }}.tar.gz
             dist/plugins-${{ matrix.os_label }}-${{ matrix.arch_label }}.zip
 
+  test_musl:
+    name: Test Musl (${{ matrix.arch }})
+    needs: [validate, build_core]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            artifact_name: lla-linux-amd64-musl
+          - arch: arm64
+            platform: linux/arm64
+            artifact_name: lla-linux-arm64-musl
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.release_tag }}
+
+      - uses: docker/setup-qemu-action@v3
+
+      - name: Download musl artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: core-${{ matrix.artifact_name }}
+          path: musl-artifact
+
+      - name: Run Alpine smoke tests
+        run: |
+          chmod +x "musl-artifact/${{ matrix.artifact_name }}"
+          docker run --rm --platform "${{ matrix.platform }}" \
+            -v "$PWD:/work" -w /work alpine:3.23 \
+            sh -c 'apk add --no-cache bash ripgrep >/dev/null && .github/scripts/smoke_test_musl.sh "musl-artifact/${{ matrix.artifact_name }}"'
+
   build_packages:
     name: Build OS Packages
     needs: [validate, build_core]
@@ -297,31 +358,34 @@ jobs:
           set -euo pipefail
           mkdir -p packages
 
-          for binary in core_binaries/lla-linux-*; do
+          for binary in core_binaries/lla-linux-amd64 core_binaries/lla-linux-arm64 core_binaries/lla-linux-i686; do
             [ -f "$binary" ] || continue
             artifact_name="$(basename "$binary")"
 
             case "$artifact_name" in
-              *amd64)
+              lla-linux-amd64)
                 ARCH="amd64"
                 DEB_ARCH="amd64"
                 RPM_ARCH="x86_64"
                 APK_ARCH="x86_64"
                 PACMAN_ARCH="x86_64"
+                APK_BINARY="core_binaries/lla-linux-amd64-musl"
                 ;;
-              *arm64)
+              lla-linux-arm64)
                 ARCH="arm64"
                 DEB_ARCH="arm64"
                 RPM_ARCH="aarch64"
                 APK_ARCH="aarch64"
                 PACMAN_ARCH="aarch64"
+                APK_BINARY="core_binaries/lla-linux-arm64-musl"
                 ;;
-              *i686)
+              lla-linux-i686)
                 ARCH="386"
                 DEB_ARCH="i386"
                 RPM_ARCH="i686"
                 APK_ARCH="x86"
                 PACMAN_ARCH="i686"
+                APK_BINARY="$binary"
                 ;;
               *)
                 echo "Skipping unsupported artifact $artifact_name"
@@ -338,10 +402,19 @@ jobs:
 
             nfpm pkg --config "$tmp_config" --packager deb --target "packages/lla_${VERSION}_${DEB_ARCH}.deb"
             nfpm pkg --config "$tmp_config" --packager rpm --target "packages/lla-${VERSION}-1.${RPM_ARCH}.rpm"
-            nfpm pkg --config "$tmp_config" --packager apk --target "packages/lla-${VERSION}-r0.${APK_ARCH}.apk"
             nfpm pkg --config "$tmp_config" --packager archlinux --target "packages/lla-${VERSION}-1-${PACMAN_ARCH}.pkg.tar.zst"
 
             rm -f "$tmp_config"
+
+            if [[ ! -f "$APK_BINARY" ]]; then
+              echo "Missing APK binary: $APK_BINARY" 1>&2
+              exit 1
+            fi
+            export BINARY_PATH="$APK_BINARY"
+            apk_config="$(mktemp)"
+            envsubst < nfpm.yaml > "$apk_config"
+            nfpm pkg --config "$apk_config" --packager apk --target "packages/lla-${VERSION}-r0.${APK_ARCH}.apk"
+            rm -f "$apk_config"
           done
 
       - name: Upload package artifacts
@@ -370,7 +443,7 @@ jobs:
 
   collect_assets:
     name: Verify Release Assets
-    needs: [validate, quality, build_core, build_plugins, build_packages, package_themes]
+    needs: [validate, quality, build_core, build_plugins, test_musl, build_packages, package_themes]
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- GNU/Linux release binaries and plugins now target glibc 2.28 explicitly, preventing build-runner updates from breaking Raspberry Pi OS and other supported older distributions.
+
 ## [0.5.10] - 2026-08-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.11] - 2026-08-15
+
 ### Added
 
 - Static core-only musl binaries are now published for Linux amd64 and arm64, with automatic musl selection in the shell installer and in-app upgrades.
@@ -15,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - GNU/Linux release binaries and plugins now target glibc 2.28 explicitly, preventing build-runner updates from breaking Raspberry Pi OS and other supported older distributions.
 - amd64 and arm64 Alpine packages now contain native static musl binaries instead of GNU binaries.
+
 
 ## [0.5.10] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Static core-only musl binaries are now published for Linux amd64 and arm64, with automatic musl selection in the shell installer and in-app upgrades.
+
 ### Fixed
 
 - GNU/Linux release binaries and plugins now target glibc 2.28 explicitly, preventing build-runner updates from breaking Raspberry Pi OS and other supported older distributions.
+- amd64 and arm64 Alpine packages now contain native static musl binaries instead of GNU binaries.
 
 ## [0.5.10] - 2026-08-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "brew"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "chrono",
@@ -220,7 +220,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "categorizer"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "colored",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "code_complexity"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "colored",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "code_snippet_extractor"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "arboard",
  "base64 0.21.7",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "dirs_meta"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "colored",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "duplicate_file_detector"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "colored",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "file_copier"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "colored",
  "dialoguer",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "file_hash"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "colored",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "file_meta"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "chrono",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "file_mover"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "colored",
  "dialoguer",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "file_organizer"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "chrono",
  "colored",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "file_remover"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "colored",
  "dialoguer",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "file_tagger"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "colored",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "flush_dns"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "chrono",
@@ -860,7 +860,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "folder_cleaner"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "chrono",
  "colored",
@@ -1011,7 +1011,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git_status"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "colored",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "google_meet"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "arboard",
  "bytes",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "google_search"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "arboard",
  "bytes",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "hackernews"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "arboard",
  "bytes",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "jwt"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "keyword_search"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "arboard",
  "bytes",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "kill_process"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "colored",
  "console",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "last_git_commit"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "colored",
@@ -1592,7 +1592,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lla"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "atty",
  "chrono",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_interface"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "prost",
  "prost-build",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_utils"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "chrono",
@@ -1738,7 +1738,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "npm"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "arboard",
  "bytes",
@@ -2285,7 +2285,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remove_paywall"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "arboard",
  "bytes",
@@ -2611,7 +2611,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sizeviz"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "colored",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "speed_test"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "bytes",
  "chrono",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "youtube"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "arboard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["lla", "lla_plugin_interface", "lla_plugin_utils", "plugins/*"]
 [workspace.package]
 description = "Blazing Fast and highly customizable ls Replacement with Superpowers"
 authors = ["Achaq <hi@achaq.dev>"]
-version = "0.5.10"
+version = "0.5.11"
 categories = ["utilities", "file-system", "cli", "file-management"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ sudo chown root:root lla
 sudo mv lla /usr/local/bin/lla
 ```
 
+Linux releases provide full-featured GNU binaries for amd64, arm64, and i686.
+Static musl binaries are also available as `lla-linux-amd64-musl` and
+`lla-linux-arm64-musl`; the install script selects them automatically on musl systems.
+Static musl builds include all core listing, formatting, search, archive, theme,
+configuration, and upgrade features, but do not support dynamically loaded plugins.
+The 32-bit x86 `.apk` remains a legacy GNU-based package.
+
 ### Upgrading
 
 Upgrade to the latest (or a specific) release without leaving the terminal:
@@ -681,6 +688,9 @@ respect_gitignore = true
 | Show only regular files, excluding dot files | `lla --files-only --no-dotfiles`  |
 
 ### Plugin Management
+
+> Dynamic plugins require a GNU/Linux or macOS build. Static musl builds return a
+> clear unsupported-build error for plugin installation, management, and actions.
 
 #### Installation
 

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,25 @@ detect_platform() {
             ;;
     esac
 
-    PLATFORM="lla-${OS}-${ARCH}"
+    LIBC=""
+    if [ "$OS" = "linux" ]; then
+        if { command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl; } \
+            || compgen -G '/lib/ld-musl-*.so.1' >/dev/null; then
+            LIBC="musl"
+            if [ "$ARCH" = "i686" ]; then
+                print_error "Static musl binaries are available only for amd64 and arm64"
+                exit 1
+            fi
+        else
+            LIBC="gnu"
+        fi
+    fi
+
+    if [ "$LIBC" = "musl" ]; then
+        PLATFORM="lla-${OS}-${ARCH}-musl"
+    else
+        PLATFORM="lla-${OS}-${ARCH}"
+    fi
 }
 
 get_latest_version() {
@@ -139,4 +157,6 @@ main() {
     install_binary
 }
 
-main
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["cli", "ls", "blazing-fast"]
 categories = ["command-line-utilities"]
 exclude = ["docs"]
 
+[features]
+default = ["dynamic-plugins"]
+dynamic-plugins = ["dep:libloading"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -23,7 +26,7 @@ colored.workspace = true
 rayon.workspace = true
 chrono.workspace = true
 chrono-humanize = "0.2"
-libloading.workspace = true
+libloading = { workspace = true, optional = true }
 serde_json.workspace = true
 walkdir.workspace = true
 tempfile.workspace = true

--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -32,8 +32,8 @@ walkdir.workspace = true
 tempfile.workspace = true
 users.workspace = true
 parking_lot.workspace = true
-lla_plugin_interface = { version = "0.5.10", path = "../lla_plugin_interface" }
-lla_plugin_utils = { version = "0.5.10", path = "../lla_plugin_utils" }
+lla_plugin_interface = { version = "0.5.11", path = "../lla_plugin_interface" }
+lla_plugin_utils = { version = "0.5.11", path = "../lla_plugin_utils" }
 once_cell.workspace = true
 dashmap.workspace = true
 unicode-width.workspace = true

--- a/lla/src/commands/command_handler.rs
+++ b/lla/src/commands/command_handler.rs
@@ -8,7 +8,7 @@ use crate::commands::search::run_search;
 use crate::config::{self, Config, ShortcutCommand};
 use crate::error::{LlaError, Result};
 use crate::installer::PluginInstaller;
-use crate::plugin::PluginManager;
+use crate::plugin::{PluginManager, DYNAMIC_PLUGINS_AVAILABLE, DYNAMIC_PLUGINS_UNAVAILABLE};
 use crate::utils::color::ColorState;
 use clap_complete;
 use colored::*;
@@ -16,6 +16,28 @@ use dialoguer::{Input, Select};
 use lla_plugin_utils::ui::components::LlaDialoguerTheme;
 use std::fs::{self, create_dir_all, File};
 use std::io::Write;
+
+fn command_requires_dynamic_plugins(args: &Args) -> bool {
+    let plugin_command = matches!(
+        &args.command,
+        Some(
+            Command::Install(_)
+                | Command::Update(_)
+                | Command::ListPlugins
+                | Command::Use
+                | Command::PluginAction(_, _, _)
+                | Command::Clean
+                | Command::Shortcut(
+                    ShortcutAction::Add(_, _) | ShortcutAction::Create | ShortcutAction::Run(_, _),
+                )
+        )
+    );
+
+    plugin_command
+        || !args.enable_plugin.is_empty()
+        || !args.disable_plugin.is_empty()
+        || !args.search_pipelines.is_empty()
+}
 
 fn install_completion(
     shell: clap_complete::Shell,
@@ -141,6 +163,10 @@ pub fn handle_command(
     plugin_manager: &mut PluginManager,
     config_error: Option<LlaError>,
 ) -> Result<()> {
+    if !DYNAMIC_PLUGINS_AVAILABLE && command_requires_dynamic_plugins(args) {
+        return Err(LlaError::Plugin(DYNAMIC_PLUGINS_UNAVAILABLE.to_string()));
+    }
+
     let color_state = ColorState::new(args);
 
     match &args.command {

--- a/lla/src/config/mod.rs
+++ b/lla/src/config/mod.rs
@@ -787,6 +787,7 @@ editor = {}"#,
         })
     }
 
+    #[cfg(feature = "dynamic-plugins")]
     pub fn enable_plugin(&mut self, plugin_name: &str) -> Result<()> {
         self.ensure_plugins_dir().map_err(|e| {
             LlaError::Config(ConfigErrorKind::InvalidPath(format!(
@@ -801,6 +802,7 @@ editor = {}"#,
         Ok(())
     }
 
+    #[cfg(feature = "dynamic-plugins")]
     pub fn disable_plugin(&mut self, plugin_name: &str) -> Result<()> {
         self.enabled_plugins.retain(|name| name != plugin_name);
         self.save(&Self::get_config_path())?;
@@ -920,6 +922,7 @@ editor = {}"#,
             }
         }
 
+        #[cfg(feature = "dynamic-plugins")]
         for plugin in &self.enabled_plugins {
             let possible_names = [
                 format!("lib{}.dylib", plugin),
@@ -1769,5 +1772,29 @@ mod tests {
     fn long_date_format_rejects_empty_and_invalid_formats() {
         assert!(validate_long_date_format("formatters.long.date_format", "").is_err());
         assert!(validate_long_date_format("formatters.long.date_format", "%Q").is_err());
+    }
+
+    #[cfg(feature = "dynamic-plugins")]
+    #[test]
+    fn dynamic_build_rejects_missing_enabled_plugins() {
+        let config_dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.plugins_dir = config_dir.path().join("plugins");
+        fs::create_dir(&config.plugins_dir).unwrap();
+        config.enabled_plugins = vec!["missing_plugin".to_string()];
+
+        assert!(config.validate().is_err());
+    }
+
+    #[cfg(not(feature = "dynamic-plugins"))]
+    #[test]
+    fn static_build_ignores_enabled_plugins_during_validation() {
+        let config_dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.plugins_dir = config_dir.path().join("plugins");
+        fs::create_dir(&config.plugins_dir).unwrap();
+        config.enabled_plugins = vec!["missing_plugin".to_string()];
+
+        assert!(config.validate().is_ok());
     }
 }

--- a/lla/src/installer.rs
+++ b/lla/src/installer.rs
@@ -7,12 +7,14 @@ use console::Term;
 use dialoguer::MultiSelect;
 use flate2::read::GzDecoder;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+#[cfg(feature = "dynamic-plugins")]
 use libloading::Library;
-use lla_plugin_interface::{
-    proto::{plugin_message::Message, PluginMessage},
-    PluginApi, CURRENT_PLUGIN_API_VERSION,
-};
+#[cfg(feature = "dynamic-plugins")]
+use lla_plugin_interface::proto::{plugin_message::Message, PluginMessage};
+#[cfg(feature = "dynamic-plugins")]
+use lla_plugin_interface::{PluginApi, CURRENT_PLUGIN_API_VERSION};
 use lla_plugin_utils::ui::components::{BoxComponent, BoxStyle, LlaDialoguerTheme};
+#[cfg(feature = "dynamic-plugins")]
 use prost::Message as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -23,6 +25,7 @@ use std::io::{BufRead, Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+#[cfg(feature = "dynamic-plugins")]
 use std::ptr;
 use std::time::{Duration, Instant, SystemTime};
 use tar::Archive;
@@ -111,51 +114,70 @@ struct CliBinaryTarget {
     os_label: &'static str,
     arch_label: &'static str,
     display_os: &'static str,
+    musl: bool,
 }
 
 impl CliBinaryTarget {
     fn detect() -> Result<Self> {
         use std::env::consts::{ARCH, OS};
 
-        match (OS, ARCH) {
+        Self::for_platform(OS, ARCH, cfg!(target_env = "musl"))
+    }
+
+    fn for_platform(os: &str, arch: &str, musl: bool) -> Result<Self> {
+        if musl && os == "linux" && arch != "x86_64" && arch != "aarch64" {
+            return Err(LlaError::Other(format!(
+                "Unsupported platform for static musl CLI upgrades: {}-{} (supported: Linux on amd64 and arm64)",
+                os, arch
+            )));
+        }
+
+        match (os, arch) {
             ("macos", "x86_64") => Ok(Self {
                 os_label: "macos",
                 arch_label: "amd64",
                 display_os: "macOS",
+                musl: false,
             }),
             ("macos", "aarch64") => Ok(Self {
                 os_label: "macos",
                 arch_label: "arm64",
                 display_os: "macOS",
+                musl: false,
             }),
             ("linux", "x86_64") => Ok(Self {
                 os_label: "linux",
                 arch_label: "amd64",
                 display_os: "Linux",
+                musl,
             }),
             ("linux", "aarch64") => Ok(Self {
                 os_label: "linux",
                 arch_label: "arm64",
                 display_os: "Linux",
+                musl,
             }),
             ("linux", arch) if arch == "i686" || arch == "x86" => Ok(Self {
                 os_label: "linux",
                 arch_label: "i686",
                 display_os: "Linux",
+                musl: false,
             }),
             _ => Err(LlaError::Other(format!(
                 "Unsupported platform for CLI upgrades: {}-{} (supported: macOS/Linux on amd64, arm64, i686)",
-                OS, ARCH
+                os, arch
             ))),
         }
     }
 
     fn asset_name(&self) -> String {
-        format!("lla-{}-{}", self.os_label, self.arch_label)
+        let musl_suffix = if self.musl { "-musl" } else { "" };
+        format!("lla-{}-{}{}", self.os_label, self.arch_label, musl_suffix)
     }
 
     fn human_label(&self) -> String {
-        format!("{} ({})", self.display_os, self.arch_label)
+        let libc = if self.musl { " musl" } else { "" };
+        format!("{}{} ({})", self.display_os, libc, self.arch_label)
     }
 }
 
@@ -1315,6 +1337,7 @@ impl PluginInstaller {
         Ok(plugins)
     }
 
+    #[cfg(feature = "dynamic-plugins")]
     fn load_prebuilt_plugin(path: &Path) -> Result<PrebuiltPlugin> {
         unsafe {
             let library = Library::new(path).map_err(|err| {
@@ -1376,6 +1399,13 @@ impl PluginInstaller {
                 description,
             })
         }
+    }
+
+    #[cfg(not(feature = "dynamic-plugins"))]
+    fn load_prebuilt_plugin(_path: &Path) -> Result<PrebuiltPlugin> {
+        Err(LlaError::Plugin(
+            crate::plugin::DYNAMIC_PLUGINS_UNAVAILABLE.to_string(),
+        ))
     }
 
     fn select_prebuilt_plugins(&self, plugins: &[PrebuiltPlugin]) -> Result<Vec<PrebuiltPlugin>> {
@@ -1473,6 +1503,7 @@ impl PluginInstaller {
         self.update_plugin_metadata(&plugin.name, metadata)
     }
 
+    #[cfg(feature = "dynamic-plugins")]
     unsafe fn send_plugin_request(
         api: *mut PluginApi,
         message: PluginMessage,
@@ -1489,6 +1520,7 @@ impl PluginInstaller {
             .map_err(|err| LlaError::Plugin(format!("Failed to decode plugin response: {}", err)))
     }
 
+    #[cfg(feature = "dynamic-plugins")]
     unsafe fn query_plugin_string(
         api: *mut PluginApi,
         message: PluginMessage,
@@ -2692,5 +2724,49 @@ impl PluginInstaller {
         } else {
             Err(LlaError::Plugin("No plugins were updated".to_string()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CliBinaryTarget, PluginInstaller};
+    use std::io::Write;
+
+    #[test]
+    fn cli_asset_names_distinguish_gnu_and_musl() {
+        let gnu = CliBinaryTarget::for_platform("linux", "aarch64", false).unwrap();
+        let musl = CliBinaryTarget::for_platform("linux", "aarch64", true).unwrap();
+        let musl_amd64 = CliBinaryTarget::for_platform("linux", "x86_64", true).unwrap();
+
+        assert_eq!(gnu.asset_name(), "lla-linux-arm64");
+        assert_eq!(musl.asset_name(), "lla-linux-arm64-musl");
+        assert_eq!(musl_amd64.asset_name(), "lla-linux-amd64-musl");
+        assert_eq!(musl.human_label(), "Linux musl (arm64)");
+    }
+
+    #[test]
+    fn cli_asset_names_preserve_macos_and_i686_gnu() {
+        let macos = CliBinaryTarget::for_platform("macos", "aarch64", false).unwrap();
+        let i686 = CliBinaryTarget::for_platform("linux", "i686", false).unwrap();
+
+        assert_eq!(macos.asset_name(), "lla-macos-arm64");
+        assert_eq!(i686.asset_name(), "lla-linux-i686");
+    }
+
+    #[test]
+    fn static_musl_upgrade_rejects_i686() {
+        let error = CliBinaryTarget::for_platform("linux", "i686", true).unwrap_err();
+        assert!(error.to_string().contains("static musl CLI upgrades"));
+    }
+
+    #[test]
+    fn cli_checksum_calculation_remains_available_without_plugins() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"abc").unwrap();
+
+        assert_eq!(
+            PluginInstaller::calculate_sha256(file.path()).unwrap(),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
     }
 }

--- a/lla/src/main.rs
+++ b/lla/src/main.rs
@@ -5,6 +5,10 @@ mod filter;
 mod formatter;
 mod installer;
 mod lister;
+#[cfg(feature = "dynamic-plugins")]
+mod plugin;
+#[cfg(not(feature = "dynamic-plugins"))]
+#[path = "plugin/static.rs"]
 mod plugin;
 mod sorter;
 mod theme;
@@ -14,7 +18,7 @@ use commands::args::{Args, Command};
 use commands::command_handler::handle_command;
 use config::Config;
 use error::{LlaError, Result};
-use plugin::PluginManager;
+use plugin::{PluginManager, DYNAMIC_PLUGINS_AVAILABLE, DYNAMIC_PLUGINS_UNAVAILABLE};
 use std::collections::HashSet;
 use utils::color::set_theme;
 
@@ -34,6 +38,9 @@ fn run() -> Result<()> {
     theme::set_no_color(args.no_color);
 
     if let Some(Command::Clean) = args.command {
+        if !DYNAMIC_PLUGINS_AVAILABLE {
+            return Err(LlaError::Plugin(DYNAMIC_PLUGINS_UNAVAILABLE.to_string()));
+        }
         println!("🔄 Starting plugin cleaning...");
         let mut plugin_manager = PluginManager::new(config.clone());
         return plugin_manager.clean_plugins();

--- a/lla/src/plugin/mod.rs
+++ b/lla/src/plugin/mod.rs
@@ -16,6 +16,10 @@ use std::path::{Path, PathBuf};
 type DecorationCache = DashMap<(String, String), HashMap<String, String>>;
 static DECORATION_CACHE: Lazy<DecorationCache> = Lazy::new(DashMap::new);
 
+pub const DYNAMIC_PLUGINS_AVAILABLE: bool = true;
+pub const DYNAMIC_PLUGINS_UNAVAILABLE: &str =
+    "Dynamic plugins are unavailable in the static musl build; use a GNU build for plugin support.";
+
 fn normalize_plugin_format(format: &str) -> Option<&'static str> {
     match format {
         "default" => Some("default"),

--- a/lla/src/plugin/static.rs
+++ b/lla/src/plugin/static.rs
@@ -1,0 +1,72 @@
+use crate::config::Config;
+use crate::error::{LlaError, Result};
+use lla_plugin_interface::{proto, ActionInfo};
+use std::collections::HashSet;
+use std::path::Path;
+
+pub const DYNAMIC_PLUGINS_AVAILABLE: bool = false;
+pub const DYNAMIC_PLUGINS_UNAVAILABLE: &str =
+    "Dynamic plugins are unavailable in the static musl build; use a GNU build for plugin support.";
+
+pub struct PluginManager {
+    pub enabled_plugins: HashSet<String>,
+}
+
+impl PluginManager {
+    pub fn new(_config: Config) -> Self {
+        Self {
+            enabled_plugins: HashSet::new(),
+        }
+    }
+
+    pub fn perform_plugin_action(
+        &mut self,
+        _plugin_name: &str,
+        _action: &str,
+        _args: &[String],
+    ) -> Result<()> {
+        Err(unavailable())
+    }
+
+    pub fn list_plugins(&mut self) -> Vec<(String, String, String)> {
+        Vec::new()
+    }
+
+    pub fn get_plugin_actions(&mut self, _plugin_name: &str) -> Result<Vec<ActionInfo>> {
+        Err(unavailable())
+    }
+
+    pub fn discover_plugins<P: AsRef<Path>>(&mut self, _plugin_dir: P) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn discover_plugins_named<P: AsRef<Path>>(
+        &mut self,
+        _plugin_dir: P,
+        _names: &HashSet<String>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn enable_plugin(&mut self, _name: &str) -> Result<()> {
+        Err(unavailable())
+    }
+
+    pub fn disable_plugin(&mut self, _name: &str) -> Result<()> {
+        Err(unavailable())
+    }
+
+    pub fn decorate_entry(&mut self, _entry: &mut proto::DecoratedEntry, _format: &str) {}
+
+    pub fn format_fields(&mut self, _entry: &proto::DecoratedEntry, _format: &str) -> Vec<String> {
+        Vec::new()
+    }
+
+    pub fn clean_plugins(&mut self) -> Result<()> {
+        Err(unavailable())
+    }
+}
+
+fn unavailable() -> LlaError {
+    LlaError::Plugin(DYNAMIC_PLUGINS_UNAVAILABLE.to_string())
+}

--- a/lla_plugin_utils/Cargo.toml
+++ b/lla_plugin_utils/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.10" }
+lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.11" }
 serde = { workspace = true }
 colored = { workspace = true }
 toml = { workspace = true }

--- a/plugins/brew/Cargo.toml
+++ b/plugins/brew/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brew"
 description = "Homebrew package manager plugin - install, uninstall, upgrade, and search packages"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/categorizer/Cargo.toml
+++ b/plugins/categorizer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "categorizer"
 description = "Categorizes files based on their extensions and metadata"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/code_complexity/Cargo.toml
+++ b/plugins/code_complexity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "code_complexity"
 description = "Analyzes code complexity and provides metrics"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/code_snippet_extractor/Cargo.toml
+++ b/plugins/code_snippet_extractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code_snippet_extractor"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 description = "Extract and manage code snippets with tagging support"
 

--- a/plugins/dirs_meta/Cargo.toml
+++ b/plugins/dirs_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dirs_meta"
 description = "Analyzes directories and shows metadata"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/duplicate_file_detector/Cargo.toml
+++ b/plugins/duplicate_file_detector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "duplicate_file_detector"
 description = "Detects duplicate files by comparing their content hashes"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_copier/Cargo.toml
+++ b/plugins/file_copier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_copier"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for copying files and directories"
 

--- a/plugins/file_hash/Cargo.toml
+++ b/plugins/file_hash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_hash"
 description = "Displays the hash of each file"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_meta/Cargo.toml
+++ b/plugins/file_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_meta"
 description = "Displays the file metadata of each file"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_mover/Cargo.toml
+++ b/plugins/file_mover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_mover"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for moving files and directories"
 

--- a/plugins/file_organizer/Cargo.toml
+++ b/plugins/file_organizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_organizer"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 description = "A plugin for lla that organizes files using various strategies"
 

--- a/plugins/file_remover/Cargo.toml
+++ b/plugins/file_remover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_remover"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 description = "A plugin for lla that provides interactive file and directory removal"
 

--- a/plugins/file_tagger/Cargo.toml
+++ b/plugins/file_tagger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_tagger"
 description = "Add and manage tags for files"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/flush_dns/Cargo.toml
+++ b/plugins/flush_dns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flush_dns"
 description = "Flush DNS cache on macOS, Linux, and Windows"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/folder_cleaner/Cargo.toml
+++ b/plugins/folder_cleaner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "folder_cleaner"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 description = "Safety-first folder organization and cleanup plugin for lla"
 

--- a/plugins/git_status/Cargo.toml
+++ b/plugins/git_status/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "git_status"
 description = "Shows Git repository status information"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_meet/Cargo.toml
+++ b/plugins/google_meet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_meet"
 description = "Google Meet plugin for creating meeting rooms and managing links"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_search/Cargo.toml
+++ b/plugins/google_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_search"
 description = "Google search with autosuggestions, search history management, and clipboard fallback"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/hackernews/Cargo.toml
+++ b/plugins/hackernews/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hackernews"
 description = "Hacker News plugin - browse top stories, best stories, new stories, ask HN, and show HN"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/jwt/Cargo.toml
+++ b/plugins/jwt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jwt"
 description = "JWT decoder and analyzer with search and validation capabilities"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/keyword_search/Cargo.toml
+++ b/plugins/keyword_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "keyword_search"
 description = "Searches file contents for user-specified keywords"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/kill_process/Cargo.toml
+++ b/plugins/kill_process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kill_process"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 description = "A plugin for lla that allows killing processes with an interactive interface"
 

--- a/plugins/last_git_commit/Cargo.toml
+++ b/plugins/last_git_commit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "last_git_commit"
 description = "A plugin for the lla that provides the last git commit hash"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/npm/Cargo.toml
+++ b/plugins/npm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "npm"
 description = "NPM package search with bundlephobia integration and favorites management"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/remove_paywall/Cargo.toml
+++ b/plugins/remove_paywall/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "remove_paywall"
 description = "Remove paywalls from URLs using services like 12ft.io, archive.is, and removepaywall.com"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/sizeviz/Cargo.toml
+++ b/plugins/sizeviz/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sizeviz"
 description = "File size visualizer plugin for lla"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/speed_test/Cargo.toml
+++ b/plugins/speed_test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "speed_test"
 description = "Internet speed test plugin - test download/upload speeds and latency"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/plugins/youtube/Cargo.toml
+++ b/plugins/youtube/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "youtube"
 description = "YouTube search plugin with autosuggestions and history management"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [dependencies]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,8 +3,10 @@ channel = "stable"
 components = ["rustfmt", "clippy"]
 targets = [
     "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
     "x86_64-apple-darwin",
     "aarch64-unknown-linux-gnu",
+    "aarch64-unknown-linux-musl",
     "aarch64-apple-darwin",
     "x86_64-pc-windows-msvc",
 ]

--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -6,11 +6,12 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 usage() {
-  echo "Usage: $0 [--target <triple>]" 1>&2
-  echo "Example: $0 --target x86_64-unknown-linux-gnu" 1>&2
+  echo "Usage: $0 [--target <triple>] [--glibc-version <version>]" 1>&2
+  echo "Example: $0 --target x86_64-unknown-linux-gnu --glibc-version 2.28" 1>&2
 }
 
 TARGET_TRIPLE=""
+GLIBC_VERSION=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -18,6 +19,12 @@ while [[ $# -gt 0 ]]; do
       shift
       TARGET_TRIPLE="${1:-}"
       [[ -z "$TARGET_TRIPLE" ]] && { echo "--target requires an argument" 1>&2; usage; exit 2; }
+      shift
+      ;;
+    --glibc-version)
+      shift
+      GLIBC_VERSION="${1:-}"
+      [[ -z "$GLIBC_VERSION" ]] && { echo "--glibc-version requires an argument" 1>&2; usage; exit 2; }
       shift
       ;;
     -h|--help)
@@ -35,6 +42,21 @@ done
 if [[ -z "$TARGET_TRIPLE" ]]; then
   # Detect host triple
   TARGET_TRIPLE=$(rustc -vV | sed -n 's/^host: \(.*\)$/\1/p')
+fi
+
+if [[ -n "$GLIBC_VERSION" ]]; then
+  if [[ ! "$GLIBC_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    echo "Invalid glibc version: $GLIBC_VERSION" 1>&2
+    exit 2
+  fi
+  if [[ "$TARGET_TRIPLE" != *-unknown-linux-gnu ]]; then
+    echo "--glibc-version is only supported for unknown-linux-gnu targets" 1>&2
+    exit 2
+  fi
+  if ! command -v cargo-zigbuild >/dev/null 2>&1; then
+    echo "cargo-zigbuild is required when --glibc-version is set" 1>&2
+    exit 1
+  fi
 fi
 
 case "$TARGET_TRIPLE" in
@@ -99,8 +121,14 @@ for crate in "${PLUGIN_CRATES[@]}"; do
   BUILD_PKGS+=( -p "$crate" )
 done
 
-echo "Running: cargo build --release --target $TARGET_TRIPLE ${BUILD_PKGS[*]}"
-cargo build --release --target "$TARGET_TRIPLE" "${BUILD_PKGS[@]}"
+if [[ -n "$GLIBC_VERSION" ]]; then
+  BUILD_TARGET="${TARGET_TRIPLE}.${GLIBC_VERSION}"
+  echo "Running: cargo zigbuild --release --target $BUILD_TARGET ${BUILD_PKGS[*]}"
+  cargo zigbuild --release --target "$BUILD_TARGET" "${BUILD_PKGS[@]}"
+else
+  echo "Running: cargo build --release --target $TARGET_TRIPLE ${BUILD_PKGS[*]}"
+  cargo build --release --target "$TARGET_TRIPLE" "${BUILD_PKGS[@]}"
+fi
 
 # Copy resulting dynamic libraries to staging
 for crate in "${PLUGIN_CRATES[@]}"; do
@@ -140,4 +168,3 @@ fi
 echo "Created archive: $ARCHIVE_ZIP"
 
 echo "Done."
-


### PR DESCRIPTION
## Summary

This single release PR combines the feasible work from #117 and #141 and prepares v0.5.11:

- pin Zig and cargo-zigbuild and enforce a GLIBC_2.28 ceiling for GNU Linux CLI and plugin artifacts
- publish core-only static musl binaries for Linux amd64 and arm64
- preserve dynamic plugins and existing artifact names on GNU Linux and macOS
- select musl artifacts in the shell installer and in-app upgrade flow
- build amd64/arm64 APKs from static musl binaries while retaining the legacy GNU i686 APK
- bump all workspace, internal dependency, plugin, and lockfile versions to 0.5.11
- promote the portability notes into the dated 0.5.11 changelog section

## Compatibility and impact

Existing GNU Linux and macOS builds keep their full feature set. Static musl builds retain listing, formatting, search, archives, themes, configuration, and upgrades. Plugin commands remain visible but return the documented unsupported-build error without contaminating ordinary or machine-readable listing output.

## Validation

- release version and changelog validators
- cargo fmt --all -- --check
- cargo test --workspace
- cargo test -p lla --no-default-features
- GNU x86_64 ELF gate verified a GLIBC_2.28 maximum
- amd64 and arm64 musl binaries verified with no ELF interpreter or NEEDED libraries
- Alpine 3.23 smoke suites passed on linux/amd64 and linux/arm64
- installer platform detection, shell syntax, ShellCheck, and workflow YAML checks

## Rollout

After merge, create and push tag v0.5.11 to start the normal release workflow. Keep #117 and #141 open until the published GNU ARM64 and musl artifacts pass their documented environment checks.

Supersedes #167 and #168.
