### PR TITLE
feat(plugins): release Plugin Platform v2

### DIFF
--- a/.github/scripts/prepare_release.sh
+++ b/.github/scripts/prepare_release.sh
@@ -41,6 +41,10 @@ while IFS= read -r manifest; do
   perl -0pi -e 's/(^version\s*=\s*")[^"]+(")/$1$ENV{VERSION}$2/m' "$manifest"
 done < <(find plugins -mindepth 2 -maxdepth 2 -name Cargo.toml | sort)
 
+while IFS= read -r manifest; do
+  perl -0pi -e 's/(^version\s*=\s*")[^"]+(")/$1$ENV{VERSION}$2/m' "$manifest"
+done < <(find plugins -mindepth 2 -maxdepth 2 -name plugin.toml | sort)
+
 tmp_changelog="$(mktemp)"
 today="$(date +%F)"
 

--- a/.github/scripts/release_helpers.sh
+++ b/.github/scripts/release_helpers.sh
@@ -108,6 +108,14 @@ validate_release_versions() {
       exit 1
     fi
   done < <(find plugins -mindepth 2 -maxdepth 2 -name Cargo.toml | sort)
+
+  while IFS= read -r manifest; do
+    plugin_version="$(awk -F '"' '/^version[[:space:]]*=/ { print $2; exit }' "$manifest")"
+    if [[ "$plugin_version" != "$version" ]]; then
+      log_error "$manifest is version $plugin_version, expected $version"
+      exit 1
+    fi
+  done < <(find plugins -mindepth 2 -maxdepth 2 -name plugin.toml | sort)
 }
 
 crate_version_published() {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        continue-on-error: true
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Run tests
         run: cargo test --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - "**/Cargo.lock"
       - "**/*.proto"
       - "**/*.sh"
+      - "plugins/*/plugin.toml"
       - "scripts/**"
       - ".github/workflows/ci.yml"
       - "nfpm.yaml"
@@ -21,6 +22,7 @@ on:
       - "**/Cargo.lock"
       - "**/*.proto"
       - "**/*.sh"
+      - "plugins/*/plugin.toml"
       - "scripts/**"
       - ".github/workflows/ci.yml"
       - "nfpm.yaml"
@@ -151,6 +153,12 @@ jobs:
         run: |
           mapfile -t artifacts < <(find "target/${{ matrix.target }}/release" -maxdepth 1 -type f \( -name lla -o -name '*.so' \) | sort)
           .github/scripts/check_glibc_baseline.sh "$GLIBC_BASELINE" "${artifacts[@]}"
+
+      - name: Verify Plugin Platform v2
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          ./scripts/build_plugins.sh --target "${{ matrix.target }}" --glibc-version "$GLIBC_BASELINE"
+          ./scripts/verify_plugins_v2.sh dist/plugins-linux-amd64
 
       - name: Verify static musl linkage
         if: matrix.libc == 'musl'

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -53,7 +53,7 @@ jobs:
           validate_release_versions "$VERSION"
           validate_changelog_section "$VERSION"
           cargo fmt --all -- --check
-          cargo check --workspace
+          cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,8 +283,12 @@ jobs:
       - name: Verify glibc baseline
         if: runner.os == 'Linux'
         run: |
-          mapfile -t plugins < <(find "dist/plugins-${{ matrix.os_label }}-${{ matrix.arch_label }}" -maxdepth 1 -type f -name '*.so' | sort)
+          mapfile -t plugins < <(find "dist/plugins-${{ matrix.os_label }}-${{ matrix.arch_label }}" -type f -name '*.so' | sort)
           .github/scripts/check_glibc_baseline.sh "$GLIBC_BASELINE" "${plugins[@]}"
+
+      - name: Verify Plugin Platform v2
+        if: matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'x86_64-apple-darwin' || matrix.target == 'aarch64-apple-darwin'
+        run: ./scripts/verify_plugins_v2.sh "dist/plugins-${{ matrix.os_label }}-${{ matrix.arch_label }}"
 
       - name: Upload plugin artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,13 +112,16 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
         run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Run tests
         run: cargo test --workspace

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 target/
+dist/
 
 .cache/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.12] - 2026-08-15
+
+### Added
+
+- Plugin Platform v2 with manifest-based packages, API-range negotiation, plugin-owned response buffers, batch decoration, typed machine-output fields, declared permissions, ordered user/system discovery, package diagnostics, and per-package checksums.
+- Plugin lifecycle destruction, panic isolation, bounded responses, functional contract probes, and CI/release conformance gates for every bundled plugin.
+- `lla plugin doctor`, `lla plugin info <name>`, and `lla plugin permissions <name>` for inspecting v2 installations.
+
+### Changed
+
+- All bundled plugins now ship with v2 manifests and are packaged as self-contained directories while legacy flat v1 libraries remain loadable during migration.
+- Invalid plugins are quarantined for recovery by `lla clean` instead of being permanently deleted.
+
+
 ## [0.5.11] - 2026-08-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.12] - 2026-08-15
+
 ### Added
 
+- Plugin Platform v2 with manifest-based packages, API-range negotiation, plugin-owned response buffers, batch decoration, typed machine-output fields, declared permissions, ordered user/system discovery, package diagnostics, and per-package checksums.
+- Plugin lifecycle destruction, panic isolation, bounded responses, functional contract probes, and CI/release conformance gates for every bundled plugin.
+- `lla plugin doctor`, `lla plugin info <name>`, and `lla plugin permissions <name>` for inspecting v2 installations.
 - `security_audit` plugin for unsafe permissions, SUID/SGID bits, suspicious symlinks, and exposed secret-like files.
 - `media_inspector` plugin for MIME detection, built-in image dimensions, optional EXIF, and ffprobe-backed audio/video metadata.
 - `project_context` plugin for Rust, Node, Python, and Go detection with lockfile, artifact, toolchain, and Git health fields.
@@ -17,21 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `file_remover remove` now moves selected entries to recoverable trash; irreversible deletion is available only through the explicit `purge` action and confirmation.
-
-## [0.5.12] - 2026-08-15
-
-### Added
-
-- Plugin Platform v2 with manifest-based packages, API-range negotiation, plugin-owned response buffers, batch decoration, typed machine-output fields, declared permissions, ordered user/system discovery, package diagnostics, and per-package checksums.
-- Plugin lifecycle destruction, panic isolation, bounded responses, functional contract probes, and CI/release conformance gates for every bundled plugin.
-- `lla plugin doctor`, `lla plugin info <name>`, and `lla plugin permissions <name>` for inspecting v2 installations.
-
-### Changed
-
 - All bundled plugins now ship with v2 manifests and are packaged as self-contained directories while legacy flat v1 libraries remain loadable during migration.
 - Invalid plugins are quarantined for recovery by `lla clean` instead of being permanently deleted.
+- `file_remover remove` now moves selected entries to recoverable trash; irreversible deletion is available only through the explicit `purge` action and confirmation.
 
+### Migration
+
+- Existing flat v1 plugins continue to load, but newly distributed plugins should use the v2 package directory layout.
+- Automations that require irreversible deletion must replace `file_remover remove` with `file_remover purge`; `remove` is now recoverable by design.
 
 ## [0.5.11] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `security_audit` plugin for unsafe permissions, SUID/SGID bits, suspicious symlinks, and exposed secret-like files.
+- `media_inspector` plugin for MIME detection, built-in image dimensions, optional EXIF, and ffprobe-backed audio/video metadata.
+- `project_context` plugin for Rust, Node, Python, and Go detection with lockfile, artifact, toolchain, and Git health fields.
+- `trash` plugin for cross-platform recoverable deletion, listing, conflict-safe restoration, and age-gated permanent emptying.
+- `preview` plugin with bat text/Markdown highlighting, chafa image rendering, safe archive listings, and built-in fallbacks.
+
+### Changed
+
+- `file_remover remove` now moves selected entries to recoverable trash; irreversible deletion is available only through the explicit `purge` action and confirmation.
+
 ## [0.5.12] - 2026-08-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "brew"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "chrono",
@@ -220,7 +220,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "categorizer"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "colored",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "code_complexity"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "colored",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "code_snippet_extractor"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "arboard",
  "base64 0.21.7",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "dirs_meta"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "colored",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "duplicate_file_detector"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "colored",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "file_copier"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "colored",
  "dialoguer",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "file_hash"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "colored",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "file_meta"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "chrono",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "file_mover"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "colored",
  "dialoguer",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "file_organizer"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "chrono",
  "colored",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "file_remover"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "colored",
  "dialoguer",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "file_tagger"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "colored",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "flush_dns"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "chrono",
@@ -860,7 +860,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "folder_cleaner"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "chrono",
  "colored",
@@ -1011,7 +1011,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git_status"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "colored",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "google_meet"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "arboard",
  "bytes",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "google_search"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "arboard",
  "bytes",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "hackernews"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "arboard",
  "bytes",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "jwt"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "keyword_search"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "arboard",
  "bytes",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "kill_process"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "colored",
  "console",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "last_git_commit"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "colored",
@@ -1592,7 +1592,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lla"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "atty",
  "chrono",
@@ -1642,16 +1642,18 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_interface"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "prost",
  "prost-build",
+ "protoc-bin-vendored",
  "serde",
+ "toml",
 ]
 
 [[package]]
 name = "lla_plugin_utils"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "chrono",
@@ -1738,7 +1740,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "npm"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "arboard",
  "bytes",
@@ -2167,6 +2169,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
 name = "quick-xml"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,7 +2351,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remove_paywall"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "arboard",
  "bytes",
@@ -2611,7 +2677,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sizeviz"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "colored",
@@ -2647,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "speed_test"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "bytes",
  "chrono",
@@ -3664,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "youtube"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "arboard",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,6 +1484,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamadak-exif"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1130d80c7374efad55a117d715a3af9368f0fa7a2c54573afc15a188cd984837"
+dependencies = [
+ "mutate_once",
+]
+
+[[package]]
 name = "keyword_search"
 version = "0.5.12"
 dependencies = [
@@ -1666,7 +1675,9 @@ dependencies = [
  "lla_plugin_interface",
  "prost",
  "serde",
+ "serde_json",
  "syntect",
+ "tempfile",
  "toml",
  "users",
 ]
@@ -1686,6 +1697,19 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "media_inspector"
+version = "0.5.12"
+dependencies = [
+ "kamadak-exif",
+ "lazy_static",
+ "lla_plugin_interface",
+ "lla_plugin_utils",
+ "parking_lot",
+ "serde_json",
+ "tempfile",
+]
 
 [[package]]
 name = "memchr"
@@ -1737,6 +1761,12 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "mutate_once"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "npm"
@@ -2098,6 +2128,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "preview"
+version = "0.5.12"
+dependencies = [
+ "lazy_static",
+ "lla_plugin_interface",
+ "lla_plugin_utils",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,6 +2154,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "project_context"
+version = "0.5.12"
+dependencies = [
+ "lazy_static",
+ "lla_plugin_interface",
+ "lla_plugin_utils",
+ "parking_lot",
+ "tempfile",
 ]
 
 [[package]]
@@ -2544,6 +2596,18 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security_audit"
+version = "0.5.12"
+dependencies = [
+ "lazy_static",
+ "lla_plugin_interface",
+ "lla_plugin_utils",
+ "parking_lot",
+ "tempfile",
+ "walkdir",
 ]
 
 [[package]]
@@ -3099,6 +3163,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trash"
+version = "0.5.12"
+dependencies = [
+ "lazy_static",
+ "lla_plugin_interface",
+ "lla_plugin_utils",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["lla", "lla_plugin_interface", "lla_plugin_utils", "plugins/*"]
 [workspace.package]
 description = "Blazing Fast and highly customizable ls Replacement with Superpowers"
 authors = ["Achaq <hi@achaq.dev>"]
-version = "0.5.11"
+version = "0.5.12"
 categories = ["utilities", "file-system", "cli", "file-management"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -710,6 +710,17 @@ respect_gitignore = true
 | `--disable-plugin` | Disable specific plugins   | `lla --disable-plugin name`                                                   |
 | `update`           | Update plugins             | `lla update` <br> `lla update file_tagger`                                    |
 | `plugin`           | Run plugin actions         | `lla plugin --name file_tagger --action add-tag --args README.md "important"` |
+| `plugin info`      | Inspect a v2 manifest      | `lla plugin info file_tagger`                                                   |
+| `plugin permissions` | Inspect declared access  | `lla plugin permissions file_tagger`                                            |
+| `plugin doctor`    | Validate v2 packages        | `lla plugin doctor`                                                             |
+
+Plugin Platform v2 packages place `plugin.toml` beside their native entrypoint.
+The manifest declares API compatibility, typed fields, capabilities, and access
+requirements before the library is loaded. `plugins_dir` remains the writable
+user location; additional package-manager-owned locations can be configured with
+`plugin_dirs = ["/path/to/plugins"]`. lla also searches the standard system
+locations for the current platform. Native permissions are declarations because
+native libraries are trusted code; sandboxed runtimes can enforce them in future.
 
 #### Shortcut Management
 

--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -32,8 +32,8 @@ walkdir.workspace = true
 tempfile.workspace = true
 users.workspace = true
 parking_lot.workspace = true
-lla_plugin_interface = { version = "0.5.11", path = "../lla_plugin_interface" }
-lla_plugin_utils = { version = "0.5.11", path = "../lla_plugin_utils" }
+lla_plugin_interface = { version = "0.5.12", path = "../lla_plugin_interface" }
+lla_plugin_utils = { version = "0.5.12", path = "../lla_plugin_utils" }
 once_cell.workspace = true
 dashmap.workspace = true
 unicode-width.workspace = true

--- a/lla/src/commands/args.rs
+++ b/lla/src/commands/args.rs
@@ -224,7 +224,7 @@ impl Args {
                         Arg::with_name("shell")
                             .long("shell")
                             .takes_value(true)
-                            .possible_values(&["bash", "zsh", "fish"]) 
+                            .possible_values(["bash", "zsh", "fish"])
                             .help("Override shell detection for setup (bash|zsh|fish)"),
                     ),
             )
@@ -524,7 +524,7 @@ impl Args {
                     .long("permission-format")
                     .help("Format for displaying permissions (symbolic, octal, binary, verbose, compact)")
                     .takes_value(true)
-                    .possible_values(&["symbolic", "octal", "binary",  "verbose", "compact"])
+                    .possible_values(["symbolic", "octal", "binary",  "verbose", "compact"])
                     .default_value(&config.permission_format),
             )
             .arg(

--- a/lla/src/commands/args.rs
+++ b/lla/src/commands/args.rs
@@ -76,6 +76,9 @@ pub enum Command {
     InitConfig { defaults_only: bool },
     Config(Option<ConfigAction>),
     PluginAction(String, String, Vec<String>),
+    PluginDoctor,
+    PluginInfo(String),
+    PluginPermissions(String),
     Update(Option<String>),
     Clean,
     Shortcut(ShortcutAction),
@@ -568,10 +571,10 @@ impl Args {
             )
             .subcommand(
                 SubCommand::with_name("plugin")
-                    .about("Run a plugin action")
+                    .about("Run actions or inspect Plugin Platform v2 packages")
                     .arg(
                         Arg::with_name("plugin_name")
-                            .help("Name of the plugin")
+                            .help("Plugin name, or doctor/info/permissions")
                             .index(1),
                     )
                     .arg(
@@ -1037,6 +1040,10 @@ impl Args {
                 .or_else(|| plugin_matches.value_of("action"));
 
             match (plugin_name, action) {
+                (Some("info"), Some(name)) => Some(Command::PluginInfo(name.to_string())),
+                (Some("permissions"), Some(name)) => {
+                    Some(Command::PluginPermissions(name.to_string()))
+                }
                 (Some(name), Some(act)) => {
                     let args = plugin_matches
                         .values_of("plugin_args")
@@ -1050,12 +1057,16 @@ impl Args {
                     ))
                 }
                 (Some(name), None) => {
-                    // No action provided - defer to command handler (menu/help fallback)
-                    Some(Command::PluginAction(
-                        name.to_string(),
-                        "__default__".to_string(),
-                        vec![],
-                    ))
+                    if name == "doctor" {
+                        Some(Command::PluginDoctor)
+                    } else {
+                        // No action provided - defer to command handler (menu/help fallback)
+                        Some(Command::PluginAction(
+                            name.to_string(),
+                            "__default__".to_string(),
+                            vec![],
+                        ))
+                    }
                 }
                 (None, _) => {
                     return Err(LlaError::Plugin(

--- a/lla/src/commands/command_handler.rs
+++ b/lla/src/commands/command_handler.rs
@@ -185,7 +185,7 @@ pub fn handle_command(
         }
         Some(Command::Theme) => crate::theme::select_theme(config),
         Some(Command::ThemePull) => crate::theme::pull_themes(&color_state),
-        Some(Command::ThemeInstall(path)) => crate::theme::install_themes(&path, &color_state),
+        Some(Command::ThemeInstall(path)) => crate::theme::install_themes(path, &color_state),
         Some(Command::ThemePreview(name)) => crate::theme::preview_theme(name),
         Some(Command::Shortcut(action)) => handle_shortcut_action(action, config, &color_state),
         Some(Command::Install(source)) => handle_install(source, args),
@@ -347,11 +347,7 @@ fn handle_shortcut_action(
                 .collect();
 
             if plugin_names.is_empty() {
-                if color_state.is_enabled() {
-                    println!("✗ No plugins found. Install plugins first",);
-                } else {
-                    println!("✗ No plugins found. Install plugins first");
-                }
+                println!("✗ No plugins found. Install plugins first");
                 return Ok(());
             }
 
@@ -381,11 +377,7 @@ fn handle_shortcut_action(
 
                         if selection == items_with_cancel.len() - 1 {
                             // User selected Cancel
-                            if color_state.is_enabled() {
-                                println!("✗ Cancelled");
-                            } else {
-                                println!("✗ Cancelled");
-                            }
+                            println!("✗ Cancelled");
                             return Ok(());
                         }
 
@@ -463,11 +455,7 @@ fn handle_shortcut_action(
                                 .interact_text()?;
 
                             if shortcut_name.is_empty() {
-                                if color_state.is_enabled() {
-                                    println!("✗ Shortcut name cannot be empty\n");
-                                } else {
-                                    println!("✗ Shortcut name cannot be empty\n");
-                                }
+                                println!("✗ Shortcut name cannot be empty\n");
                                 WizardState::EnterName(plugin.clone(), action.clone())
                             } else if config.get_shortcut(&shortcut_name).is_some() {
                                 if color_state.is_enabled() {
@@ -594,7 +582,7 @@ fn handle_shortcut_action(
         }
         ShortcutAction::Import(file_path, merge) => {
             // Read and parse file
-            let content = fs::read_to_string(&file_path).map_err(|e| {
+            let content = fs::read_to_string(file_path).map_err(|e| {
                 LlaError::Other(format!("Failed to read file '{}': {}", file_path, e))
             })?;
 
@@ -625,9 +613,7 @@ fn handle_shortcut_action(
 
                 // Merge plugin aliases
                 for (alias, plugin) in import_data.plugin_aliases {
-                    if !config.plugin_aliases.contains_key(&alias) {
-                        config.plugin_aliases.insert(alias, plugin);
-                    }
+                    config.plugin_aliases.entry(alias).or_insert(plugin);
                 }
                 config.save(&Config::get_config_path())?;
 

--- a/lla/src/commands/command_handler.rs
+++ b/lla/src/commands/command_handler.rs
@@ -26,6 +26,9 @@ fn command_requires_dynamic_plugins(args: &Args) -> bool {
                 | Command::ListPlugins
                 | Command::Use
                 | Command::PluginAction(_, _, _)
+                | Command::PluginDoctor
+                | Command::PluginInfo(_)
+                | Command::PluginPermissions(_)
                 | Command::Clean
                 | Command::Shortcut(
                     ShortcutAction::Add(_, _) | ShortcutAction::Create | ShortcutAction::Run(_, _),
@@ -230,6 +233,24 @@ pub fn handle_command(
                 plugin_manager.perform_plugin_action(&resolved_plugin, action, action_args)
             }
         }
+        Some(Command::PluginDoctor) => {
+            let plugin_paths = config.plugin_search_paths(Some(&args.plugins_dir));
+            if plugin_manager.doctor(&plugin_paths)? {
+                Ok(())
+            } else {
+                Err(LlaError::Plugin(
+                    "Plugin Platform v2 diagnostics found problems".to_string(),
+                ))
+            }
+        }
+        Some(Command::PluginInfo(plugin_name)) => {
+            let resolved = config.resolve_plugin_alias(plugin_name);
+            plugin_manager.print_manifest(&resolved, false)
+        }
+        Some(Command::PluginPermissions(plugin_name)) => {
+            let resolved = config.resolve_plugin_alias(plugin_name);
+            plugin_manager.print_manifest(&resolved, true)
+        }
         Some(Command::Jump(action)) => jump::handle_jump(action, config),
         Some(Command::Clean) => unreachable!(),
         None => {
@@ -316,7 +337,7 @@ fn handle_shortcut_action(
 
             // Create plugin manager to query plugins
             let mut plugin_manager = PluginManager::new(config.clone());
-            plugin_manager.discover_plugins(&config.plugins_dir)?;
+            plugin_manager.discover_plugin_paths(&config.plugin_search_paths(None))?;
 
             // Get all discovered plugins
             let all_plugins = plugin_manager.list_plugins();

--- a/lla/src/commands/diff.rs
+++ b/lla/src/commands/diff.rs
@@ -496,11 +496,8 @@ fn relativize_git_path(path: &str, prefix: &str) -> Option<String> {
 
     let normalized_prefix = prefix.trim_end_matches('/');
     let prefix_with_sep = format!("{}/", normalized_prefix);
-    if let Some(stripped) = path.strip_prefix(&prefix_with_sep) {
-        Some(stripped.to_string())
-    } else {
-        None
-    }
+    path.strip_prefix(&prefix_with_sep)
+        .map(|stripped| stripped.to_string())
 }
 
 fn render_diff(
@@ -696,7 +693,7 @@ fn format_delta_with_percent(
     if delta == 0 {
         return "0B".to_string();
     }
-    let magnitude = human_size(delta.abs() as u64);
+    let magnitude = human_size(delta.unsigned_abs());
     let percent = match (left_size, right_size) {
         (Some(left), Some(right)) if left > 0 => {
             let pct = ((right as f64 - left as f64) / left as f64) * 100.0;
@@ -727,7 +724,7 @@ fn format_delta(delta: i64) -> String {
     if delta == 0 {
         return "0B".to_string();
     }
-    let magnitude = human_size(delta.abs() as u64);
+    let magnitude = human_size(delta.unsigned_abs());
     let text = if delta > 0 {
         format!("+{}", magnitude)
     } else {
@@ -829,7 +826,7 @@ fn calculate_stats(rows: &[DiffRow]) -> DiffStats {
                 if stats
                     .largest_growth
                     .as_ref()
-                    .map_or(true, |(_, d)| delta > *d)
+                    .is_none_or(|(_, d)| delta > *d)
                 {
                     stats.largest_growth = Some((row.path.clone(), delta));
                 }
@@ -840,7 +837,7 @@ fn calculate_stats(rows: &[DiffRow]) -> DiffStats {
                 if stats
                     .largest_shrink
                     .as_ref()
-                    .map_or(true, |(_, d)| delta < *d)
+                    .is_none_or(|(_, d)| delta < *d)
                 {
                     stats.largest_shrink = Some((row.path.clone(), delta));
                 }
@@ -851,7 +848,7 @@ fn calculate_stats(rows: &[DiffRow]) -> DiffStats {
                     && stats
                         .largest_growth
                         .as_ref()
-                        .map_or(true, |(_, d)| delta > *d)
+                        .is_none_or(|(_, d)| delta > *d)
                 {
                     stats.largest_growth = Some((row.path.clone(), delta));
                 }
@@ -859,7 +856,7 @@ fn calculate_stats(rows: &[DiffRow]) -> DiffStats {
                     && stats
                         .largest_shrink
                         .as_ref()
-                        .map_or(true, |(_, d)| delta < *d)
+                        .is_none_or(|(_, d)| delta < *d)
                 {
                     stats.largest_shrink = Some((row.path.clone(), delta));
                 }

--- a/lla/src/commands/file_utils.rs
+++ b/lla/src/commands/file_utils.rs
@@ -83,7 +83,7 @@ pub fn list_directory(
             OutputMode::Json { pretty } => {
                 let include_git_status = args.git_format;
                 json_writer::write_json_array_stream(
-                    decorated_files.into_iter(),
+                    decorated_files,
                     plugin_manager,
                     pretty,
                     include_git_status,
@@ -92,18 +92,14 @@ pub fn list_directory(
             OutputMode::Ndjson => {
                 let include_git_status = args.git_format;
                 json_writer::write_ndjson_stream(
-                    decorated_files.into_iter(),
+                    decorated_files,
                     plugin_manager,
                     include_git_status,
                 )
             }
             OutputMode::Csv => {
                 let include_git_status = args.git_format;
-                csv_writer::write_csv_stream(
-                    decorated_files.into_iter(),
-                    plugin_manager,
-                    include_git_status,
-                )
+                csv_writer::write_csv_stream(decorated_files, plugin_manager, include_git_status)
             }
         };
     }
@@ -130,7 +126,7 @@ pub fn list_directory(
             OutputMode::Json { pretty } => {
                 let include_git_status = args.git_format;
                 json_writer::write_json_array_stream(
-                    decorated_files.into_iter(),
+                    decorated_files,
                     plugin_manager,
                     pretty,
                     include_git_status,
@@ -139,18 +135,14 @@ pub fn list_directory(
             OutputMode::Ndjson => {
                 let include_git_status = args.git_format;
                 json_writer::write_ndjson_stream(
-                    decorated_files.into_iter(),
+                    decorated_files,
                     plugin_manager,
                     include_git_status,
                 )
             }
             OutputMode::Csv => {
                 let include_git_status = args.git_format;
-                csv_writer::write_csv_stream(
-                    decorated_files.into_iter(),
-                    plugin_manager,
-                    include_git_status,
-                )
+                csv_writer::write_csv_stream(decorated_files, plugin_manager, include_git_status)
             }
         };
     }
@@ -211,7 +203,7 @@ pub fn list_directory(
             // Only include git status if git format was requested
             let include_git_status = args.git_format;
             json_writer::write_json_array_stream(
-                decorated_files.into_iter(),
+                decorated_files,
                 plugin_manager,
                 pretty,
                 include_git_status,
@@ -219,19 +211,11 @@ pub fn list_directory(
         }
         OutputMode::Ndjson => {
             let include_git_status = args.git_format;
-            json_writer::write_ndjson_stream(
-                decorated_files.into_iter(),
-                plugin_manager,
-                include_git_status,
-            )
+            json_writer::write_ndjson_stream(decorated_files, plugin_manager, include_git_status)
         }
         OutputMode::Csv => {
             let include_git_status = args.git_format;
-            csv_writer::write_csv_stream(
-                decorated_files.into_iter(),
-                plugin_manager,
-                include_git_status,
-            )
+            csv_writer::write_csv_stream(decorated_files, plugin_manager, include_git_status)
         }
     }
 }
@@ -438,11 +422,10 @@ pub fn list_and_decorate_files(
                 .map(|n| n == "." || n == "..")
                 .unwrap_or(false);
 
-            if args.dotfiles_only && !is_dotfile {
-                return None;
-            } else if args.no_dotfiles && is_dotfile {
-                return None;
-            } else if args.almost_all && is_current_or_parent_dir {
+            if (args.dotfiles_only && !is_dotfile)
+                || (args.no_dotfiles && is_dotfile)
+                || (args.almost_all && is_current_or_parent_dir)
+            {
                 return None;
             }
 
@@ -542,7 +525,7 @@ fn list_files_with_gitignore(args: &Args, config: &Config) -> Result<Vec<PathBuf
         let entry = dent.map_err(|err| LlaError::Other(err.to_string()))?;
 
         if args.respect_gitignore && path_contains_git_dir(entry.path()) {
-            if entry.file_type().map_or(false, |ft| ft.is_dir()) {
+            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
                 continue;
             }
             continue;
@@ -607,7 +590,7 @@ pub fn list_and_decorate_archive_entries(
         let pb = PathBuf::from(&entry.path);
 
         // Exclude synthetic root from all views
-        if pb == PathBuf::from(&root_name) {
+        if pb == root_name {
             continue;
         }
 
@@ -647,11 +630,10 @@ pub fn list_and_decorate_archive_entries(
             .map(|n| n == "." || n == "..")
             .unwrap_or(false);
 
-        if args.dotfiles_only && !is_dotfile {
-            continue;
-        } else if args.no_dotfiles && is_dotfile {
-            continue;
-        } else if args.almost_all && is_current_or_parent_dir {
+        if (args.dotfiles_only && !is_dotfile)
+            || (args.no_dotfiles && is_dotfile)
+            || (args.almost_all && is_current_or_parent_dir)
+        {
             continue;
         }
 
@@ -816,13 +798,13 @@ pub fn create_filter(args: &Args) -> Arc<dyn FileFilter + Send + Sync> {
                     composite.add_filter(create_base_filter(part.trim(), !args.case_sensitive));
                 }
                 Arc::new(composite)
-            } else if filter_str.starts_with("NOT ") {
+            } else if let Some(pattern) = filter_str.strip_prefix("NOT ") {
                 let mut composite = CompositeFilter::new(FilterOperation::Not);
-                composite.add_filter(create_base_filter(&filter_str[4..], !args.case_sensitive));
+                composite.add_filter(create_base_filter(pattern, !args.case_sensitive));
                 Arc::new(composite)
-            } else if filter_str.starts_with("XOR ") {
+            } else if let Some(pattern) = filter_str.strip_prefix("XOR ") {
                 let mut composite = CompositeFilter::new(FilterOperation::Xor);
-                composite.add_filter(create_base_filter(&filter_str[4..], !args.case_sensitive));
+                composite.add_filter(create_base_filter(pattern, !args.case_sensitive));
                 Arc::new(composite)
             } else {
                 Arc::from(create_base_filter(filter_str, !args.case_sensitive))
@@ -833,15 +815,16 @@ pub fn create_filter(args: &Args) -> Arc<dyn FileFilter + Send + Sync> {
 }
 
 fn create_base_filter(pattern: &str, case_insensitive: bool) -> Box<dyn FileFilter + Send + Sync> {
-    let base_filter: Box<dyn FileFilter + Send + Sync> = if pattern.starts_with("regex:") {
-        Box::new(RegexFilter::new(pattern[6..].to_string()))
-    } else if pattern.starts_with("glob:") {
-        Box::new(GlobFilter::new(pattern[5..].to_string()))
-    } else if pattern.starts_with('.') {
-        Box::new(ExtensionFilter::new(pattern[1..].to_string()))
-    } else {
-        Box::new(PatternFilter::new(pattern.to_string()))
-    };
+    let base_filter: Box<dyn FileFilter + Send + Sync> =
+        if let Some(pattern) = pattern.strip_prefix("regex:") {
+            Box::new(RegexFilter::new(pattern.to_string()))
+        } else if let Some(pattern) = pattern.strip_prefix("glob:") {
+            Box::new(GlobFilter::new(pattern.to_string()))
+        } else if let Some(pattern) = pattern.strip_prefix('.') {
+            Box::new(ExtensionFilter::new(pattern.to_string()))
+        } else {
+            Box::new(PatternFilter::new(pattern.to_string()))
+        };
 
     if case_insensitive {
         Box::new(CaseInsensitiveFilter::new(base_filter))

--- a/lla/src/commands/file_utils.rs
+++ b/lla/src/commands/file_utils.rs
@@ -417,6 +417,7 @@ pub fn list_and_decorate_files(
                                 gid: 0,
                             }),
                             custom_fields,
+                            typed_fields: Default::default(),
                         });
                     }
                     return None;
@@ -497,14 +498,13 @@ pub fn list_and_decorate_files(
                 path: path.to_string_lossy().into_owned(),
                 metadata: Some(metadata),
                 custom_fields,
+                typed_fields: Default::default(),
             })
         })
         .collect();
 
     let mut decorated_entries = entries;
-    for entry in &mut decorated_entries {
-        plugin_manager.decorate_entry(entry, format);
-    }
+    plugin_manager.decorate_entries(&mut decorated_entries, format);
 
     Ok(decorated_entries)
 }
@@ -744,6 +744,7 @@ pub fn list_and_decorate_single_file(
         path: path.to_string_lossy().into_owned(),
         metadata: Some(metadata),
         custom_fields,
+        typed_fields: Default::default(),
     };
 
     plugin_manager.decorate_entry(&mut entry, format);

--- a/lla/src/commands/init_wizard.rs
+++ b/lla/src/commands/init_wizard.rs
@@ -3,6 +3,7 @@ use crate::error::Result;
 use crate::theme;
 use colored::*;
 use dialoguer::{Confirm, Input, MultiSelect, Select};
+use lla_plugin_interface::manifest::PluginManifest;
 use lla_plugin_utils::ui::components::LlaDialoguerTheme;
 use std::fmt::Display;
 use std::fs;
@@ -330,7 +331,7 @@ pub fn run_wizard() -> Result<()> {
         Some(depth_guard_input.trim().parse::<usize>().unwrap())
     };
 
-    let installed_plugins = discover_plugins(&config.plugins_dir).unwrap_or_default();
+    let installed_plugins = discover_plugins(&config.plugin_search_paths(None)).unwrap_or_default();
     let selected_plugins = if installed_plugins.is_empty() {
         config.enabled_plugins.clone()
     } else {
@@ -453,21 +454,28 @@ fn seed_default_theme(themes_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn discover_plugins(plugins_dir: &Path) -> std::io::Result<Vec<String>> {
+fn discover_plugins(plugin_dirs: &[PathBuf]) -> std::io::Result<Vec<String>> {
     let mut names = Vec::new();
-    if !plugins_dir.exists() {
-        return Ok(names);
-    }
-    for entry in fs::read_dir(plugins_dir)? {
-        let entry = entry?;
-        if entry.file_type()?.is_file() {
-            if let Some(name) = entry.path().file_name().and_then(|s| s.to_str()) {
+    for plugins_dir in plugin_dirs {
+        if !plugins_dir.is_dir() {
+            continue;
+        }
+        for entry in fs::read_dir(plugins_dir)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                let manifest_path = entry.path().join("plugin.toml");
+                if let Ok(manifest) = PluginManifest::from_path(&manifest_path) {
+                    names.push(manifest.plugin.name);
+                }
+            } else if let Some(name) = entry.path().file_name().and_then(|s| s.to_str()) {
                 if let Some(canonical) = canonical_plugin_name(name) {
                     names.push(canonical);
                 }
             }
         }
     }
+    names.sort();
+    names.dedup();
     Ok(names)
 }
 

--- a/lla/src/commands/jump.rs
+++ b/lla/src/commands/jump.rs
@@ -121,9 +121,7 @@ fn add_bookmark(path: &str, config: &Config) -> Result<()> {
     if !store.bookmarks.iter().any(|q| q == &abs) {
         store.bookmarks.push(abs);
     }
-    store
-        .save()
-        .map_err(|e| LlaError::Other(format!("{}", e)))?;
+    store.save().map_err(|e| LlaError::Other(e.to_string()))?;
     Ok(())
 }
 
@@ -132,9 +130,7 @@ fn remove_bookmark(path: &str) -> Result<()> {
     let abs = canonicalize_best_effort(p);
     let mut store = JumpStore::load();
     store.bookmarks.retain(|q| q != &abs);
-    store
-        .save()
-        .map_err(|e| LlaError::Other(format!("{}", e)))?;
+    store.save().map_err(|e| LlaError::Other(e.to_string()))?;
     Ok(())
 }
 
@@ -157,9 +153,7 @@ fn list_entries(config: &Config) -> Result<()> {
 fn clear_history() -> Result<()> {
     let mut store = JumpStore::load();
     store.history.clear();
-    store
-        .save()
-        .map_err(|e| LlaError::Other(format!("{}", e)))?;
+    store.save().map_err(|e| LlaError::Other(e.to_string()))?;
     Ok(())
 }
 
@@ -229,7 +223,7 @@ fn setup_shell_integration(shell_override: Option<&str>) -> Result<()> {
         env::var("SHELL")
             .unwrap_or_default()
             .split('/')
-            .last()
+            .next_back()
             .unwrap_or("unknown")
             .to_string()
     };
@@ -242,7 +236,7 @@ fn setup_shell_integration(shell_override: Option<&str>) -> Result<()> {
             println!("❌ Unsupported shell: {}", shell);
             println!("   Supported shells: bash, zsh, fish");
             println!("   Please set up manually using the documentation.");
-            return Ok(());
+            Ok(())
         }
     }
 }

--- a/lla/src/commands/plugin_utils.rs
+++ b/lla/src/commands/plugin_utils.rs
@@ -309,6 +309,6 @@ pub fn handle_plugin_action(
     let resolved_plugin = config.resolve_plugin_alias(plugin_name);
     let mut plugin_manager = PluginManager::new(config.clone());
     let requested = std::collections::HashSet::from([resolved_plugin.clone()]);
-    plugin_manager.discover_plugins_named(&config.plugins_dir, &requested)?;
+    plugin_manager.discover_plugin_paths_named(&config.plugin_search_paths(None), &requested)?;
     plugin_manager.perform_plugin_action(&resolved_plugin, action, args)
 }

--- a/lla/src/commands/search.rs
+++ b/lla/src/commands/search.rs
@@ -35,12 +35,10 @@ fn build_name_filter_args(args_cfg: &Args) -> Vec<String> {
     // We only map simple extension (.ext) and glob: patterns to ripgrep globs.
     let mut args = Vec::new();
     if let Some(filter_str) = &args_cfg.filter {
-        if filter_str.starts_with("glob:") {
-            let g = &filter_str[5..];
+        if let Some(g) = filter_str.strip_prefix("glob:") {
             args.push("--glob".to_string());
             args.push(g.to_string());
-        } else if filter_str.starts_with('.') {
-            let ext = &filter_str[1..];
+        } else if let Some(ext) = filter_str.strip_prefix('.') {
             args.push("--glob".to_string());
             args.push(format!("**/*.{}", ext));
         }
@@ -77,8 +75,8 @@ pub fn run_search(args: &Args, config: &Config, plugin_manager: &mut PluginManag
 
     // Use fixed-string mode by default for literal matching (safer for user input)
     // Users can override with regex: prefix if they want regex behavior
-    let (search_pattern, use_fixed_string) = if pattern.starts_with("regex:") {
-        (&pattern[6..], false)
+    let (search_pattern, use_fixed_string) = if let Some(pattern) = pattern.strip_prefix("regex:") {
+        (pattern, false)
     } else {
         (pattern.as_str(), true)
     };
@@ -139,21 +137,17 @@ pub fn run_search(args: &Args, config: &Config, plugin_manager: &mut PluginManag
     walker.hidden(!args.almost_all && (args.no_dotfiles || config.filter.no_dotfiles));
     walker.git_ignore(true).git_exclude(true).parents(true);
     let walker = walker.build();
-    for dent in walker {
-        if let Ok(d) = dent {
-            let p = d.path();
-            // Skip directories under excluded prefixes
-            if !config.exclude_paths.is_empty() {
-                let abs = p;
-                if config.exclude_paths.iter().any(|ex| abs.starts_with(ex)) {
-                    continue;
-                }
+    for d in walker.flatten() {
+        let p = d.path();
+        // Skip directories under excluded prefixes
+        if !config.exclude_paths.is_empty() {
+            let abs = p;
+            if config.exclude_paths.iter().any(|ex| abs.starts_with(ex)) {
+                continue;
             }
-            if p.is_file() {
-                if args.files_only || (!args.no_files) {
-                    paths.push(p.to_path_buf());
-                }
-            }
+        }
+        if p.is_file() && (args.files_only || (!args.no_files)) {
+            paths.push(p.to_path_buf());
         }
     }
 
@@ -295,8 +289,8 @@ fn render_pretty(matches: &[RgMatch], args: &Args) -> Result<()> {
                             let e = display_col_at(&center_text, sm.end, TABSTOP);
                             let end = e.min(markers.len());
                             let start = s.min(end);
-                            for i in start..end {
-                                markers[i] = '^';
+                            for marker in markers.iter_mut().take(end).skip(start) {
+                                *marker = '^';
                             }
                         }
                         let marker_line: String = markers.into_iter().collect();
@@ -330,7 +324,7 @@ fn render_csv(matches: &[RgMatch]) -> Result<()> {
     for data in matches {
         let file = data.path.text.clone();
         let line_no = data.line_number;
-        let col = data.submatches.get(0).map(|sm| sm.start + 1).unwrap_or(1);
+        let col = data.submatches.first().map(|sm| sm.start + 1).unwrap_or(1);
         let text = data.lines.text.replace('\n', "");
         let text_escaped = text.replace('"', "\"\"");
         println!(
@@ -344,10 +338,8 @@ fn render_csv(matches: &[RgMatch]) -> Result<()> {
 fn collect_matches(stdout: &[u8]) -> Vec<RgMatch> {
     let mut matches = Vec::new();
     for line in String::from_utf8_lossy(stdout).lines() {
-        if let Ok(ev) = serde_json::from_str::<RipgrepEvent>(line) {
-            if let RipgrepEvent::Match { data } = ev {
-                matches.push(data);
-            }
+        if let Ok(RipgrepEvent::Match { data }) = serde_json::from_str::<RipgrepEvent>(line) {
+            matches.push(data);
         }
     }
     matches

--- a/lla/src/config/mod.rs
+++ b/lla/src/config/mod.rs
@@ -75,7 +75,7 @@ fn default_table_columns() -> Vec<String> {
     ]
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct FormatterConfig {
     #[serde(default)]
     pub tree: TreeFormatterConfig,
@@ -87,18 +87,6 @@ pub struct FormatterConfig {
     pub table: TableFormatterConfig,
     #[serde(default)]
     pub sizemap: SizeMapConfig,
-}
-
-impl Default for FormatterConfig {
-    fn default() -> Self {
-        Self {
-            tree: TreeFormatterConfig::default(),
-            grid: GridFormatterConfig::default(),
-            long: LongFormatterConfig::default(),
-            table: TableFormatterConfig::default(),
-            sizemap: SizeMapConfig::default(),
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -355,9 +343,7 @@ pub fn load_config_layers(start_dir: Option<&Path>) -> Result<(ConfigLayers, Opt
     let mut effective_config = global_config.clone();
     let profile_path = match find_profile_file(start_dir)? {
         Some(path) => {
-            if let Err(profile_err) = effective_config.apply_profile_file(&path) {
-                return Err(profile_err);
-            }
+            effective_config.apply_profile_file(&path)?;
             Some(path)
         }
         None => None,
@@ -1796,8 +1782,10 @@ mod tests {
         let plugins_dir = config_dir.path().join("plugins");
         let config_path = config_dir.path().join("config.toml");
         fs::create_dir(&plugins_dir).unwrap();
-        let mut config = Config::default();
-        config.plugins_dir = plugins_dir;
+        let mut config = Config {
+            plugins_dir,
+            ..Default::default()
+        };
 
         config
             .set_value_at_path(
@@ -1816,8 +1804,10 @@ mod tests {
         let config_dir = tempfile::tempdir().unwrap();
         let plugins_dir = config_dir.path().join("missing-plugins");
         let config_path = config_dir.path().join("config.toml");
-        let mut config = Config::default();
-        config.plugins_dir = plugins_dir.clone();
+        let config = Config {
+            plugins_dir: plugins_dir.clone(),
+            ..Default::default()
+        };
         fs::write(&config_path, config.generate_config_content()).unwrap();
 
         let loaded = Config::load(&config_path).unwrap();
@@ -1836,8 +1826,10 @@ mod tests {
     #[test]
     fn dynamic_build_rejects_missing_enabled_plugins() {
         let config_dir = tempfile::tempdir().unwrap();
-        let mut config = Config::default();
-        config.plugins_dir = config_dir.path().join("plugins");
+        let mut config = Config {
+            plugins_dir: config_dir.path().join("plugins"),
+            ..Default::default()
+        };
         fs::create_dir(&config.plugins_dir).unwrap();
         config.enabled_plugins = vec!["missing_plugin".to_string()];
 
@@ -1848,8 +1840,10 @@ mod tests {
     #[test]
     fn static_build_ignores_enabled_plugins_during_validation() {
         let config_dir = tempfile::tempdir().unwrap();
-        let mut config = Config::default();
-        config.plugins_dir = config_dir.path().join("plugins");
+        let mut config = Config {
+            plugins_dir: config_dir.path().join("plugins"),
+            ..Default::default()
+        };
         fs::create_dir(&config.plugins_dir).unwrap();
         config.enabled_plugins = vec!["missing_plugin".to_string()];
 

--- a/lla/src/config/mod.rs
+++ b/lla/src/config/mod.rs
@@ -258,6 +258,10 @@ pub struct Config {
     pub enabled_plugins: Vec<String>,
     #[serde(deserialize_with = "deserialize_path_with_tilde")]
     pub plugins_dir: PathBuf,
+    /// Additional read-only or package-manager-owned plugin locations.
+    /// Earlier entries take precedence over later entries.
+    #[serde(default, deserialize_with = "deserialize_paths_with_tilde")]
+    pub plugin_dirs: Vec<PathBuf>,
     #[serde(default, deserialize_with = "deserialize_paths_with_tilde")]
     pub exclude_paths: Vec<PathBuf>,
     pub default_depth: Option<usize>,
@@ -507,6 +511,10 @@ enabled_plugins = {}
 # Directory where plugins are stored
 # Default: ~/.config/lla/plugins
 plugins_dir = "{}"
+
+# Additional plugin locations searched after plugins_dir.
+# Package managers can install plugins into system directories without touching $HOME.
+plugin_dirs = []
 
 # Paths to exclude from listings (tilde is supported)
 # Examples:
@@ -787,6 +795,32 @@ editor = {}"#,
         })
     }
 
+    pub fn plugin_search_paths(&self, primary_override: Option<&Path>) -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+        let primary = primary_override.unwrap_or(&self.plugins_dir).to_path_buf();
+        paths.push(primary);
+        paths.extend(self.plugin_dirs.iter().cloned());
+
+        #[cfg(target_os = "linux")]
+        paths.extend([
+            PathBuf::from("/usr/local/lib/lla/plugins"),
+            PathBuf::from("/usr/lib/lla/plugins"),
+        ]);
+        #[cfg(target_os = "macos")]
+        paths.extend([
+            PathBuf::from("/opt/homebrew/lib/lla/plugins"),
+            PathBuf::from("/usr/local/lib/lla/plugins"),
+        ]);
+        #[cfg(target_os = "windows")]
+        if let Some(program_data) = std::env::var_os("PROGRAMDATA") {
+            paths.push(PathBuf::from(program_data).join("lla").join("plugins"));
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        paths.retain(|path| seen.insert(path.clone()));
+        paths
+    }
+
     #[cfg(feature = "dynamic-plugins")]
     pub fn enable_plugin(&mut self, plugin_name: &str) -> Result<()> {
         self.ensure_plugins_dir().map_err(|e| {
@@ -933,9 +967,12 @@ editor = {}"#,
                 plugin.clone(),
             ];
 
-            let exists = possible_names
-                .iter()
-                .any(|name| self.plugins_dir.join(name).exists());
+            let exists = self.plugin_search_paths(None).iter().any(|plugin_dir| {
+                possible_names
+                    .iter()
+                    .any(|name| plugin_dir.join(name).exists())
+                    || plugin_dir.join(plugin).join("plugin.toml").is_file()
+            });
 
             if !exists {
                 return Err(LlaError::Config(ConfigErrorKind::ValidationError(format!(
@@ -983,6 +1020,26 @@ editor = {}"#,
                     )))
                 })?;
                 self.plugins_dir = new_dir;
+            }
+            ["plugin_dirs"] => {
+                let paths: Vec<String> = serde_json::from_str(value).map_err(|_| {
+                    LlaError::Config(ConfigErrorKind::InvalidValue(
+                        key.to_string(),
+                        "must be a JSON array of plugin directories".to_string(),
+                    ))
+                })?;
+                self.plugin_dirs = paths
+                    .into_iter()
+                    .map(|path| {
+                        if let Some(suffix) = path.strip_prefix("~/") {
+                            dirs::home_dir()
+                                .unwrap_or_else(|| PathBuf::from("."))
+                                .join(suffix)
+                        } else {
+                            PathBuf::from(path)
+                        }
+                    })
+                    .collect();
             }
             ["exclude_paths"] => {
                 // Accept JSON array (e.g., ["~/foo","/bar"]) or a single path string
@@ -1232,6 +1289,7 @@ impl Default for Config {
             default_format: String::from("default"),
             enabled_plugins: vec![],
             plugins_dir: default_plugins_dir,
+            plugin_dirs: Vec::new(),
             exclude_paths: Vec::new(),
             default_depth: Some(3),
             show_icons: false,

--- a/lla/src/filter/pattern.rs
+++ b/lla/src/filter/pattern.rs
@@ -1,6 +1,6 @@
 use super::FileFilter;
 use crate::error::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub struct PatternFilter {
     patterns: Vec<String>,
@@ -23,8 +23,8 @@ impl PatternFilter {
         let patterns = patterns
             .into_iter()
             .map(|p| {
-                if p.starts_with('+') {
-                    p[1..].to_string()
+                if let Some(pattern) = p.strip_prefix('+') {
+                    pattern.to_string()
                 } else {
                     p
                 }
@@ -37,7 +37,7 @@ impl PatternFilter {
         }
     }
 
-    fn matches_pattern(&self, path: &PathBuf) -> bool {
+    fn matches_pattern(&self, path: &Path) -> bool {
         if let Some(name) = path.file_name().and_then(|name| name.to_str()) {
             if self.match_all {
                 return self.patterns.iter().all(|pattern| name.contains(pattern));

--- a/lla/src/filter/range.rs
+++ b/lla/src/filter/range.rs
@@ -255,7 +255,7 @@ fn normalize_numeric_range(range: &mut NumericRange) {
 }
 
 fn normalize_time_range(range: &mut TimeRange) {
-    if let (Some(start), Some(end)) = (range.earliest.clone(), range.latest.clone()) {
+    if let (Some(start), Some(end)) = (range.earliest, range.latest) {
         if start > end {
             range.earliest = Some(end);
             range.latest = Some(start);

--- a/lla/src/formatter/csv.rs
+++ b/lla/src/formatter/csv.rs
@@ -16,7 +16,7 @@ where
     let handle = stdout.lock();
     let mut wtr = csv::Writer::from_writer(handle);
 
-    wtr.write_record(&[
+    wtr.write_record([
         "path",
         "name",
         "extension",

--- a/lla/src/formatter/fuzzy.rs
+++ b/lla/src/formatter/fuzzy.rs
@@ -79,7 +79,7 @@ impl FileFormatter for FuzzyFormatter {
         for (idx, file) in files.iter().enumerate() {
             let line = self.format_entry(file, "", idx == 0, plugin_manager);
             output.push_str(&line);
-            output.push_str("\n");
+            output.push('\n');
         }
 
         Ok(output)

--- a/lla/src/formatter/git.rs
+++ b/lla/src/formatter/git.rs
@@ -465,6 +465,7 @@ impl GitFormatter {
         row
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn prepare_table(
         files: &[DecoratedEntry],
         plugin_manager: &mut PluginManager,

--- a/lla/src/formatter/long.rs
+++ b/lla/src/formatter/long.rs
@@ -7,7 +7,6 @@ use crate::utils::color::*;
 use crate::utils::icons::format_with_icon;
 use chrono::format::{Item, StrftimeItems};
 use chrono::{DateTime, Local};
-use console;
 use lla_plugin_interface::proto::{DecoratedEntry, EntryMetadata};
 use once_cell::sync::Lazy;
 use unicode_width::UnicodeWidthStr;
@@ -172,7 +171,7 @@ impl LongFormatter {
 
         let with_target = if metadata.is_symlink {
             if let Some(target) = entry.custom_fields.get("symlink_target") {
-                if entry.custom_fields.get("invalid_symlink").is_some() {
+                if entry.custom_fields.contains_key("invalid_symlink") {
                     let broken_target = console::style(target).red().bold();
                     format!("{} -> {} (broken)", base_name, broken_target)
                 } else {
@@ -182,7 +181,7 @@ impl LongFormatter {
                         colorize_symlink_target(Path::new(target))
                     )
                 }
-            } else if entry.custom_fields.get("invalid_symlink").is_some() {
+            } else if entry.custom_fields.contains_key("invalid_symlink") {
                 let broken_indicator = console::style("(broken link)").red().bold();
                 format!("{} -> {}", base_name, broken_indicator)
             } else {
@@ -345,8 +344,10 @@ mod tests {
 
     #[test]
     fn relative_dates_take_precedence_over_custom_format() {
-        let mut formatter = LongFormatter::default();
-        formatter.relative_dates = true;
+        let mut formatter = LongFormatter {
+            relative_dates: true,
+            ..Default::default()
+        };
         formatter.set_date_format("%Y-%m-%d %H:%M");
         let seconds = 1_700_000_000;
 

--- a/lla/src/formatter/serializable.rs
+++ b/lla/src/formatter/serializable.rs
@@ -197,10 +197,7 @@ pub fn find_git_root(start: &Path) -> Option<PathBuf> {
         if dir.join(".git").exists() {
             return Some(dir.to_path_buf());
         }
-        match dir.parent() {
-            Some(parent) => dir = parent,
-            None => return None,
-        }
+        dir = dir.parent()?;
     }
 }
 

--- a/lla/src/formatter/serializable.rs
+++ b/lla/src/formatter/serializable.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use chrono::{SecondsFormat, TimeZone, Utc};
 use once_cell::sync::Lazy;
+#[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 use std::sync::Mutex;
 use users::{get_group_by_gid, get_user_by_uid};
@@ -112,10 +113,13 @@ pub fn to_serializable(entry: &DecoratedEntry, git_status: Option<String>) -> Se
     .to_string();
 
     // Extra FS data
+    #[cfg(unix)]
     let (inode, hard_links) = match fs::symlink_metadata(&entry.path) {
-        Ok(m) => (Some(m.ino()), Some(m.nlink() as u64)),
+        Ok(m) => (Some(m.ino()), Some(m.nlink())),
         Err(_) => (None, None),
     };
+    #[cfg(not(unix))]
+    let (inode, hard_links) = (None, None);
 
     let symlink_target = if md.is_symlink {
         if let Some(t) = entry.custom_fields.get("symlink_target") {
@@ -137,6 +141,33 @@ pub fn to_serializable(entry: &DecoratedEntry, git_status: Option<String>) -> Se
     let mut plugin: HashMap<String, serde_json::Value> = HashMap::new();
     for (k, v) in &entry.custom_fields {
         plugin.insert(k.clone(), serde_json::Value::String(v.clone()));
+    }
+    for (key, value) in &entry.typed_fields {
+        let Some(value) = &value.value else {
+            continue;
+        };
+        let json = match value {
+            lla_plugin_interface::proto::typed_value::Value::StringValue(value)
+            | lla_plugin_interface::proto::typed_value::Value::PathValue(value) => {
+                serde_json::Value::String(value.clone())
+            }
+            lla_plugin_interface::proto::typed_value::Value::IntegerValue(value) => {
+                serde_json::Value::Number((*value).into())
+            }
+            lla_plugin_interface::proto::typed_value::Value::FloatValue(value) => {
+                serde_json::Number::from_f64(*value)
+                    .map(serde_json::Value::Number)
+                    .unwrap_or(serde_json::Value::Null)
+            }
+            lla_plugin_interface::proto::typed_value::Value::BooleanValue(value) => {
+                serde_json::Value::Bool(*value)
+            }
+            lla_plugin_interface::proto::typed_value::Value::BytesValue(value)
+            | lla_plugin_interface::proto::typed_value::Value::TimestampValue(value) => {
+                serde_json::Value::Number((*value).into())
+            }
+        };
+        plugin.insert(key.clone(), json);
     }
 
     SerializableEntry {

--- a/lla/src/formatter/sizemap.rs
+++ b/lla/src/formatter/sizemap.rs
@@ -320,6 +320,7 @@ mod tests {
                     gid: 0,
                 }),
                 custom_fields: Default::default(),
+                typed_fields: Default::default(),
             },
             DecoratedEntry {
                 path: "b".to_string(),
@@ -336,6 +337,7 @@ mod tests {
                     gid: 0,
                 }),
                 custom_fields: Default::default(),
+                typed_fields: Default::default(),
             },
         ];
 

--- a/lla/src/formatter/tree.rs
+++ b/lla/src/formatter/tree.rs
@@ -45,7 +45,7 @@ impl TreeFormatter {
             if let Some(parent) = path.parent() {
                 if path_set.contains(parent) {
                     tree.entry(parent.to_path_buf())
-                        .or_insert_with(Vec::new)
+                        .or_default()
                         .push(path.clone());
                     child_paths.insert(path.clone());
                 }
@@ -63,6 +63,7 @@ impl TreeFormatter {
         (root_paths, tree)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn write_tree_recursive(
         &self,
         path: &Path,
@@ -83,9 +84,9 @@ impl TreeFormatter {
         let child_prefix = if is_last { "    " } else { "│   " };
 
         let formatted_name = self.format_entry(path);
-        write!(
+        writeln!(
             writer,
-            "{}{}{}\n",
+            "{}{}{}",
             prefix.bright_black(),
             node_prefix.bright_black(),
             formatted_name

--- a/lla/src/installer.rs
+++ b/lla/src/installer.rs
@@ -1778,10 +1778,7 @@ impl PluginInstaller {
 
         let mut plugins = Vec::new();
         for path in plugin_paths {
-            match Self::load_prebuilt_plugin(&path) {
-                Ok(plugin) => plugins.push(plugin),
-                Err(err) => return Err(err),
-            }
+            plugins.push(Self::load_prebuilt_plugin(&path)?);
         }
 
         let selected_plugins = self.select_prebuilt_plugins(&plugins)?;

--- a/lla/src/installer.rs
+++ b/lla/src/installer.rs
@@ -631,7 +631,7 @@ pub fn upgrade_cli(args: &Args, options: &UpgradeCommand) -> Result<()> {
 
     let install_path_display = install_path.display().to_string();
 
-    let env_lines = vec![
+    let env_lines = [
         format!(
             "  {}  {}  {}",
             ui.muted_text("Platform    "),
@@ -716,7 +716,7 @@ pub fn upgrade_cli(args: &Args, options: &UpgradeCommand) -> Result<()> {
     )?;
 
     let current_version = format!("v{}", env!("CARGO_PKG_VERSION"));
-    let summary_lines = vec![
+    let summary_lines = [
         format!(
             "  {}  {}  {}  {}",
             ui.muted_text("Previous"),
@@ -1891,7 +1891,7 @@ impl PluginInstaller {
 
         let repo_name = url
             .split('/')
-            .last()
+            .next_back()
             .ok_or_else(|| LlaError::Plugin(format!("Invalid GitHub URL: {}", url)))?
             .trim_end_matches(".git");
 
@@ -2204,21 +2204,19 @@ impl PluginInstaller {
         if let Some(pb) = pb {
             if let Some(stderr) = child.stderr.take() {
                 let reader = std::io::BufReader::new(stderr);
-                for line in reader.lines() {
-                    if let Ok(line) = line {
-                        if line.trim().starts_with("Compiling") {
-                            let parts: Vec<&str> = line.split_whitespace().collect();
-                            if parts.len() >= 2 {
-                                let package_info = parts[1..].join(" ");
-                                pb.set_message(format!(
-                                    "{} {}",
-                                    ui.progress_message("Building", &plugin_name),
-                                    ui.muted_text(&format!("({})", package_info))
-                                ));
-                            }
-                        } else if line.trim().starts_with("Finished") {
-                            pb.set_message(ui.progress_message("Finalizing", &plugin_name));
+                for line in reader.lines().map_while(std::result::Result::ok) {
+                    if line.trim().starts_with("Compiling") {
+                        let parts: Vec<&str> = line.split_whitespace().collect();
+                        if parts.len() >= 2 {
+                            let package_info = parts[1..].join(" ");
+                            pb.set_message(format!(
+                                "{} {}",
+                                ui.progress_message("Building", &plugin_name),
+                                ui.muted_text(&format!("({})", package_info))
+                            ));
                         }
+                    } else if line.trim().starts_with("Finished") {
+                        pb.set_message(ui.progress_message("Finalizing", &plugin_name));
                     }
                 }
             }
@@ -2530,7 +2528,7 @@ impl PluginInstaller {
 
                     let repo_name = url
                         .split('/')
-                        .last()
+                        .next_back()
                         .map(|n| n.trim_end_matches(".git"))
                         .unwrap_or(name);
 

--- a/lla/src/installer.rs
+++ b/lla/src/installer.rs
@@ -12,7 +12,10 @@ use libloading::Library;
 #[cfg(feature = "dynamic-plugins")]
 use lla_plugin_interface::proto::{plugin_message::Message, PluginMessage};
 #[cfg(feature = "dynamic-plugins")]
-use lla_plugin_interface::{PluginApi, CURRENT_PLUGIN_API_VERSION};
+use lla_plugin_interface::{
+    manifest::{PluginManifest, PluginRuntime},
+    PluginApi, CURRENT_PLUGIN_API_VERSION, LEGACY_PLUGIN_API_VERSION,
+};
 use lla_plugin_utils::ui::components::{BoxComponent, BoxStyle, LlaDialoguerTheme};
 #[cfg(feature = "dynamic-plugins")]
 use prost::Message as _;
@@ -1339,6 +1342,36 @@ impl PluginInstaller {
 
     #[cfg(feature = "dynamic-plugins")]
     fn load_prebuilt_plugin(path: &Path) -> Result<PrebuiltPlugin> {
+        Self::verify_plugin_package(path)?;
+        let manifest_path = path
+            .parent()
+            .map(|directory| directory.join("plugin.toml"))
+            .unwrap_or_default();
+        if manifest_path.is_file() {
+            let manifest = PluginManifest::from_path(&manifest_path).map_err(LlaError::Plugin)?;
+            if manifest.plugin.runtime != PluginRuntime::Native {
+                return Err(LlaError::Plugin(format!(
+                    "Plugin '{}' uses unsupported prebuilt runtime {:?}",
+                    manifest.plugin.name, manifest.plugin.runtime
+                )));
+            }
+            if !manifest.supports_host_api(CURRENT_PLUGIN_API_VERSION) {
+                return Err(LlaError::Plugin(format!(
+                    "Plugin '{}' supports API {}..={} but lla uses API {}",
+                    manifest.plugin.name,
+                    manifest.plugin.api_min,
+                    manifest.plugin.api_max,
+                    CURRENT_PLUGIN_API_VERSION
+                )));
+            }
+            return Ok(PrebuiltPlugin {
+                path: path.to_path_buf(),
+                name: manifest.plugin.name,
+                version: manifest.plugin.version,
+                description: manifest.plugin.description,
+            });
+        }
+
         unsafe {
             let library = Library::new(path).map_err(|err| {
                 LlaError::Plugin(format!("Failed to load plugin {:?}: {}", path, err))
@@ -1354,12 +1387,12 @@ impl PluginInstaller {
 
             let api = create_fn();
 
-            if (*api).version != CURRENT_PLUGIN_API_VERSION {
+            if (*api).version != LEGACY_PLUGIN_API_VERSION {
                 return Err(LlaError::Plugin(format!(
-                    "Plugin {:?} targets API v{} but lla expects v{}",
+                    "Legacy plugin {:?} targets API v{} but lla expects legacy API v{}",
                     path,
                     (*api).version,
-                    CURRENT_PLUGIN_API_VERSION
+                    LEGACY_PLUGIN_API_VERSION
                 )));
             }
 
@@ -1399,6 +1432,13 @@ impl PluginInstaller {
                 description,
             })
         }
+    }
+
+    #[cfg(feature = "dynamic-plugins")]
+    fn verify_plugin_package(entrypoint: &Path) -> Result<()> {
+        crate::plugin::package::verify_package_checksums(entrypoint)
+            .map(|_| ())
+            .map_err(LlaError::Plugin)
     }
 
     #[cfg(not(feature = "dynamic-plugins"))]
@@ -1481,13 +1521,34 @@ impl PluginInstaller {
             LlaError::Plugin(format!("Plugin {} has an invalid file name", plugin.name))
         })?;
 
-        let destination = self.plugins_dir.join(file_name);
+        let manifest_source = plugin.path.parent().map(|dir| dir.join("plugin.toml"));
+        let is_v2_package = manifest_source.as_ref().is_some_and(|path| path.is_file());
+        let package_dir = self.plugins_dir.join(&plugin.name);
+        let destination = if is_v2_package {
+            fs::create_dir_all(&package_dir)?;
+            package_dir.join(file_name)
+        } else {
+            self.plugins_dir.join(file_name)
+        };
         fs::copy(&plugin.path, &destination).map_err(|err| {
             LlaError::Plugin(format!(
                 "Failed to copy plugin {} to {:?}: {}",
                 plugin.name, destination, err
             ))
         })?;
+
+        if let Some(manifest_source) = manifest_source.filter(|path| path.is_file()) {
+            fs::copy(&manifest_source, package_dir.join("plugin.toml")).map_err(|err| {
+                LlaError::Plugin(format!(
+                    "Failed to install manifest for {}: {}",
+                    plugin.name, err
+                ))
+            })?;
+            let checksums_source = manifest_source.with_file_name("checksums.toml");
+            if checksums_source.is_file() {
+                fs::copy(checksums_source, package_dir.join("checksums.toml"))?;
+            }
+        }
 
         let metadata = PluginMetadata::new(
             plugin.name.clone(),
@@ -2198,9 +2259,18 @@ impl PluginInstaller {
         }
 
         fs::create_dir_all(&self.plugins_dir)?;
+        let manifest_source = plugin_dir.join("plugin.toml");
+        let destination_dir = if manifest_source.is_file() {
+            let destination = self.plugins_dir.join(&plugin_name);
+            fs::create_dir_all(&destination)?;
+            fs::copy(&manifest_source, destination.join("plugin.toml"))?;
+            destination
+        } else {
+            self.plugins_dir.clone()
+        };
 
         for plugin_file in plugin_files.iter() {
-            let dest_path = self.plugins_dir.join(plugin_file.file_name().unwrap());
+            let dest_path = destination_dir.join(plugin_file.file_name().unwrap());
             fs::copy(plugin_file, &dest_path)?;
         }
 
@@ -2730,6 +2800,7 @@ impl PluginInstaller {
 #[cfg(test)]
 mod tests {
     use super::{CliBinaryTarget, PluginInstaller};
+    use std::fs;
     use std::io::Write;
 
     #[test]
@@ -2768,5 +2839,22 @@ mod tests {
             PluginInstaller::calculate_sha256(file.path()).unwrap(),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         );
+    }
+
+    #[test]
+    fn v2_package_checksums_detect_tampering() {
+        let root = tempfile::tempdir().unwrap();
+        let entrypoint = root.path().join("libexample.so");
+        fs::write(&entrypoint, b"plugin").unwrap();
+        let checksum = PluginInstaller::calculate_sha256(&entrypoint).unwrap();
+        fs::write(
+            root.path().join("checksums.toml"),
+            format!("[files]\n\"libexample.so\" = \"{}\"\n", checksum),
+        )
+        .unwrap();
+
+        PluginInstaller::verify_plugin_package(&entrypoint).unwrap();
+        fs::write(&entrypoint, b"tampered").unwrap();
+        assert!(PluginInstaller::verify_plugin_package(&entrypoint).is_err());
     }
 }

--- a/lla/src/lister/archive.rs
+++ b/lla/src/lister/archive.rs
@@ -134,9 +134,11 @@ pub fn read_zip(path: &Path) -> Result<Vec<DecoratedEntry>> {
             abs_src.to_string_lossy().into_owned(),
         );
 
-        // Heuristic for symlink from mode bits (if present)
+        // Heuristic for symlink from POSIX mode bits (if present).
+        const FILE_TYPE_MASK: u32 = 0o170000;
+        const SYMLINK_TYPE: u32 = 0o120000;
         let is_symlink = match file.unix_mode() {
-            Some(m) => (m & (libc::S_IFMT as u32)) == (libc::S_IFLNK as u32),
+            Some(m) => (m & FILE_TYPE_MASK) == SYMLINK_TYPE,
             None => false,
         };
 

--- a/lla/src/lister/archive.rs
+++ b/lla/src/lister/archive.rs
@@ -126,7 +126,7 @@ pub fn read_zip(path: &Path) -> Result<Vec<DecoratedEntry>> {
 
         let mode = file
             .unix_mode()
-            .unwrap_or_else(|| if is_dir { 0o755 } else { 0o644 });
+            .unwrap_or(if is_dir { 0o755 } else { 0o644 });
 
         let mut custom_fields = HashMap::new();
         custom_fields.insert(
@@ -241,9 +241,7 @@ pub fn read_tar<R: Read>(mut reader: R, source_path: &Path) -> Result<Vec<Decora
             header.size().unwrap_or(0)
         };
         let modified = header.mtime().unwrap_or(0);
-        let mode = header
-            .mode()
-            .unwrap_or_else(|_| if is_dir { 0o755 } else { 0o644 });
+        let mode = header.mode().unwrap_or(if is_dir { 0o755 } else { 0o644 });
         let uid = header.uid().unwrap_or(0) as u32;
         let gid = header.gid().unwrap_or(0) as u32;
 
@@ -271,7 +269,7 @@ pub fn read_tar<R: Read>(mut reader: R, source_path: &Path) -> Result<Vec<Decora
                 is_dir,
                 is_file,
                 is_symlink,
-                permissions: mode as u32,
+                permissions: mode,
                 uid,
                 gid,
             }),

--- a/lla/src/lister/archive.rs
+++ b/lla/src/lister/archive.rs
@@ -52,6 +52,7 @@ fn synthesize_directory_entries(entries: &mut Vec<DecoratedEntry>, root_prefix: 
                 gid: 0,
             }),
             custom_fields: HashMap::new(),
+            typed_fields: HashMap::new(),
         });
     }
 }
@@ -98,6 +99,7 @@ pub fn read_zip(path: &Path) -> Result<Vec<DecoratedEntry>> {
             gid: 0,
         }),
         custom_fields: root_fields,
+        typed_fields: HashMap::new(),
     });
 
     for i in 0..archive.len() {
@@ -153,6 +155,7 @@ pub fn read_zip(path: &Path) -> Result<Vec<DecoratedEntry>> {
                 gid: 0,
             }),
             custom_fields,
+            typed_fields: HashMap::new(),
         });
     }
 
@@ -192,6 +195,7 @@ pub fn read_tar<R: Read>(mut reader: R, source_path: &Path) -> Result<Vec<Decora
             gid: 0,
         }),
         custom_fields: root_fields,
+        typed_fields: HashMap::new(),
     });
 
     let entries_iter = match archive.entries() {
@@ -272,6 +276,7 @@ pub fn read_tar<R: Read>(mut reader: R, source_path: &Path) -> Result<Vec<Decora
                 gid,
             }),
             custom_fields,
+            typed_fields: HashMap::new(),
         });
     }
 

--- a/lla/src/lister/fuzzy.rs
+++ b/lla/src/lister/fuzzy.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(dead_code))]
+
 use super::FileLister;
 use crate::utils::color::*;
 use crate::utils::icons::format_with_icon;
@@ -1231,13 +1233,9 @@ impl SearchBar {
                     false
                 }
             }
-            (KeyCode::End, KeyModifiers::NONE) => {
-                if self.cursor_pos < self.query.len() {
-                    self.cursor_pos = self.query.len();
-                    true
-                } else {
-                    false
-                }
+            (KeyCode::End, KeyModifiers::NONE) if self.cursor_pos < self.query.len() => {
+                self.cursor_pos = self.query.len();
+                true
             }
             _ => false,
         }

--- a/lla/src/lister/fuzzy.rs
+++ b/lla/src/lister/fuzzy.rs
@@ -83,7 +83,7 @@ fn stream_gitignore_filtered_entries(
             continue;
         }
 
-        if !entry.file_type().map_or(false, |ft| ft.is_file()) {
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
             continue;
         }
 
@@ -325,14 +325,14 @@ impl SearchIndex {
             .ignore_patterns
             .iter()
             .any(|pattern| {
-                if pattern.starts_with("regex:") {
-                    if let Ok(re) = regex::Regex::new(&pattern[6..]) {
+                if let Some(pattern) = pattern.strip_prefix("regex:") {
+                    if let Ok(re) = regex::Regex::new(pattern) {
                         re.is_match(&path_str)
                     } else {
                         false
                     }
-                } else if pattern.starts_with("glob:") {
-                    if let Ok(glob) = glob::Pattern::new(&pattern[5..]) {
+                } else if let Some(pattern) = pattern.strip_prefix("glob:") {
+                    if let Ok(glob) = glob::Pattern::new(pattern) {
                         glob.matches(&path_str)
                     } else {
                         false
@@ -544,7 +544,7 @@ impl FuzzyLister {
                 let total_indexed = Arc::clone(&total_indexed_clone);
                 Box::new(move |entry| {
                     if let Ok(entry) = entry {
-                        if entry.file_type().map_or(false, |ft| ft.is_file()) {
+                        if entry.file_type().is_some_and(|ft| ft.is_file()) {
                             let _ = tx.send(FileEntry::new(entry.into_path()));
                             total_indexed.fetch_add(1, AtomicOrdering::SeqCst);
                         }

--- a/lla/src/main.rs
+++ b/lla/src/main.rs
@@ -41,9 +41,8 @@ fn run() -> Result<()> {
         if !DYNAMIC_PLUGINS_AVAILABLE {
             return Err(LlaError::Plugin(DYNAMIC_PLUGINS_UNAVAILABLE.to_string()));
         }
-        println!("🔄 Starting plugin cleaning...");
         let mut plugin_manager = PluginManager::new(config.clone());
-        return plugin_manager.clean_plugins();
+        return plugin_manager.clean_plugins(&args.plugins_dir);
     }
 
     let mut plugin_manager = initialize_plugin_manager(&args, &config)?;
@@ -81,13 +80,18 @@ fn load_config() -> Result<(Config, Option<error::LlaError>)> {
 
 fn initialize_plugin_manager(args: &Args, config: &Config) -> Result<PluginManager> {
     let mut plugin_manager = PluginManager::new(config.clone());
+    let plugin_paths = config.plugin_search_paths(Some(&args.plugins_dir));
     match &args.command {
         Some(Command::ListPlugins | Command::Use) => {
-            plugin_manager.discover_plugins(&args.plugins_dir)?;
+            plugin_manager.discover_plugin_paths(&plugin_paths)?;
         }
-        Some(Command::PluginAction(name, _, _)) => {
+        Some(
+            Command::PluginAction(name, _, _)
+            | Command::PluginInfo(name)
+            | Command::PluginPermissions(name),
+        ) => {
             let names = HashSet::from([config.resolve_plugin_alias(name)]);
-            plugin_manager.discover_plugins_named(&args.plugins_dir, &names)?;
+            plugin_manager.discover_plugin_paths_named(&plugin_paths, &names)?;
         }
         None => {
             let mut names: HashSet<_> = config.enabled_plugins.iter().cloned().collect();
@@ -98,7 +102,7 @@ fn initialize_plugin_manager(args: &Args, config: &Config) -> Result<PluginManag
                     .iter()
                     .map(|pipeline| pipeline.plugin.clone()),
             );
-            plugin_manager.discover_plugins_named(&args.plugins_dir, &names)?;
+            plugin_manager.discover_plugin_paths_named(&plugin_paths, &names)?;
         }
         _ => {}
     }

--- a/lla/src/plugin/mod.rs
+++ b/lla/src/plugin/mod.rs
@@ -3,22 +3,124 @@ use crate::error::{LlaError, Result};
 use dashmap::DashMap;
 use libloading::Library;
 use lla_plugin_interface::{
+    manifest::{FieldType, PluginManifest, PluginRuntime, MANIFEST_FILE_NAME},
     proto::{self, plugin_message::Message, PluginMessage},
-    ActionInfo, PluginApi, CURRENT_PLUGIN_API_VERSION,
+    ActionInfo, PluginApi, PluginApiV2, CURRENT_PLUGIN_API_VERSION, LEGACY_PLUGIN_API_VERSION,
 };
 use once_cell::sync::Lazy;
 use prost::Message as _;
 use std::collections::{HashMap, HashSet};
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
-type DecorationCache = DashMap<(String, String), HashMap<String, String>>;
+pub(crate) mod package;
+
+#[derive(Clone, Default)]
+struct CachedDecoration {
+    custom_fields: HashMap<String, String>,
+    typed_fields: HashMap<String, proto::TypedValue>,
+}
+
+type DecorationCache = DashMap<(String, String, String), CachedDecoration>;
 static DECORATION_CACHE: Lazy<DecorationCache> = Lazy::new(DashMap::new);
+const MAX_PLUGIN_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl ScopedEnvVar {
+    fn set_path(key: &'static str, value: &Path) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.take() {
+            std::env::set_var(self.key, previous);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
 
 pub const DYNAMIC_PLUGINS_AVAILABLE: bool = true;
 pub const DYNAMIC_PLUGINS_UNAVAILABLE: &str =
     "Dynamic plugins are unavailable in the static musl build; use a GNU build for plugin support.";
+
+enum PluginHandle {
+    V1(*mut PluginApi),
+    V2(*mut PluginApiV2),
+}
+
+impl Drop for PluginHandle {
+    fn drop(&mut self) {
+        if let Self::V2(api) = self {
+            unsafe {
+                if !api.is_null() {
+                    ((**api).destroy)(*api);
+                    *api = std::ptr::null_mut();
+                }
+            }
+        }
+    }
+}
+
+struct LoadedPlugin {
+    // `api` must be destroyed before the dynamic library is unloaded. Rust
+    // drops fields in declaration order, so keep it before `_library`.
+    api: PluginHandle,
+    // The library must outlive every function pointer stored in `api`.
+    _library: Library,
+    path: PathBuf,
+}
+
+impl PluginHandle {
+    unsafe fn send(&self, request: &[u8]) -> Result<Vec<u8>> {
+        match self {
+            Self::V1(api) => {
+                let response =
+                    ((**api).handle_request)(std::ptr::null_mut(), request.as_ptr(), request.len());
+                if response.ptr.is_null() {
+                    return Err(LlaError::Plugin(
+                        "Plugin returned an empty response".to_string(),
+                    ));
+                }
+                // v1 requires reconstructing plugin-owned memory in the host. It remains
+                // available only as a compatibility path; v2 always frees in the plugin.
+                Ok(response.into_vec())
+            }
+            Self::V2(api) => {
+                let response = ((**api).handle_request)(request.as_ptr(), request.len());
+                if response.ptr.is_null() {
+                    return Err(LlaError::Plugin(
+                        "Plugin returned an empty response".to_string(),
+                    ));
+                }
+                if response.len > MAX_PLUGIN_RESPONSE_BYTES {
+                    ((**api).free_response)(response);
+                    return Err(LlaError::Plugin(format!(
+                        "Plugin response exceeds the {} MiB limit",
+                        MAX_PLUGIN_RESPONSE_BYTES / (1024 * 1024)
+                    )));
+                }
+                let bytes = std::slice::from_raw_parts(response.ptr, response.len).to_vec();
+                ((**api).free_response)(response);
+                Ok(bytes)
+            }
+        }
+    }
+
+    fn is_v2(&self) -> bool {
+        matches!(self, Self::V2(_))
+    }
+}
 
 fn normalize_plugin_format(format: &str) -> Option<&'static str> {
     match format {
@@ -35,9 +137,11 @@ fn plugin_name_hint(path: &Path) -> Option<String> {
 }
 
 pub struct PluginManager {
-    plugins: HashMap<String, (Library, *mut PluginApi)>,
+    plugins: HashMap<String, LoadedPlugin>,
     loaded_paths: HashSet<PathBuf>,
     supported_formats: HashMap<String, HashSet<String>>,
+    manifests: HashMap<String, PluginManifest>,
+    shadowed_plugins: Vec<(String, PathBuf)>,
     pub enabled_plugins: HashSet<String>,
     config: Config,
 }
@@ -49,12 +153,19 @@ impl PluginManager {
             plugins: HashMap::new(),
             loaded_paths: HashSet::new(),
             supported_formats: HashMap::new(),
+            manifests: HashMap::new(),
+            shadowed_plugins: Vec::new(),
             enabled_plugins,
             config,
         }
     }
 
-    fn _convert_metadata(metadata: &std::fs::Metadata) -> proto::EntryMetadata {
+    fn convert_metadata(metadata: &std::fs::Metadata) -> proto::EntryMetadata {
+        #[cfg(unix)]
+        let (permissions, uid, gid) = (metadata.mode(), metadata.uid(), metadata.gid());
+        #[cfg(not(unix))]
+        let (permissions, uid, gid) = (0, 0, 0);
+
         proto::EntryMetadata {
             size: metadata.len(),
             modified: metadata
@@ -84,14 +195,14 @@ impl PluginManager {
             is_dir: metadata.is_dir(),
             is_file: metadata.is_file(),
             is_symlink: metadata.is_symlink(),
-            permissions: metadata.mode(),
-            uid: metadata.uid(),
-            gid: metadata.gid(),
+            permissions,
+            uid,
+            gid,
         }
     }
 
     fn send_request(&self, plugin_name: &str, request: PluginMessage) -> Result<PluginMessage> {
-        if let Some((_, api)) = self.plugins.get(plugin_name) {
+        if let Some(plugin) = self.plugins.get(plugin_name) {
             let mut buf = Vec::with_capacity(request.encoded_len());
             request.encode(&mut buf).map_err(|e| {
                 LlaError::Plugin(format!(
@@ -100,25 +211,15 @@ impl PluginManager {
                 ))
             })?;
 
-            unsafe {
-                let raw_response =
-                    ((**api).handle_request)(std::ptr::null_mut(), buf.as_ptr(), buf.len());
-                if raw_response.ptr.is_null() {
-                    return Err(LlaError::Plugin(format!(
-                        "Plugin '{}' returned an empty response",
-                        plugin_name
-                    )));
-                }
-                let response_vec = raw_response.into_vec();
-                let response_msg =
-                    proto::PluginMessage::decode(&response_vec[..]).map_err(|e| {
-                        LlaError::Plugin(format!(
-                            "Failed to decode response from plugin '{}': {}",
-                            plugin_name, e
-                        ))
-                    })?;
-                Ok(response_msg)
-            }
+            let response_vec = unsafe { plugin.api.send(&buf) }.map_err(|error| {
+                LlaError::Plugin(format!("Plugin '{}' failed: {}", plugin_name, error))
+            })?;
+            proto::PluginMessage::decode(&response_vec[..]).map_err(|e| {
+                LlaError::Plugin(format!(
+                    "Failed to decode response from plugin '{}': {}",
+                    plugin_name, e
+                ))
+            })
         } else {
             Err(LlaError::Plugin(format!(
                 "Plugin '{}' not found",
@@ -203,6 +304,14 @@ impl PluginManager {
     pub fn list_plugins(&mut self) -> Vec<(String, String, String)> {
         let mut result = Vec::new();
         for plugin_name in self.plugins.keys() {
+            if let Some(manifest) = self.manifests.get(plugin_name) {
+                result.push((
+                    manifest.plugin.name.clone(),
+                    manifest.plugin.version.clone(),
+                    manifest.plugin.description.clone(),
+                ));
+                continue;
+            }
             let name = match self
                 .send_request(
                     plugin_name,
@@ -292,101 +401,111 @@ impl PluginManager {
         }
 
         unsafe {
-            match Library::new(&path) {
-                Ok(library) => {
-                    match library.get::<unsafe fn() -> *mut PluginApi>(b"_plugin_create") {
-                        Ok(create_fn) => {
-                            let api = create_fn();
-                            if (*api).version != CURRENT_PLUGIN_API_VERSION {
-                                eprintln!(
-                                    "⚠️ Plugin version mismatch for {:?}: expected {}, got {} run `lla clean` to remove invalid plugins",
-                                    path,
-                                    CURRENT_PLUGIN_API_VERSION,
-                                    (*api).version
-                                );
-                                return Ok(());
-                            }
+            let library = Library::new(&path).map_err(|error| {
+                LlaError::Plugin(format!(
+                    "Failed to load plugin library {}: {error}",
+                    path.display()
+                ))
+            })?;
 
-                            let request = PluginMessage {
-                                message: Some(Message::GetName(true)),
-                            };
-                            let mut buf = Vec::with_capacity(request.encoded_len());
-                            if let Err(e) = request.encode(&mut buf) {
-                                eprintln!("⚠️ Failed to encode name request for {:?}: {}", path, e);
-                                return Ok(());
-                            }
-
-                            match ((*api).handle_request)(
-                                std::ptr::null_mut(),
-                                buf.as_ptr(),
-                                buf.len(),
-                            ) {
-                                raw_response => {
-                                    if raw_response.ptr.is_null() {
-                                        eprintln!(
-                                            "⚠️ Plugin returned an empty response for {:?}",
-                                            path
-                                        );
-                                        return Ok(());
-                                    }
-                                    let response_vec = raw_response.into_vec();
-                                    match proto::PluginMessage::decode(&response_vec[..]) {
-                                        Ok(response_msg) => match response_msg.message {
-                                            Some(Message::NameResponse(name)) => {
-                                                if let std::collections::hash_map::Entry::Vacant(
-                                                    e,
-                                                ) = self.plugins.entry(name)
-                                                {
-                                                    e.insert((library, api));
-                                                    self.loaded_paths.insert(path);
-                                                }
-                                            }
-                                            _ => eprintln!(
-                                                "⚠️ Failed to get plugin name for {:?}",
-                                                path
-                                            ),
-                                        },
-                                        Err(e) => eprintln!(
-                                            "⚠️ Failed to decode response for {:?}: {}",
-                                            path, e
-                                        ),
-                                    }
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            eprintln!("⚠️ Plugin doesn't have a create function {:?}: {}", path, e)
-                        }
-                    }
+            let api = if let Ok(create_v2) =
+                library.get::<unsafe fn() -> *mut PluginApiV2>(b"_plugin_create_v2")
+            {
+                let api = create_v2();
+                if api.is_null() {
+                    return Err(LlaError::Plugin(format!(
+                        "Plugin {} returned a null v2 API",
+                        path.display()
+                    )));
                 }
-                Err(e) => eprintln!("⚠️ Failed to load plugin library {:?}: {}", path, e),
+                let compatible = (*api).abi_version == CURRENT_PLUGIN_API_VERSION
+                    && (*api).min_host_api <= CURRENT_PLUGIN_API_VERSION
+                    && (*api).max_host_api >= CURRENT_PLUGIN_API_VERSION;
+                let handle = PluginHandle::V2(api);
+                if !compatible {
+                    return Err(LlaError::Plugin(format!(
+                        "Plugin {} has an incompatible v2 API",
+                        path.display()
+                    )));
+                }
+                handle
+            } else if let Ok(create_v1) =
+                library.get::<unsafe fn() -> *mut PluginApi>(b"_plugin_create")
+            {
+                let api = create_v1();
+                if api.is_null() || (*api).version != LEGACY_PLUGIN_API_VERSION {
+                    return Err(LlaError::Plugin(format!(
+                        "Plugin {} has an incompatible legacy API",
+                        path.display()
+                    )));
+                }
+                PluginHandle::V1(api)
+            } else {
+                return Err(LlaError::Plugin(format!(
+                    "Plugin {} has no supported create function",
+                    path.display()
+                )));
+            };
+
+            let request = PluginMessage {
+                message: Some(Message::GetName(true)),
+            };
+            let mut buf = Vec::with_capacity(request.encoded_len());
+            request.encode(&mut buf).map_err(|error| {
+                LlaError::Plugin(format!("Failed to encode plugin name request: {error}"))
+            })?;
+            let response = api.send(&buf)?;
+            let decoded = proto::PluginMessage::decode(&response[..]).map_err(|error| {
+                LlaError::Plugin(format!("Failed to decode plugin name response: {error}"))
+            })?;
+            let name = match decoded.message {
+                Some(Message::NameResponse(name)) => name,
+                _ => {
+                    return Err(LlaError::Plugin(format!(
+                        "Plugin {} returned an invalid name response",
+                        path.display()
+                    )))
+                }
+            };
+
+            if let std::collections::hash_map::Entry::Vacant(entry) = self.plugins.entry(name) {
+                entry.insert(LoadedPlugin {
+                    api,
+                    _library: library,
+                    path: path.clone(),
+                });
+                self.loaded_paths.insert(path);
             }
         }
         Ok(())
     }
 
-    pub fn discover_plugins<P: AsRef<Path>>(&mut self, plugin_dir: P) -> Result<()> {
-        self.discover_plugins_impl(plugin_dir.as_ref(), None)
+    pub fn discover_plugin_paths(&mut self, plugin_dirs: &[PathBuf]) -> Result<()> {
+        for (index, plugin_dir) in plugin_dirs.iter().enumerate() {
+            if index == 0 || plugin_dir.is_dir() {
+                self.discover_plugins_impl(plugin_dir, None)?;
+            }
+        }
+        Ok(())
     }
 
-    pub fn discover_plugins_named<P: AsRef<Path>>(
+    pub fn discover_plugin_paths_named(
         &mut self,
-        plugin_dir: P,
+        plugin_dirs: &[PathBuf],
         names: &HashSet<String>,
     ) -> Result<()> {
-        let plugin_dir = plugin_dir.as_ref();
         if names.is_empty() {
-            if !plugin_dir.is_dir() {
-                fs::create_dir_all(plugin_dir).map_err(|e| {
-                    LlaError::Plugin(format!(
-                        "Failed to create plugin directory {:?}: {}",
-                        plugin_dir, e
-                    ))
-                })?;
+            if let Some(primary) = plugin_dirs.first() {
+                fs::create_dir_all(primary)?;
             }
             return Ok(());
         }
-        self.discover_plugins_impl(plugin_dir, Some(names))
+        for (index, plugin_dir) in plugin_dirs.iter().enumerate() {
+            if index == 0 || plugin_dir.is_dir() {
+                self.discover_plugins_impl(plugin_dir, Some(names))?;
+            }
+        }
+        Ok(())
     }
 
     fn discover_plugins_impl(
@@ -403,14 +522,95 @@ impl PluginManager {
             })?;
         }
 
-        let mut candidates = Vec::new();
-        for entry in fs::read_dir(plugin_dir)? {
-            let entry = entry?;
-            let path = entry.path();
+        let mut paths = fs::read_dir(plugin_dir)?
+            .map(|entry| entry.map(|entry| entry.path()))
+            .collect::<std::io::Result<Vec<_>>>()?;
+        paths.sort();
+
+        let mut package_candidates = Vec::new();
+        let mut legacy_candidates = Vec::new();
+        for path in paths {
+            if is_regular_directory(&path) {
+                let manifest_path = path.join(MANIFEST_FILE_NAME);
+                if is_regular_file(&manifest_path) {
+                    match PluginManifest::from_path(&manifest_path) {
+                        Ok(manifest) => {
+                            if !manifest.supports_host_api(CURRENT_PLUGIN_API_VERSION) {
+                                eprintln!(
+                                    "⚠️ Plugin '{}' does not support host API v{}",
+                                    manifest.plugin.name, CURRENT_PLUGIN_API_VERSION
+                                );
+                                continue;
+                            }
+                            if manifest.plugin.runtime != PluginRuntime::Native {
+                                eprintln!(
+                                    "⚠️ Plugin '{}' uses runtime {:?}, which is not enabled yet",
+                                    manifest.plugin.name, manifest.plugin.runtime
+                                );
+                                continue;
+                            }
+                            if names.is_some_and(|requested| {
+                                !requested.contains(&manifest.plugin.name)
+                                    && !requested.contains(&manifest.plugin.id)
+                            }) {
+                                continue;
+                            }
+                            match resolve_manifest_entrypoint(&path, &manifest.plugin.entrypoint) {
+                                Some(entrypoint) => {
+                                    match package::verify_package_checksums(&entrypoint) {
+                                        Ok(_) => package_candidates.push((
+                                            entrypoint,
+                                            manifest,
+                                            manifest_path,
+                                        )),
+                                        Err(error) => eprintln!(
+                                        "⚠️ Plugin package '{}' failed checksum verification: {}",
+                                        manifest.plugin.name, error
+                                    ),
+                                    }
+                                }
+                                None => eprintln!(
+                                    "⚠️ Plugin '{}' entrypoint '{}' was not found in {}",
+                                    manifest.plugin.name,
+                                    manifest.plugin.entrypoint,
+                                    path.display()
+                                ),
+                            }
+                        }
+                        Err(error) => eprintln!("⚠️ {error}"),
+                    }
+                }
+                continue;
+            }
             if let Some(extension) = path.extension() {
                 if extension == "so" || extension == "dll" || extension == "dylib" {
-                    candidates.push(path);
+                    legacy_candidates.push(path);
                 }
+            }
+        }
+
+        for (entrypoint, manifest, manifest_path) in package_candidates {
+            let name = manifest.plugin.name.clone();
+            if self.plugins.contains_key(&name) {
+                self.shadowed_plugins.push((name, manifest_path));
+                continue;
+            }
+
+            if let Err(error) = self.load_plugin(&entrypoint) {
+                eprintln!(
+                    "⚠️ Failed to load plugin package '{}': {}",
+                    manifest.plugin.name, error
+                );
+                continue;
+            }
+            if self.loaded_plugin_matches_manifest(&manifest, &entrypoint) {
+                self.manifests.insert(name, manifest);
+            } else {
+                self.unload_plugin_path(&entrypoint);
+                eprintln!(
+                    "⚠️ Plugin package '{}' does not match its v2 manifest",
+                    manifest.plugin.name
+                );
             }
         }
 
@@ -419,18 +619,470 @@ impl PluginManager {
             // just the requested libraries on the hot path. If a third-party plugin
             // uses a non-standard filename, fall back to discovery so compatibility
             // and the existing error suggestions are preserved.
-            let (matching, remaining): (Vec<_>, Vec<_>) = candidates
+            let (matching, remaining): (Vec<_>, Vec<_>) = legacy_candidates
                 .into_iter()
                 .partition(|path| plugin_name_hint(path).is_some_and(|name| names.contains(&name)));
 
             self.load_plugin_candidates(matching);
-            if names.iter().any(|name| !self.plugins.contains_key(name)) {
+            let all_requested_loaded = names.iter().all(|requested| {
+                self.plugins.contains_key(requested)
+                    || self
+                        .manifests
+                        .values()
+                        .any(|manifest| manifest.plugin.id == *requested)
+            });
+            if !all_requested_loaded {
                 self.load_plugin_candidates(remaining);
             }
         } else {
-            self.load_plugin_candidates(candidates);
+            self.load_plugin_candidates(legacy_candidates);
         }
 
+        Ok(())
+    }
+
+    pub fn doctor(&self, paths: &[PathBuf]) -> Result<bool> {
+        let mut healthy = true;
+        let mut found = 0usize;
+        let mut seen_names = HashMap::<String, PathBuf>::new();
+        let mut seen_ids = HashMap::<String, PathBuf>::new();
+        let verification_data = tempfile::tempdir().map_err(|error| {
+            LlaError::Plugin(format!(
+                "Failed to isolate plugin verification data: {error}"
+            ))
+        })?;
+        let _data_guard = ScopedEnvVar::set_path("LLA_PLUGIN_DATA_DIR", verification_data.path());
+        println!("Plugin Platform v2 diagnostics");
+
+        for plugin_dir in paths {
+            if !plugin_dir.is_dir() {
+                println!("  · {} (not present)", plugin_dir.display());
+                continue;
+            }
+            println!("  ✓ {}", plugin_dir.display());
+            let mut package_paths = fs::read_dir(plugin_dir)?
+                .map(|entry| entry.map(|entry| entry.path()))
+                .collect::<std::io::Result<Vec<_>>>()?;
+            package_paths.sort();
+            for path in package_paths {
+                if !is_regular_directory(&path) {
+                    continue;
+                }
+                let manifest_path = path.join(MANIFEST_FILE_NAME);
+                if !is_regular_file(&manifest_path) {
+                    continue;
+                }
+                found += 1;
+                match PluginManifest::from_path(&manifest_path) {
+                    Ok(manifest) => {
+                        if let Some(selected) = seen_names.get(&manifest.plugin.name) {
+                            println!(
+                                "    ! {} at {} is shadowed by {}",
+                                manifest.plugin.name,
+                                manifest_path.display(),
+                                selected.display()
+                            );
+                        } else {
+                            seen_names.insert(manifest.plugin.name.clone(), manifest_path.clone());
+                        }
+                        if let Some(selected) = seen_ids.get(&manifest.plugin.id) {
+                            println!(
+                                "    ! ID {} at {} is already provided by {}",
+                                manifest.plugin.id,
+                                manifest_path.display(),
+                                selected.display()
+                            );
+                        } else {
+                            seen_ids.insert(manifest.plugin.id.clone(), manifest_path.clone());
+                        }
+                        let compatible = manifest.supports_host_api(CURRENT_PLUGIN_API_VERSION);
+                        let entrypoint =
+                            resolve_manifest_entrypoint(&path, &manifest.plugin.entrypoint);
+                        let checksum_result = entrypoint.as_ref().map_or(Ok(false), |entrypoint| {
+                            package::verify_package_checksums(entrypoint)
+                        });
+                        let runtime_matches = checksum_result.is_ok()
+                            && entrypoint.as_ref().is_some_and(|entrypoint| {
+                                self.manifest_matches_runtime(&manifest, entrypoint)
+                            });
+                        if compatible && runtime_matches && checksum_result.is_ok() {
+                            println!(
+                                "    ✓ {} v{} (API {}..={}{})",
+                                manifest.plugin.name,
+                                manifest.plugin.version,
+                                manifest.plugin.api_min,
+                                manifest.plugin.api_max,
+                                if matches!(checksum_result, Ok(true)) {
+                                    ", checksums + contract verified"
+                                } else {
+                                    ""
+                                }
+                            );
+                        } else {
+                            healthy = false;
+                            let checksum_error = checksum_result.err();
+                            println!(
+                                "    ✗ {}: {}{}",
+                                manifest.plugin.name,
+                                if !compatible {
+                                    "incompatible API"
+                                } else if entrypoint.is_none() {
+                                    "missing entrypoint"
+                                } else if let Some(error) = checksum_error.as_deref() {
+                                    error
+                                } else if !runtime_matches {
+                                    "manifest/runtime metadata mismatch"
+                                } else {
+                                    ""
+                                },
+                                ""
+                            );
+                        }
+                    }
+                    Err(error) => {
+                        healthy = false;
+                        println!("    ✗ {error}");
+                    }
+                }
+            }
+        }
+        println!("  {} v2 plugin package(s) found", found);
+        if !self.shadowed_plugins.is_empty() {
+            for (name, path) in &self.shadowed_plugins {
+                println!("    ! {name} is shadowed at {}", path.display());
+            }
+        }
+        Ok(healthy)
+    }
+
+    fn manifest_matches_runtime(&self, manifest: &PluginManifest, entrypoint: &Path) -> bool {
+        let mut probe = PluginManager::new(self.config.clone());
+        if let Err(error) = probe.load_plugin(entrypoint) {
+            eprintln!(
+                "⚠️ Plugin '{}' could not be loaded for verification: {}",
+                manifest.plugin.name, error
+            );
+            return false;
+        }
+        if !probe.loaded_plugin_matches_manifest(manifest, entrypoint) {
+            return false;
+        }
+        if let Err(error) = probe.verify_functional_contract(manifest) {
+            eprintln!(
+                "⚠️ Plugin '{}' failed v2 functional verification: {}",
+                manifest.plugin.name, error
+            );
+            return false;
+        }
+        true
+    }
+
+    fn loaded_plugin_matches_manifest(
+        &mut self,
+        manifest: &PluginManifest,
+        entrypoint: &Path,
+    ) -> bool {
+        let Ok(entrypoint) = entrypoint.canonicalize() else {
+            return false;
+        };
+        let Some(plugin) = self.plugins.get(&manifest.plugin.name) else {
+            return false;
+        };
+        if plugin.path != entrypoint || !plugin.api.is_v2() {
+            return false;
+        }
+
+        let runtime_version = self
+            .send_request(
+                &manifest.plugin.name,
+                PluginMessage {
+                    message: Some(Message::GetVersion(true)),
+                },
+            )
+            .ok()
+            .and_then(|response| match response.message {
+                Some(Message::VersionResponse(version)) => Some(version),
+                _ => None,
+            });
+        if runtime_version.as_deref() != Some(manifest.plugin.version.as_str()) {
+            return false;
+        }
+
+        let runtime_formats = self
+            .send_request(
+                &manifest.plugin.name,
+                PluginMessage {
+                    message: Some(Message::GetSupportedFormats(true)),
+                },
+            )
+            .ok()
+            .and_then(|response| match response.message {
+                Some(Message::FormatsResponse(formats)) => Some(formats.formats),
+                _ => None,
+            });
+        let Some(runtime_formats) = runtime_formats else {
+            return false;
+        };
+        let runtime_format_set = runtime_formats.iter().cloned().collect::<HashSet<_>>();
+        if runtime_formats
+            .iter()
+            .any(|format| format.trim().is_empty())
+            || runtime_format_set.len() != runtime_formats.len()
+        {
+            return false;
+        }
+        let declared_formats = manifest
+            .capabilities
+            .formats
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+        if runtime_format_set != declared_formats {
+            return false;
+        }
+
+        let Ok(runtime_actions) = self.get_plugin_actions(&manifest.plugin.name) else {
+            return false;
+        };
+        if runtime_actions.iter().any(|action| {
+            action.name.trim().is_empty()
+                || action.usage.trim().is_empty()
+                || action.description.trim().is_empty()
+        }) {
+            return false;
+        }
+        let runtime_action_set = runtime_actions
+            .iter()
+            .map(|action| action.name.clone())
+            .collect::<HashSet<_>>();
+        if runtime_action_set.len() != runtime_actions.len() {
+            return false;
+        }
+        let declared_actions = manifest
+            .capabilities
+            .actions
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+        runtime_action_set == declared_actions
+    }
+
+    fn verify_functional_contract(&mut self, manifest: &PluginManifest) -> Result<()> {
+        let fixture = tempfile::tempdir().map_err(|error| {
+            LlaError::Plugin(format!(
+                "Failed to create plugin verification fixture: {error}"
+            ))
+        })?;
+        let fixture_path = fixture.path().join("lla-v2-fixture.txt");
+        fs::write(&fixture_path, b"lla plugin platform v2\n")?;
+        let mut entries = Vec::new();
+        for path in [&fixture_path, fixture.path()] {
+            let metadata = fs::metadata(path)?;
+            entries.push(proto::DecoratedEntry {
+                path: path.to_string_lossy().to_string(),
+                metadata: Some(Self::convert_metadata(&metadata)),
+                custom_fields: HashMap::new(),
+                typed_fields: HashMap::new(),
+            });
+        }
+
+        let mut singles = Vec::with_capacity(entries.len());
+        for entry in &entries {
+            let decorated = self
+                .send_request(
+                    &manifest.plugin.name,
+                    PluginMessage {
+                        message: Some(Message::Decorate(entry.clone())),
+                    },
+                )?
+                .message
+                .and_then(|message| match message {
+                    Message::DecoratedResponse(entry) => Some(entry),
+                    _ => None,
+                })
+                .ok_or_else(|| {
+                    LlaError::Plugin(
+                        "single-entry decoration returned the wrong response".to_string(),
+                    )
+                })?;
+            singles.push(decorated);
+        }
+
+        let format = manifest
+            .capabilities
+            .formats
+            .first()
+            .map(String::as_str)
+            .unwrap_or("default");
+        let batch = self
+            .send_request(
+                &manifest.plugin.name,
+                PluginMessage {
+                    message: Some(Message::DecorateBatch(proto::BatchDecorateRequest {
+                        entries,
+                        format: format.to_string(),
+                    })),
+                },
+            )?
+            .message
+            .and_then(|message| match message {
+                Message::DecorateBatchResponse(response)
+                    if response.entries.len() == singles.len() =>
+                {
+                    Some(response.entries)
+                }
+                _ => None,
+            })
+            .ok_or_else(|| {
+                LlaError::Plugin("batch decoration returned the wrong response shape".to_string())
+            })?;
+        if batch != singles {
+            return Err(LlaError::Plugin(
+                "batch decoration does not preserve single-entry behavior".to_string(),
+            ));
+        }
+
+        self.manifests
+            .insert(manifest.plugin.name.clone(), manifest.clone());
+        for entry in &mut singles {
+            self.apply_typed_fields(entry);
+            for field in &manifest.fields {
+                if entry.custom_fields.contains_key(&field.name)
+                    && !entry.typed_fields.contains_key(&field.name)
+                {
+                    return Err(LlaError::Plugin(format!(
+                        "field '{}' cannot be converted to its declared {:?} type",
+                        field.name, field.field_type
+                    )));
+                }
+            }
+        }
+
+        for format in &manifest.capabilities.formats {
+            for entry in &singles {
+                let has_declared_fields = manifest
+                    .fields
+                    .iter()
+                    .any(|field| entry.custom_fields.contains_key(&field.name));
+                let response = self.send_request(
+                    &manifest.plugin.name,
+                    PluginMessage {
+                        message: Some(Message::FormatField(proto::FormatFieldRequest {
+                            entry: Some(entry.clone()),
+                            format: format.clone(),
+                        })),
+                    },
+                )?;
+                match response.message {
+                    Some(Message::FieldResponse(response))
+                        if !has_declared_fields || response.field.is_some() => {}
+                    Some(Message::FieldResponse(_)) => {
+                        return Err(LlaError::Plugin(format!(
+                            "format '{}' omitted present declared fields",
+                            format
+                        )));
+                    }
+                    _ => {
+                        return Err(LlaError::Plugin(format!(
+                            "format '{}' returned the wrong response",
+                            format
+                        )));
+                    }
+                }
+            }
+        }
+
+        let unknown_action = "__lla_v2_contract_probe__";
+        let response = self.send_request(
+            &manifest.plugin.name,
+            PluginMessage {
+                message: Some(Message::Action(proto::ActionRequest {
+                    action: unknown_action.to_string(),
+                    args: Vec::new(),
+                })),
+            },
+        )?;
+        if !matches!(
+            response.message,
+            Some(Message::ActionResponse(proto::ActionResponse {
+                success: false,
+                ..
+            }))
+        ) {
+            return Err(LlaError::Plugin(
+                "action dispatch did not reject an unknown action safely".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn unload_plugin_path(&mut self, path: &Path) {
+        let Ok(path) = path.canonicalize() else {
+            return;
+        };
+        self.plugins.retain(|_, plugin| plugin.path != path);
+        self.loaded_paths.remove(&path);
+    }
+
+    pub fn print_manifest(&self, plugin_name: &str, permissions_only: bool) -> Result<()> {
+        let manifest = self.manifests.get(plugin_name).ok_or_else(|| {
+            LlaError::Plugin(format!(
+                "Plugin '{}' has no v2 manifest or is not installed",
+                plugin_name
+            ))
+        })?;
+
+        if !permissions_only {
+            println!("{} v{}", manifest.plugin.name, manifest.plugin.version);
+            println!("  ID: {}", manifest.plugin.id);
+            println!("  Runtime: {:?}", manifest.plugin.runtime);
+            println!(
+                "  API: {}..={}",
+                manifest.plugin.api_min, manifest.plugin.api_max
+            );
+            if !manifest.plugin.description.is_empty() {
+                println!("  {}", manifest.plugin.description);
+            }
+            if !manifest.capabilities.formats.is_empty() {
+                println!("  Formats: {}", manifest.capabilities.formats.join(", "));
+            }
+            if !manifest.fields.is_empty() {
+                println!(
+                    "  Fields: {}",
+                    manifest
+                        .fields
+                        .iter()
+                        .map(|field| field.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+        }
+
+        println!("Permissions for {}:", manifest.plugin.name);
+        println!(
+            "  Filesystem: {}",
+            if manifest.permissions.filesystem.is_empty() {
+                "none".to_string()
+            } else {
+                manifest.permissions.filesystem.join(", ")
+            }
+        );
+        println!(
+            "  Network: {}",
+            if manifest.permissions.network.is_empty() {
+                "none".to_string()
+            } else {
+                manifest.permissions.network.join(", ")
+            }
+        );
+        println!("  Process execution: {}", manifest.permissions.process);
+        println!("  Clipboard: {}", manifest.permissions.clipboard);
+        println!("  Open URL: {}", manifest.permissions.open_url);
+        if manifest.plugin.runtime == PluginRuntime::Native {
+            println!("  Note: native permissions are declarations; native code is fully trusted.");
+        }
         Ok(())
     }
 
@@ -497,11 +1149,25 @@ impl PluginManager {
         }
 
         let path_str = entry.path.clone();
-        let cache_key = (path_str.clone(), format.to_string());
+        let cache_key = (
+            path_str.clone(),
+            format.to_string(),
+            self.decoration_cache_scope(),
+        );
         if let Some(fields) = DECORATION_CACHE.get(&cache_key) {
-            entry
-                .custom_fields
-                .extend(fields.value().iter().map(|(k, v)| (k.clone(), v.clone())));
+            entry.custom_fields.extend(
+                fields
+                    .custom_fields
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone())),
+            );
+            entry.typed_fields.extend(
+                fields
+                    .typed_fields
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone())),
+            );
+            self.apply_typed_fields(entry);
             return;
         }
 
@@ -516,6 +1182,7 @@ impl PluginManager {
         }
 
         let mut new_decorations = HashMap::with_capacity(supported_names.len() * 2);
+        let mut new_typed_decorations = HashMap::with_capacity(supported_names.len() * 2);
         for name in supported_names {
             let request = PluginMessage {
                 message: Some(Message::Decorate(entry.clone())),
@@ -524,15 +1191,163 @@ impl PluginManager {
             if let Ok(response) = self.send_request(&name, request) {
                 if let Some(Message::DecoratedResponse(decorated)) = response.message {
                     new_decorations.extend(decorated.custom_fields);
+                    new_typed_decorations.extend(decorated.typed_fields);
                 }
             }
         }
 
-        if !new_decorations.is_empty() {
+        if !new_decorations.is_empty() || !new_typed_decorations.is_empty() {
             entry
                 .custom_fields
                 .extend(new_decorations.iter().map(|(k, v)| (k.clone(), v.clone())));
-            DECORATION_CACHE.insert(cache_key, new_decorations);
+            entry.typed_fields.extend(
+                new_typed_decorations
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone())),
+            );
+            DECORATION_CACHE.insert(
+                cache_key,
+                CachedDecoration {
+                    custom_fields: new_decorations,
+                    typed_fields: new_typed_decorations,
+                },
+            );
+        }
+        self.apply_typed_fields(entry);
+    }
+
+    pub fn decorate_entries(&mut self, entries: &mut [proto::DecoratedEntry], format: &str) {
+        let Some(plugin_format) = normalize_plugin_format(format) else {
+            return;
+        };
+        if entries.is_empty() || self.enabled_plugins.is_empty() {
+            return;
+        }
+
+        let cache_scope = self.decoration_cache_scope();
+        let enabled_names: Vec<_> = self.enabled_plugins.iter().cloned().collect();
+        let supported_names: Vec<_> = enabled_names
+            .into_iter()
+            .filter(|name| self.supports_format(name, plugin_format))
+            .collect();
+
+        for name in supported_names {
+            let is_v2 = self
+                .plugins
+                .get(&name)
+                .is_some_and(|plugin| plugin.api.is_v2());
+            if !is_v2 {
+                self.decorate_entries_individually(&name, entries);
+                continue;
+            }
+
+            let request = PluginMessage {
+                message: Some(Message::DecorateBatch(proto::BatchDecorateRequest {
+                    entries: entries.to_vec(),
+                    format: plugin_format.to_string(),
+                })),
+            };
+            let batch_entries = self.send_request(&name, request).ok().and_then(|response| {
+                match response.message {
+                    Some(Message::DecorateBatchResponse(batch))
+                        if batch.entries.len() == entries.len()
+                            && entries
+                                .iter()
+                                .zip(&batch.entries)
+                                .all(|(entry, decorated)| entry.path == decorated.path) =>
+                    {
+                        Some(batch.entries)
+                    }
+                    _ => None,
+                }
+            });
+            if let Some(batch_entries) = batch_entries {
+                for (entry, decorated) in entries.iter_mut().zip(batch_entries) {
+                    entry.custom_fields.extend(decorated.custom_fields);
+                    entry.typed_fields.extend(decorated.typed_fields);
+                }
+            } else {
+                self.decorate_entries_individually(&name, entries);
+            }
+        }
+
+        for entry in entries {
+            self.apply_typed_fields(entry);
+            if !entry.custom_fields.is_empty() || !entry.typed_fields.is_empty() {
+                DECORATION_CACHE.insert(
+                    (entry.path.clone(), format.to_string(), cache_scope.clone()),
+                    CachedDecoration {
+                        custom_fields: entry.custom_fields.clone(),
+                        typed_fields: entry.typed_fields.clone(),
+                    },
+                );
+            }
+        }
+    }
+
+    fn decorate_entries_individually(
+        &self,
+        plugin_name: &str,
+        entries: &mut [proto::DecoratedEntry],
+    ) {
+        for entry in entries {
+            let request = PluginMessage {
+                message: Some(Message::Decorate(entry.clone())),
+            };
+            if let Ok(response) = self.send_request(plugin_name, request) {
+                if let Some(Message::DecoratedResponse(decorated)) = response.message {
+                    entry.custom_fields.extend(decorated.custom_fields);
+                    entry.typed_fields.extend(decorated.typed_fields);
+                }
+            }
+        }
+    }
+
+    fn decoration_cache_scope(&self) -> String {
+        let mut plugins = self.enabled_plugins.iter().cloned().collect::<Vec<_>>();
+        plugins.sort();
+        plugins.join("\0")
+    }
+
+    fn apply_typed_fields(&self, entry: &mut proto::DecoratedEntry) {
+        for manifest in self.manifests.values() {
+            for field in &manifest.fields {
+                let Some(value) = entry.custom_fields.get(&field.name) else {
+                    continue;
+                };
+                let typed = match field.field_type {
+                    FieldType::String => {
+                        Some(proto::typed_value::Value::StringValue(value.clone()))
+                    }
+                    FieldType::Integer => value
+                        .parse::<i64>()
+                        .ok()
+                        .map(proto::typed_value::Value::IntegerValue),
+                    FieldType::Float => value
+                        .parse::<f64>()
+                        .ok()
+                        .map(proto::typed_value::Value::FloatValue),
+                    FieldType::Boolean => value
+                        .parse::<bool>()
+                        .ok()
+                        .map(proto::typed_value::Value::BooleanValue),
+                    FieldType::Bytes => value
+                        .parse::<u64>()
+                        .ok()
+                        .map(proto::typed_value::Value::BytesValue),
+                    FieldType::Timestamp => value
+                        .parse::<u64>()
+                        .ok()
+                        .map(proto::typed_value::Value::TimestampValue),
+                    FieldType::Path => Some(proto::typed_value::Value::PathValue(value.clone())),
+                };
+                if let Some(value) = typed {
+                    entry
+                        .typed_fields
+                        .entry(field.name.clone())
+                        .or_insert(proto::TypedValue { value: Some(value) });
+                }
+            }
         }
     }
 
@@ -567,15 +1382,42 @@ impl PluginManager {
         result
     }
 
-    pub fn clean_plugins(&mut self) -> Result<()> {
+    pub fn clean_plugins(&mut self, plugins_dir: &Path) -> Result<()> {
         println!("🔄 Starting plugin cleaning...");
 
-        let plugins_dir = self.config.plugins_dir.clone();
         let mut failed_plugins = Vec::new();
 
-        for entry in fs::read_dir(&plugins_dir)? {
+        for entry in fs::read_dir(plugins_dir)? {
             let entry = entry?;
             let path = entry.path();
+
+            if path.is_dir() {
+                if path.file_name().and_then(|name| name.to_str()) == Some(".quarantine") {
+                    continue;
+                }
+                let manifest_path = path.join(MANIFEST_FILE_NAME);
+                println!("📦 Checking v2 plugin package: {:?}", path);
+                let valid = is_regular_directory(&path)
+                    && is_regular_file(&manifest_path)
+                    && PluginManifest::from_path(&manifest_path)
+                        .ok()
+                        .filter(|manifest| manifest.supports_host_api(CURRENT_PLUGIN_API_VERSION))
+                        .and_then(|manifest| {
+                            resolve_manifest_entrypoint(&path, &manifest.plugin.entrypoint)
+                                .map(|entrypoint| (manifest, entrypoint))
+                        })
+                        .is_some_and(|(manifest, entrypoint)| {
+                            package::verify_package_checksums(&entrypoint).is_ok()
+                                && self.manifest_matches_runtime(&manifest, &entrypoint)
+                        });
+                if valid {
+                    println!("✅ Plugin package is valid: {:?}", path);
+                } else {
+                    println!("❌ Plugin package is invalid: {:?}", path);
+                    failed_plugins.push(path);
+                }
+                continue;
+            }
 
             if let Some(extension) = path.extension() {
                 if extension == "so" || extension == "dll" || extension == "dylib" {
@@ -600,11 +1442,29 @@ impl PluginManager {
             }
         }
 
+        let quarantine = plugins_dir
+            .join(".quarantine")
+            .join(chrono::Local::now().format("%Y%m%d-%H%M%S").to_string());
         for path in failed_plugins {
-            if let Err(e) = fs::remove_file(&path) {
-                eprintln!("⚠️ Failed to remove invalid plugin {:?}: {}", path, e);
+            fs::create_dir_all(&quarantine)?;
+            let Some(file_name) = path.file_name() else {
+                continue;
+            };
+            let mut destination = quarantine.join(file_name);
+            if destination.exists() {
+                destination = quarantine.join(format!(
+                    "{}-{}",
+                    file_name.to_string_lossy(),
+                    std::process::id()
+                ));
+            }
+            if let Err(e) = fs::rename(&path, &destination) {
+                eprintln!("⚠️ Failed to quarantine invalid plugin {:?}: {}", path, e);
             } else {
-                println!("🗑️ Removed invalid plugin: {:?}", path);
+                println!(
+                    "🗑️ Quarantined invalid plugin at {:?} (recoverable)",
+                    destination
+                );
             }
         }
 
@@ -619,23 +1479,30 @@ impl PluginManager {
                 Err(_) => return Ok(false),
             };
 
-            let create_fn = match library.get::<unsafe fn() -> *mut PluginApi>(b"_plugin_create") {
-                Ok(f) => f,
-                Err(_) => return Ok(false),
+            let api = if let Ok(create_v2) =
+                library.get::<unsafe fn() -> *mut PluginApiV2>(b"_plugin_create_v2")
+            {
+                let api = create_v2();
+                if api.is_null()
+                    || (*api).abi_version != CURRENT_PLUGIN_API_VERSION
+                    || (*api).min_host_api > CURRENT_PLUGIN_API_VERSION
+                    || (*api).max_host_api < CURRENT_PLUGIN_API_VERSION
+                {
+                    return Ok(false);
+                }
+                PluginHandle::V2(api)
+            } else {
+                let create_v1 =
+                    match library.get::<unsafe fn() -> *mut PluginApi>(b"_plugin_create") {
+                        Ok(create) => create,
+                        Err(_) => return Ok(false),
+                    };
+                let api = create_v1();
+                if api.is_null() || (*api).version != LEGACY_PLUGIN_API_VERSION {
+                    return Ok(false);
+                }
+                PluginHandle::V1(api)
             };
-
-            let api = match create_fn() {
-                api if api.is_null() => return Ok(false),
-                api => api,
-            };
-
-            if (api as usize) % std::mem::align_of::<PluginApi>() != 0 {
-                return Ok(false);
-            }
-
-            if (*api).version != CURRENT_PLUGIN_API_VERSION {
-                return Ok(false);
-            }
 
             let request = PluginMessage {
                 message: Some(Message::GetName(true)),
@@ -645,23 +1512,11 @@ impl PluginManager {
                 return Ok(false);
             }
 
-            let raw_response = match std::panic::catch_unwind(|| {
-                ((*api).handle_request)(std::ptr::null_mut(), buf.as_ptr(), buf.len())
-            }) {
-                Ok(response) => response,
-                Err(_) => return Ok(false),
-            };
-
-            if raw_response.ptr.is_null() || raw_response.len == 0 || raw_response.len > 1024 * 1024
-            {
-                return Ok(false);
-            }
-
-            let response_vec = match std::panic::catch_unwind(|| {
-                Vec::from_raw_parts(raw_response.ptr, raw_response.len, raw_response.capacity)
-            }) {
-                Ok(vec) => vec,
-                Err(_) => return Ok(false),
+            let response_vec = match std::panic::catch_unwind(|| api.send(&buf)) {
+                Ok(Ok(response)) if !response.is_empty() && response.len() <= 1024 * 1024 => {
+                    response
+                }
+                _ => return Ok(false),
             };
 
             match proto::PluginMessage::decode(&response_vec[..]) {
@@ -673,6 +1528,36 @@ impl PluginManager {
             }
         }
     }
+}
+
+fn resolve_manifest_entrypoint(plugin_dir: &Path, entrypoint: &str) -> Option<PathBuf> {
+    let exact = plugin_dir.join(entrypoint);
+    let platform_name = format!(
+        "{}{}{}",
+        std::env::consts::DLL_PREFIX,
+        entrypoint,
+        std::env::consts::DLL_SUFFIX
+    );
+    let without_prefix = format!("{}{}", entrypoint, std::env::consts::DLL_SUFFIX);
+    [
+        exact,
+        plugin_dir.join(platform_name),
+        plugin_dir.join(without_prefix),
+    ]
+    .into_iter()
+    .find(|candidate| is_regular_file(candidate))
+}
+
+fn is_regular_file(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_file())
+        .unwrap_or(false)
+}
+
+fn is_regular_directory(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_dir())
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -698,9 +1583,38 @@ mod tests {
         let mut manager = PluginManager::new(Config::default());
 
         manager
-            .discover_plugins_named(&plugin_dir, &HashSet::new())
+            .discover_plugin_paths_named(&[plugin_dir.clone()], &HashSet::new())
             .unwrap();
 
         assert!(plugin_dir.is_dir());
+    }
+
+    #[test]
+    fn resolves_logical_manifest_entrypoint() {
+        let root = tempfile::tempdir().unwrap();
+        let library = root.path().join(format!(
+            "{}example{}",
+            std::env::consts::DLL_PREFIX,
+            std::env::consts::DLL_SUFFIX
+        ));
+        fs::write(&library, b"not a real library").unwrap();
+        assert_eq!(
+            resolve_manifest_entrypoint(root.path(), "example").as_deref(),
+            Some(library.as_path())
+        );
+    }
+
+    #[test]
+    fn loading_an_invalid_library_returns_an_error() {
+        let root = tempfile::tempdir().unwrap();
+        let library = root.path().join(format!(
+            "{}invalid{}",
+            std::env::consts::DLL_PREFIX,
+            std::env::consts::DLL_SUFFIX
+        ));
+        fs::write(&library, b"not a dynamic library").unwrap();
+        let mut manager = PluginManager::new(Config::default());
+
+        assert!(manager.load_plugin(&library).is_err());
     }
 }

--- a/lla/src/plugin/mod.rs
+++ b/lla/src/plugin/mod.rs
@@ -722,7 +722,7 @@ impl PluginManager {
                             healthy = false;
                             let checksum_error = checksum_result.err();
                             println!(
-                                "    ✗ {}: {}{}",
+                                "    ✗ {}: {}",
                                 manifest.plugin.name,
                                 if !compatible {
                                     "incompatible API"
@@ -734,8 +734,7 @@ impl PluginManager {
                                     "manifest/runtime metadata mismatch"
                                 } else {
                                     ""
-                                },
-                                ""
+                                }
                             );
                         }
                     }
@@ -1583,7 +1582,7 @@ mod tests {
         let mut manager = PluginManager::new(Config::default());
 
         manager
-            .discover_plugin_paths_named(&[plugin_dir.clone()], &HashSet::new())
+            .discover_plugin_paths_named(std::slice::from_ref(&plugin_dir), &HashSet::new())
             .unwrap();
 
         assert!(plugin_dir.is_dir());

--- a/lla/src/plugin/package.rs
+++ b/lla/src/plugin/package.rs
@@ -1,0 +1,131 @@
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::Read;
+use std::path::{Component, Path};
+use toml::Value;
+
+/// Verifies a package's optional checksum inventory. A present inventory must
+/// cover the runtime entrypoint and, for v2 packages, the manifest.
+pub(crate) fn verify_package_checksums(entrypoint: &Path) -> Result<bool, String> {
+    let package_dir = entrypoint
+        .parent()
+        .ok_or_else(|| "plugin entrypoint has no package directory".to_string())?;
+    let checksums_path = package_dir.join("checksums.toml");
+    if !checksums_path.is_file() {
+        return Ok(false);
+    }
+
+    let contents = fs::read_to_string(&checksums_path)
+        .map_err(|error| format!("failed to read {}: {error}", checksums_path.display()))?;
+    let document: Value = toml::from_str(&contents)
+        .map_err(|error| format!("failed to parse {}: {error}", checksums_path.display()))?;
+    let files = document
+        .get("files")
+        .and_then(Value::as_table)
+        .ok_or_else(|| format!("{} is missing a [files] table", checksums_path.display()))?;
+
+    let entrypoint_name = entrypoint
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| "plugin entrypoint has an invalid file name".to_string())?;
+    if !files.contains_key(entrypoint_name) {
+        return Err(format!(
+            "{} does not cover runtime entrypoint '{}'",
+            checksums_path.display(),
+            entrypoint_name
+        ));
+    }
+    if package_dir.join("plugin.toml").is_file() && !files.contains_key("plugin.toml") {
+        return Err(format!(
+            "{} does not cover plugin.toml",
+            checksums_path.display()
+        ));
+    }
+
+    for (relative, expected) in files {
+        let relative_path = Path::new(relative);
+        if relative_path.is_absolute()
+            || relative_path.components().any(|component| {
+                matches!(
+                    component,
+                    Component::ParentDir | Component::RootDir | Component::Prefix(_)
+                )
+            })
+        {
+            return Err(format!(
+                "unsafe checksum path '{}' in {}",
+                relative,
+                checksums_path.display()
+            ));
+        }
+        let expected = expected
+            .as_str()
+            .filter(|value| {
+                value.len() == 64 && value.chars().all(|character| character.is_ascii_hexdigit())
+            })
+            .ok_or_else(|| format!("invalid SHA-256 checksum for '{relative}'"))?;
+        let file = package_dir.join(relative_path);
+        let metadata = fs::symlink_metadata(&file)
+            .map_err(|error| format!("failed to inspect {}: {error}", file.display()))?;
+        if !metadata.file_type().is_file() {
+            return Err(format!(
+                "plugin package checksum target is not a regular file: {}",
+                file.display()
+            ));
+        }
+        let actual = calculate_sha256(&file)?;
+        if !actual.eq_ignore_ascii_case(expected) {
+            return Err(format!(
+                "plugin package checksum mismatch for {}",
+                file.display()
+            ));
+        }
+    }
+
+    Ok(true)
+}
+
+fn calculate_sha256(path: &Path) -> Result<String, String> {
+    let mut file = fs::File::open(path)
+        .map_err(|error| format!("failed to open {}: {error}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 8192];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn checksum_inventory_rejects_symlinked_entrypoints() {
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("actual.so");
+        let entrypoint = root.path().join("plugin.so");
+        let manifest = root.path().join("plugin.toml");
+        fs::write(&target, b"plugin").unwrap();
+        fs::write(&manifest, b"manifest").unwrap();
+        symlink(&target, &entrypoint).unwrap();
+        let entrypoint_hash = calculate_sha256(&target).unwrap();
+        let manifest_hash = calculate_sha256(&manifest).unwrap();
+        fs::write(
+            root.path().join("checksums.toml"),
+            format!(
+                "[files]\n\"plugin.so\" = \"{entrypoint_hash}\"\n\"plugin.toml\" = \"{manifest_hash}\"\n"
+            ),
+        )
+        .unwrap();
+
+        assert!(verify_package_checksums(&entrypoint).is_err());
+    }
+}

--- a/lla/src/plugin/static.rs
+++ b/lla/src/plugin/static.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use crate::error::{LlaError, Result};
 use lla_plugin_interface::{proto, ActionInfo};
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::PathBuf;
 
 pub const DYNAMIC_PLUGINS_AVAILABLE: bool = false;
 pub const DYNAMIC_PLUGINS_UNAVAILABLE: &str =
@@ -36,16 +36,24 @@ impl PluginManager {
         Err(unavailable())
     }
 
-    pub fn discover_plugins<P: AsRef<Path>>(&mut self, _plugin_dir: P) -> Result<()> {
+    pub fn discover_plugin_paths(&mut self, _plugin_dirs: &[PathBuf]) -> Result<()> {
         Ok(())
     }
 
-    pub fn discover_plugins_named<P: AsRef<Path>>(
+    pub fn discover_plugin_paths_named(
         &mut self,
-        _plugin_dir: P,
+        _plugin_dirs: &[PathBuf],
         _names: &HashSet<String>,
     ) -> Result<()> {
         Ok(())
+    }
+
+    pub fn doctor(&self, _paths: &[PathBuf]) -> Result<bool> {
+        Err(unavailable())
+    }
+
+    pub fn print_manifest(&self, _plugin_name: &str, _permissions_only: bool) -> Result<()> {
+        Err(unavailable())
     }
 
     pub fn enable_plugin(&mut self, _name: &str) -> Result<()> {
@@ -58,11 +66,13 @@ impl PluginManager {
 
     pub fn decorate_entry(&mut self, _entry: &mut proto::DecoratedEntry, _format: &str) {}
 
+    pub fn decorate_entries(&mut self, _entries: &mut [proto::DecoratedEntry], _format: &str) {}
+
     pub fn format_fields(&mut self, _entry: &proto::DecoratedEntry, _format: &str) -> Vec<String> {
         Vec::new()
     }
 
-    pub fn clean_plugins(&mut self) -> Result<()> {
+    pub fn clean_plugins(&mut self, _plugins_dir: &std::path::Path) -> Result<()> {
         Err(unavailable())
     }
 }

--- a/lla/src/sorter/alphabetical.rs
+++ b/lla/src/sorter/alphabetical.rs
@@ -14,8 +14,8 @@ impl FileSorter for AlphabeticalSorter {
     ) -> Result<()> {
         entries.par_sort_unstable_by(|(path_a, entry_a), (path_b, entry_b)| {
             if options.dirs_first {
-                let a_is_dir = entry_a.metadata.as_ref().map_or(false, |m| m.is_dir);
-                let b_is_dir = entry_b.metadata.as_ref().map_or(false, |m| m.is_dir);
+                let a_is_dir = entry_a.metadata.as_ref().is_some_and(|m| m.is_dir);
+                let b_is_dir = entry_b.metadata.as_ref().is_some_and(|m| m.is_dir);
 
                 match (a_is_dir, b_is_dir) {
                     (true, false) => {

--- a/lla/src/sorter/date.rs
+++ b/lla/src/sorter/date.rs
@@ -14,8 +14,8 @@ impl FileSorter for DateSorter {
     ) -> Result<()> {
         entries.par_sort_unstable_by(|(_path_a, entry_a), (_path_b, entry_b)| {
             if options.dirs_first {
-                let a_is_dir = entry_a.metadata.as_ref().map_or(false, |m| m.is_dir);
-                let b_is_dir = entry_b.metadata.as_ref().map_or(false, |m| m.is_dir);
+                let a_is_dir = entry_a.metadata.as_ref().is_some_and(|m| m.is_dir);
+                let b_is_dir = entry_b.metadata.as_ref().is_some_and(|m| m.is_dir);
 
                 match (a_is_dir, b_is_dir) {
                     (true, false) => {

--- a/lla/src/sorter/mod.rs
+++ b/lla/src/sorter/mod.rs
@@ -35,13 +35,13 @@ pub(crate) fn natural_cmp(a: &str, b: &str) -> std::cmp::Ordering {
             let mut a_num = 0u64;
             let mut b_num = 0u64;
 
-            while a_chars.peek().map_or(false, |c| c.is_ascii_digit()) {
+            while a_chars.peek().is_some_and(|c| c.is_ascii_digit()) {
                 if let Some(digit) = a_chars.next() {
                     a_num = a_num * 10 + digit.to_digit(10).unwrap() as u64;
                 }
             }
 
-            while b_chars.peek().map_or(false, |c| c.is_ascii_digit()) {
+            while b_chars.peek().is_some_and(|c| c.is_ascii_digit()) {
                 if let Some(digit) = b_chars.next() {
                     b_num = b_num * 10 + digit.to_digit(10).unwrap() as u64;
                 }

--- a/lla/src/sorter/size.rs
+++ b/lla/src/sorter/size.rs
@@ -14,8 +14,8 @@ impl FileSorter for SizeSorter {
     ) -> Result<()> {
         entries.par_sort_unstable_by(|(_path_a, entry_a), (_path_b, entry_b)| {
             if options.dirs_first {
-                let a_is_dir = entry_a.metadata.as_ref().map_or(false, |m| m.is_dir);
-                let b_is_dir = entry_b.metadata.as_ref().map_or(false, |m| m.is_dir);
+                let a_is_dir = entry_a.metadata.as_ref().is_some_and(|m| m.is_dir);
+                let b_is_dir = entry_b.metadata.as_ref().is_some_and(|m| m.is_dir);
 
                 match (a_is_dir, b_is_dir) {
                     (true, false) => {

--- a/lla/src/theme/mod.rs
+++ b/lla/src/theme/mod.rs
@@ -12,7 +12,6 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tempfile;
 
 static NO_COLOR: AtomicBool = AtomicBool::new(false);
 
@@ -37,9 +36,9 @@ fn theme_file_name(path: &Path) -> Result<&OsStr> {
 #[serde(untagged)]
 pub enum ColorValue {
     Named(String),
-    RGB { r: u8, g: u8, b: u8 },
-    RGBA { r: u8, g: u8, b: u8, a: f32 },
-    HSL { h: f32, s: f32, l: f32 },
+    Rgb { r: u8, g: u8, b: u8 },
+    Rgba { r: u8, g: u8, b: u8, a: f32 },
+    Hsl { h: f32, s: f32, l: f32 },
     Hex(String),
     None,
 }
@@ -194,17 +193,17 @@ pub fn color_value_to_color(color_value: &ColorValue) -> Color {
     match color_value {
         ColorValue::None => Color::White,
         ColorValue::Named(name) => str_to_color(name),
-        ColorValue::RGB { r, g, b } => Color::TrueColor {
+        ColorValue::Rgb { r, g, b } => Color::TrueColor {
             r: *r,
             g: *g,
             b: *b,
         },
-        ColorValue::RGBA { r, g, b, a: _ } => Color::TrueColor {
+        ColorValue::Rgba { r, g, b, a: _ } => Color::TrueColor {
             r: *r,
             g: *g,
             b: *b,
         },
-        ColorValue::HSL { h, s, l } => {
+        ColorValue::Hsl { h, s, l } => {
             let rgb = hsl_to_rgb(*h, *s, *l);
             Color::TrueColor {
                 r: rgb.0,
@@ -416,7 +415,7 @@ pub fn get_file_color(path: &std::path::Path) -> Option<Color> {
             return Some(color_value_to_color(color));
         }
 
-        for (group_name, _) in &theme.extensions.groups {
+        for group_name in theme.extensions.groups.keys() {
             if let Some(extensions) = theme.extensions.groups.get(group_name) {
                 if extensions.iter().any(|e| e.to_lowercase() == ext) {
                     if let Some(color) = theme.extensions.colors.get(group_name) {
@@ -431,10 +430,10 @@ pub fn get_file_color(path: &std::path::Path) -> Option<Color> {
 }
 
 fn pattern_matches(pattern: &str, filename: &str) -> bool {
-    if pattern.starts_with('*') {
-        filename.ends_with(&pattern[1..])
-    } else if pattern.ends_with('*') {
-        filename.starts_with(&pattern[..pattern.len() - 1])
+    if let Some(pattern) = pattern.strip_prefix('*') {
+        filename.ends_with(pattern)
+    } else if let Some(pattern) = pattern.strip_suffix('*') {
+        filename.starts_with(pattern)
     } else {
         filename == pattern
     }
@@ -781,13 +780,12 @@ fn render_directory_sample(theme: &Theme) {
         .max(5);
 
     println!(
-        "{} {} {} {} {} {}",
+        "{} {} {} {} {} Name",
         pad_right_plain("Permissions", 12),
         pad_left_plain("Size", max_size_len),
         pad_right_plain("Modified", max_date_len),
         pad_right_plain("User", max_user_len),
-        pad_right_plain("Group", max_group_len),
-        "Name"
+        pad_right_plain("Group", max_group_len)
     );
     for entry in &entries {
         let perms = format_permissions_sample(entry.perms, theme);

--- a/lla/src/utils/cache.rs
+++ b/lla/src/utils/cache.rs
@@ -108,6 +108,7 @@ impl From<SerializableEntry> for DecoratedEntry {
             path: entry.path,
             metadata: entry.metadata.map(EntryMetadata::from),
             custom_fields: entry.custom_fields,
+            typed_fields: Default::default(),
         }
     }
 }

--- a/lla/src/utils/color.rs
+++ b/lla/src/utils/color.rs
@@ -69,11 +69,7 @@ pub fn colorize_file_name_with_icon(path: &Path, content: String) -> ColoredStri
     let name = parts[1];
 
     if is_no_color() {
-        return if path.is_dir() {
-            format!("{} {}", icon, name).normal()
-        } else {
-            format!("{} {}", icon, name).normal()
-        };
+        return format!("{} {}", icon, name).normal();
     }
 
     let theme = get_theme();
@@ -150,11 +146,11 @@ pub fn colorize_permissions(permissions: &Permissions, format: Option<&str>) -> 
     let theme = get_theme();
 
     match format.unwrap_or("symbolic") {
-        "octal" => format_octal_permissions(mode, &theme),
-        "binary" => format_binary_permissions(mode, &theme),
-        "verbose" => format_verbose_permissions(mode, &theme),
-        "compact" => format_compact_permissions(mode, &theme),
-        _ => format_symbolic_permissions(mode, &theme),
+        "octal" => format_octal_permissions(mode, theme),
+        "binary" => format_binary_permissions(mode, theme),
+        "verbose" => format_verbose_permissions(mode, theme),
+        "compact" => format_compact_permissions(mode, theme),
+        _ => format_symbolic_permissions(mode, theme),
     }
 }
 

--- a/lla_plugin_interface/Cargo.toml
+++ b/lla_plugin_interface/Cargo.toml
@@ -12,9 +12,11 @@ categories = ["command-line-utilities"]
 [dependencies]
 serde.workspace = true
 prost.workspace = true
+toml.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true
+protoc-bin-vendored = "3"
 
 [features]
 regenerate-protobuf = []

--- a/lla_plugin_interface/README.md
+++ b/lla_plugin_interface/README.md
@@ -2,6 +2,31 @@
 
 This crate provides a plugin interface for the `lla` command line tool.
 
+## Plugin Platform v2
+
+API v2 exports `_plugin_create_v2` and uses `PluginBufferV2`. A response is
+copied by the host and released through the plugin's own `free_response`
+callback, so Rust allocator ownership never crosses the dynamic-library
+boundary. The host releases the API object through its plugin-owned `destroy`
+callback before unloading the library. The declaration macro catches unwinding
+plugin panics at the FFI boundary and also exports the legacy v1 symbol during
+the migration period.
+
+Every distributed plugin must include a `plugin.toml` validated through
+`lla_plugin_interface::manifest::PluginManifest`. Manifests declare an API
+range instead of a single exact version and describe the plugin's runtime,
+capabilities, permissions, and typed fields. Native permissions are
+declarative; native plugins must be treated as trusted code.
+
+The host accepts a v2 package only when the loaded runtime exports the v2 ABI
+and its name, version, supported formats, and action IDs match the manifest.
+Release checksum inventories are verified before native code is loaded.
+
+The protobuf contract includes batch decoration and typed values. Existing
+plugin implementations receive batch requests through the v2 adapter, which
+serializes them through their established per-entry handler while holding one
+thread-safe plugin instance.
+
 ## Plugin Architecture
 
 The plugin system in `lla` is designed to be robust and version-independent, using a message-passing architecture that ensures ABI compatibility across different Rust versions. Here's how it works:

--- a/lla_plugin_interface/build.rs
+++ b/lla_plugin_interface/build.rs
@@ -8,13 +8,14 @@ fn main() -> Result<()> {
         let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
         println!("cargo:rerun-if-changed=src/plugin.proto");
 
-        let protoc_available =
-            std::env::var("PROTOC").is_ok() || Command::new("protoc").output().is_ok();
+        let protoc_available = std::env::var("PROTOC").is_ok()
+            || Command::new("protoc")
+                .output()
+                .is_ok_and(|output| output.status.success());
         if !protoc_available {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "protoc not found (required for --features regenerate-protobuf). Install protoc or set PROTOC to its path.",
-            ));
+            let protoc = protoc_bin_vendored::protoc_bin_path()
+                .map_err(|error| std::io::Error::other(error.to_string()))?;
+            std::env::set_var("PROTOC", protoc);
         }
 
         prost_build::Config::new()

--- a/lla_plugin_interface/src/generated/mod.rs
+++ b/lla_plugin_interface/src/generated/mod.rs
@@ -35,13 +35,18 @@ pub struct DecoratedEntry {
         ::prost::alloc::string::String,
         ::prost::alloc::string::String,
     >,
+    #[prost(map = "string, message", tag = "4")]
+    pub typed_fields: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        TypedValue,
+    >,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PluginMessage {
     #[prost(
         oneof = "plugin_message::Message",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 101, 102, 103, 104, 105, 106, 107, 108, 109"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110"
     )]
     pub message: ::core::option::Option<plugin_message::Message>,
 }
@@ -66,6 +71,8 @@ pub mod plugin_message {
         Action(super::ActionRequest),
         #[prost(bool, tag = "8")]
         ListActions(bool),
+        #[prost(message, tag = "9")]
+        DecorateBatch(super::BatchDecorateRequest),
         #[prost(string, tag = "101")]
         NameResponse(::prost::alloc::string::String),
         #[prost(string, tag = "102")]
@@ -84,7 +91,50 @@ pub mod plugin_message {
         ErrorResponse(::prost::alloc::string::String),
         #[prost(message, tag = "109")]
         ListActionsResponse(super::ListActionsResponse),
+        #[prost(message, tag = "110")]
+        DecorateBatchResponse(super::BatchDecorateResponse),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TypedValue {
+    #[prost(oneof = "typed_value::Value", tags = "1, 2, 3, 4, 5, 6, 7")]
+    pub value: ::core::option::Option<typed_value::Value>,
+}
+/// Nested message and enum types in `TypedValue`.
+pub mod typed_value {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Value {
+        #[prost(string, tag = "1")]
+        StringValue(::prost::alloc::string::String),
+        #[prost(sint64, tag = "2")]
+        IntegerValue(i64),
+        #[prost(double, tag = "3")]
+        FloatValue(f64),
+        #[prost(bool, tag = "4")]
+        BooleanValue(bool),
+        #[prost(uint64, tag = "5")]
+        BytesValue(u64),
+        #[prost(uint64, tag = "6")]
+        TimestampValue(u64),
+        #[prost(string, tag = "7")]
+        PathValue(::prost::alloc::string::String),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BatchDecorateRequest {
+    #[prost(message, repeated, tag = "1")]
+    pub entries: ::prost::alloc::vec::Vec<DecoratedEntry>,
+    #[prost(string, tag = "2")]
+    pub format: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BatchDecorateResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub entries: ::prost::alloc::vec::Vec<DecoratedEntry>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lla_plugin_interface/src/lib.rs
+++ b/lla_plugin_interface/src/lib.rs
@@ -2,6 +2,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+pub mod manifest;
+#[doc(hidden)]
+pub use prost as prost_runtime;
+
 pub mod proto {
     #[cfg(not(feature = "regenerate-protobuf"))]
     include!("generated/mod.rs");
@@ -108,6 +112,7 @@ impl From<DecoratedEntry> for proto::DecoratedEntry {
             path: entry.path.to_string_lossy().to_string(),
             metadata: Some(entry.metadata.into()),
             custom_fields: entry.custom_fields,
+            typed_fields: HashMap::new(),
         }
     }
 }
@@ -156,7 +161,47 @@ pub struct PluginApi {
     pub free_response: extern "C" fn(*mut RawBuffer),
 }
 
-pub const CURRENT_PLUGIN_API_VERSION: u32 = 1;
+pub const LEGACY_PLUGIN_API_VERSION: u32 = 1;
+pub const CURRENT_PLUGIN_API_VERSION: u32 = 2;
+
+/// A v2 response buffer is always released by the plugin that allocated it.
+/// The host may read `len` bytes from `ptr`, then must call `free_response`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct PluginBufferV2 {
+    pub ptr: *mut u8,
+    pub len: usize,
+}
+
+impl PluginBufferV2 {
+    pub fn from_vec(vec: Vec<u8>) -> Self {
+        let boxed = vec.into_boxed_slice();
+        let len = boxed.len();
+        let ptr = Box::into_raw(boxed) as *mut u8;
+        Self { ptr, len }
+    }
+}
+
+#[repr(C)]
+pub struct PluginApiV2 {
+    pub abi_version: u32,
+    pub min_host_api: u32,
+    pub max_host_api: u32,
+    pub handle_request: extern "C" fn(*const u8, usize) -> PluginBufferV2,
+    pub free_response: extern "C" fn(PluginBufferV2),
+    pub destroy: extern "C" fn(*mut PluginApiV2),
+}
+
+#[doc(hidden)]
+pub fn encode_plugin_error(error: &str) -> Vec<u8> {
+    use prost::Message as _;
+    proto::PluginMessage {
+        message: Some(proto::plugin_message::Message::ErrorResponse(
+            error.to_string(),
+        )),
+    }
+    .encode_to_vec()
+}
 
 #[repr(C)]
 pub struct PluginContext(*mut std::ffi::c_void);
@@ -164,27 +209,33 @@ pub struct PluginContext(*mut std::ffi::c_void);
 #[macro_export]
 macro_rules! declare_plugin {
     ($plugin_type:ty) => {
-        static mut PLUGIN_INSTANCE: Option<$plugin_type> = None;
+        static PLUGIN_INSTANCE: std::sync::OnceLock<std::sync::Mutex<$plugin_type>> =
+            std::sync::OnceLock::new();
 
         #[no_mangle]
         pub extern "C" fn _plugin_create() -> *mut $crate::PluginApi {
             let api = Box::new($crate::PluginApi {
-                version: $crate::CURRENT_PLUGIN_API_VERSION,
+                version: $crate::LEGACY_PLUGIN_API_VERSION,
                 handle_request: {
                     extern "C" fn handle_request(
                         _ctx: *mut std::ffi::c_void,
                         request: *const u8,
                         len: usize,
                     ) -> $crate::RawBuffer {
-                        unsafe {
-                            if PLUGIN_INSTANCE.is_none() {
-                                PLUGIN_INSTANCE = Some(<$plugin_type>::default());
-                            }
-                            let plugin = PLUGIN_INSTANCE.as_mut().unwrap();
-                            let request_slice = std::slice::from_raw_parts(request, len);
-                            let response = plugin.handle_raw_request(request_slice);
-                            $crate::RawBuffer::from_vec(response)
+                        if request.is_null() {
+                            return $crate::RawBuffer::from_vec(Vec::new());
                         }
+                        let request_slice = unsafe { std::slice::from_raw_parts(request, len) };
+                        let plugin = PLUGIN_INSTANCE
+                            .get_or_init(|| std::sync::Mutex::new(<$plugin_type>::default()));
+                        let response = std::panic::catch_unwind(
+                            std::panic::AssertUnwindSafe(|| match plugin.lock() {
+                                Ok(mut plugin) => plugin.handle_raw_request(request_slice),
+                                Err(_) => $crate::encode_plugin_error("plugin state is poisoned"),
+                            }),
+                        )
+                        .unwrap_or_else(|_| $crate::encode_plugin_error("plugin panicked"));
+                        $crate::RawBuffer::from_vec(response)
                     }
                     handle_request
                 },
@@ -200,5 +251,251 @@ macro_rules! declare_plugin {
             });
             Box::into_raw(api)
         }
+
+        #[no_mangle]
+        pub extern "C" fn _plugin_create_v2() -> *mut $crate::PluginApiV2 {
+            extern "C" fn handle_request_v2(
+                request: *const u8,
+                len: usize,
+            ) -> $crate::PluginBufferV2 {
+                if request.is_null() {
+                    return $crate::PluginBufferV2 {
+                        ptr: std::ptr::null_mut(),
+                        len: 0,
+                    };
+                }
+                use $crate::prost_runtime::Message as _;
+                let request_slice = unsafe { std::slice::from_raw_parts(request, len) };
+                let plugin = PLUGIN_INSTANCE
+                    .get_or_init(|| std::sync::Mutex::new(<$plugin_type>::default()));
+                let response = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    match plugin.lock() {
+                        Ok(mut plugin) => match $crate::proto::PluginMessage::decode(request_slice) {
+                            Ok($crate::proto::PluginMessage {
+                                message: Some(
+                                    $crate::proto::plugin_message::Message::DecorateBatch(batch),
+                                ),
+                            }) => {
+                                let mut decorated = Vec::with_capacity(batch.entries.len());
+                                for entry in batch.entries {
+                                    let original = entry.clone();
+                                    let request = $crate::proto::PluginMessage {
+                                        message: Some(
+                                            $crate::proto::plugin_message::Message::Decorate(entry),
+                                        ),
+                                    };
+                                    let mut request_bytes =
+                                        Vec::with_capacity(request.encoded_len());
+                                    if request.encode(&mut request_bytes).is_err() {
+                                        decorated.push(original);
+                                        continue;
+                                    }
+                                    let response = std::panic::catch_unwind(
+                                        std::panic::AssertUnwindSafe(|| {
+                                            <$plugin_type as $crate::Plugin>::handle_raw_request(
+                                                &mut *plugin,
+                                                &request_bytes,
+                                            )
+                                        }),
+                                    )
+                                    .unwrap_or_else(|_| {
+                                        $crate::encode_plugin_error("plugin panicked")
+                                    });
+                                    let decorated_entry = if let Ok(response) =
+                                        $crate::proto::PluginMessage::decode(&response[..])
+                                    {
+                                        if let Some(
+                                            $crate::proto::plugin_message::Message::DecoratedResponse(
+                                                entry,
+                                            ),
+                                        ) = response.message
+                                        {
+                                            entry
+                                        } else {
+                                            original
+                                        }
+                                    } else {
+                                        original
+                                    };
+                                    decorated.push(decorated_entry);
+                                }
+                                let response = $crate::proto::PluginMessage {
+                                    message: Some(
+                                        $crate::proto::plugin_message::Message::DecorateBatchResponse(
+                                            $crate::proto::BatchDecorateResponse {
+                                                entries: decorated,
+                                            },
+                                        ),
+                                    ),
+                                };
+                                let mut bytes = Vec::with_capacity(response.encoded_len());
+                                if response.encode(&mut bytes).is_ok() {
+                                    bytes
+                                } else {
+                                    $crate::encode_plugin_error(
+                                        "failed to encode batch decoration response",
+                                    )
+                                }
+                            }
+                            _ => <$plugin_type as $crate::Plugin>::handle_raw_request(
+                                &mut *plugin,
+                                request_slice,
+                            ),
+                        },
+                        Err(_) => $crate::encode_plugin_error("plugin state is poisoned"),
+                    }
+                }))
+                .unwrap_or_else(|_| $crate::encode_plugin_error("plugin panicked"));
+                $crate::PluginBufferV2::from_vec(response)
+            }
+
+            extern "C" fn free_response_v2(buffer: $crate::PluginBufferV2) {
+                if buffer.ptr.is_null() {
+                    return;
+                }
+                unsafe {
+                    let slice = std::ptr::slice_from_raw_parts_mut(buffer.ptr, buffer.len);
+                    drop(Box::from_raw(slice));
+                }
+            }
+
+            extern "C" fn destroy_v2(api: *mut $crate::PluginApiV2) {
+                if !api.is_null() {
+                    unsafe {
+                        drop(Box::from_raw(api));
+                    }
+                }
+            }
+
+            Box::into_raw(Box::new($crate::PluginApiV2 {
+                abi_version: $crate::CURRENT_PLUGIN_API_VERSION,
+                min_host_api: $crate::CURRENT_PLUGIN_API_VERSION,
+                max_host_api: $crate::CURRENT_PLUGIN_API_VERSION,
+                handle_request: handle_request_v2,
+                free_response: free_response_v2,
+                destroy: destroy_v2,
+            }))
+        }
     };
+}
+
+#[cfg(test)]
+mod v2_tests {
+    use super::*;
+    use prost::Message as _;
+
+    #[derive(Default)]
+    struct EchoPlugin;
+
+    impl Plugin for EchoPlugin {
+        fn handle_raw_request(&mut self, request: &[u8]) -> Vec<u8> {
+            let request = proto::PluginMessage::decode(request).unwrap();
+            let message = match request.message {
+                Some(proto::plugin_message::Message::Decorate(mut entry)) => {
+                    if entry.path == "panic" {
+                        panic!("intentional test panic");
+                    }
+                    if entry.path == "malformed" {
+                        return vec![0xff];
+                    }
+                    entry
+                        .custom_fields
+                        .insert("echo".to_string(), "ok".to_string());
+                    proto::plugin_message::Message::DecoratedResponse(entry)
+                }
+                _ => proto::plugin_message::Message::ErrorResponse("unsupported".to_string()),
+            };
+            let response = proto::PluginMessage {
+                message: Some(message),
+            };
+            response.encode_to_vec()
+        }
+    }
+
+    declare_plugin!(EchoPlugin);
+
+    #[test]
+    fn v2_preserves_legacy_non_batch_request_behavior() {
+        let request = proto::PluginMessage {
+            message: Some(proto::plugin_message::Message::Decorate(
+                proto::DecoratedEntry {
+                    path: "README.md".to_string(),
+                    metadata: Some(proto::EntryMetadata::default()),
+                    custom_fields: HashMap::new(),
+                    typed_fields: HashMap::new(),
+                },
+            )),
+        }
+        .encode_to_vec();
+
+        let v1 = _plugin_create();
+        let v1_response = unsafe {
+            ((*v1).handle_request)(std::ptr::null_mut(), request.as_ptr(), request.len()).into_vec()
+        };
+        unsafe { drop(Box::from_raw(v1)) };
+
+        let v2 = _plugin_create_v2();
+        let v2_buffer = unsafe { ((*v2).handle_request)(request.as_ptr(), request.len()) };
+        let v2_response =
+            unsafe { std::slice::from_raw_parts(v2_buffer.ptr, v2_buffer.len).to_vec() };
+        unsafe {
+            ((*v2).free_response)(v2_buffer);
+            ((*v2).destroy)(v2);
+        }
+
+        assert_eq!(v2_response, v1_response);
+    }
+
+    #[test]
+    fn v2_batch_adapter_returns_plugin_owned_buffer() {
+        let api = _plugin_create_v2();
+        assert!(!api.is_null());
+        let request = proto::PluginMessage {
+            message: Some(proto::plugin_message::Message::DecorateBatch(
+                proto::BatchDecorateRequest {
+                    entries: vec![
+                        proto::DecoratedEntry {
+                            path: "malformed".to_string(),
+                            metadata: Some(proto::EntryMetadata::default()),
+                            custom_fields: HashMap::new(),
+                            typed_fields: HashMap::new(),
+                        },
+                        proto::DecoratedEntry {
+                            path: "panic".to_string(),
+                            metadata: Some(proto::EntryMetadata::default()),
+                            custom_fields: HashMap::new(),
+                            typed_fields: HashMap::new(),
+                        },
+                        proto::DecoratedEntry {
+                            path: "README.md".to_string(),
+                            metadata: Some(proto::EntryMetadata::default()),
+                            custom_fields: HashMap::new(),
+                            typed_fields: HashMap::new(),
+                        },
+                    ],
+                    format: "default".to_string(),
+                },
+            )),
+        }
+        .encode_to_vec();
+
+        let response = unsafe { ((*api).handle_request)(request.as_ptr(), request.len()) };
+        assert!(!response.ptr.is_null());
+        let bytes = unsafe { std::slice::from_raw_parts(response.ptr, response.len).to_vec() };
+        unsafe { ((*api).free_response)(response) };
+
+        let response = proto::PluginMessage::decode(&bytes[..]).unwrap();
+        let Some(proto::plugin_message::Message::DecorateBatchResponse(batch)) = response.message
+        else {
+            panic!("expected batch response");
+        };
+        assert_eq!(batch.entries.len(), 3);
+        assert_eq!(batch.entries[0].path, "malformed");
+        assert!(batch.entries[0].custom_fields.is_empty());
+        assert_eq!(batch.entries[1].path, "panic");
+        assert!(batch.entries[1].custom_fields.is_empty());
+        assert_eq!(batch.entries[2].custom_fields["echo"], "ok");
+
+        unsafe { ((*api).destroy)(api) };
+    }
 }

--- a/lla_plugin_interface/src/manifest.rs
+++ b/lla_plugin_interface/src/manifest.rs
@@ -1,0 +1,368 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Component, Path};
+
+pub const MANIFEST_FILE_NAME: &str = "plugin.toml";
+const FILESYSTEM_PERMISSION_SCOPES: &[&str] = &[
+    "metadata:selection",
+    "metadata:tree",
+    "read:selection",
+    "read:tree",
+    "read:user-path",
+    "write:selected-destination",
+    "write:tree",
+    "write:user-path",
+    "delete:selection",
+    "delete:quarantine",
+];
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginManifest {
+    pub plugin: PluginDescriptor,
+    #[serde(default)]
+    pub capabilities: PluginCapabilities,
+    #[serde(default)]
+    pub permissions: PluginPermissions,
+    #[serde(default)]
+    pub fields: Vec<FieldDescriptor>,
+}
+
+impl PluginManifest {
+    pub fn from_path(path: &Path) -> Result<Self, String> {
+        let source = fs::read_to_string(path)
+            .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+        let manifest: Self = toml::from_str(&source)
+            .map_err(|error| format!("failed to parse {}: {error}", path.display()))?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        validate_identifier("plugin.id", &self.plugin.id)?;
+        validate_identifier("plugin.name", &self.plugin.name)?;
+        if self.plugin.version.trim().is_empty() {
+            return Err("plugin.version must not be empty".to_string());
+        }
+        if self.plugin.api_min == 0 || self.plugin.api_max < self.plugin.api_min {
+            return Err("plugin API range is invalid".to_string());
+        }
+        if self.plugin.entrypoint.trim().is_empty() {
+            return Err("plugin.entrypoint must not be empty".to_string());
+        }
+        let entrypoint = Path::new(&self.plugin.entrypoint);
+        if entrypoint.is_absolute()
+            || !matches!(
+                entrypoint.components().collect::<Vec<_>>().as_slice(),
+                [Component::Normal(_)]
+            )
+        {
+            return Err("plugin.entrypoint must be a single package-local file name".to_string());
+        }
+
+        validate_unique_nonempty("capabilities.formats", &self.capabilities.formats)?;
+        validate_unique_nonempty("capabilities.actions", &self.capabilities.actions)?;
+        validate_unique_nonempty("permissions.filesystem", &self.permissions.filesystem)?;
+        validate_unique_nonempty("permissions.network", &self.permissions.network)?;
+        for scope in &self.permissions.filesystem {
+            if !FILESYSTEM_PERMISSION_SCOPES.contains(&scope.as_str()) {
+                return Err(format!("unknown filesystem permission scope '{scope}'"));
+            }
+        }
+        for domain in &self.permissions.network {
+            if domain != "*"
+                && (domain.starts_with('.')
+                    || domain.ends_with('.')
+                    || domain.contains("..")
+                    || !domain.chars().all(|character| {
+                        character.is_ascii_alphanumeric() || matches!(character, '.' | '-')
+                    }))
+            {
+                return Err(format!("invalid network permission domain '{domain}'"));
+            }
+        }
+
+        let mut fields = HashSet::new();
+        for field in &self.fields {
+            validate_identifier("field name", &field.name)?;
+            if !fields.insert(field.name.as_str()) {
+                return Err(format!("duplicate field name '{}'", field.name));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn supports_host_api(&self, host_api: u32) -> bool {
+        self.plugin.api_min <= host_api && host_api <= self.plugin.api_max
+    }
+}
+
+fn validate_identifier(label: &str, value: &str) -> Result<(), String> {
+    if value.is_empty()
+        || value.trim() != value
+        || !value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "._-".contains(character))
+    {
+        return Err(format!(
+            "{label} must contain only ASCII letters, numbers, '.', '_' or '-'"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_unique_nonempty(label: &str, values: &[String]) -> Result<(), String> {
+    let mut seen = HashSet::new();
+    for value in values {
+        if value.is_empty() || value.trim() != value {
+            return Err(format!("{label} entries must not be empty or padded"));
+        }
+        if !seen.insert(value.as_str()) {
+            return Err(format!("duplicate {label} entry '{value}'"));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginDescriptor {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub api_min: u32,
+    pub api_max: u32,
+    #[serde(default)]
+    pub runtime: PluginRuntime,
+    pub entrypoint: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub license: Option<String>,
+    #[serde(default)]
+    pub repository: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PluginRuntime {
+    #[default]
+    Native,
+    WasmWasi,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginCapabilities {
+    #[serde(default)]
+    pub decorates_entries: bool,
+    #[serde(default)]
+    pub formats: Vec<String>,
+    #[serde(default)]
+    pub actions: Vec<String>,
+    #[serde(default)]
+    pub machine_output: bool,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginPermissions {
+    #[serde(default)]
+    pub filesystem: Vec<String>,
+    #[serde(default)]
+    pub network: Vec<String>,
+    #[serde(default)]
+    pub process: bool,
+    #[serde(default)]
+    pub clipboard: bool,
+    #[serde(default)]
+    pub open_url: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FieldDescriptor {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub field_type: FieldType,
+    #[serde(default)]
+    pub sortable: bool,
+    #[serde(default)]
+    pub filterable: bool,
+    #[serde(default)]
+    pub description: String,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum FieldType {
+    String,
+    Integer,
+    Float,
+    Boolean,
+    Bytes,
+    Timestamp,
+    Path,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_and_validates_manifest() {
+        let manifest: PluginManifest = toml::from_str(
+            r#"
+[plugin]
+id = "dev.lla.example"
+name = "example"
+version = "1.0.0"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "libexample.so"
+
+[capabilities]
+decorates_entries = true
+formats = ["default"]
+
+[[fields]]
+name = "score"
+type = "integer"
+sortable = true
+"#,
+        )
+        .unwrap();
+
+        manifest.validate().unwrap();
+        assert!(manifest.supports_host_api(2));
+        assert!(!manifest.supports_host_api(3));
+    }
+
+    #[test]
+    fn every_workspace_plugin_has_a_valid_v2_manifest() {
+        let plugins_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../plugins");
+        if !plugins_dir.is_dir() {
+            return;
+        }
+
+        let mut plugin_count = 0;
+        for entry in fs::read_dir(&plugins_dir).unwrap() {
+            let plugin_dir = entry.unwrap().path();
+            if !plugin_dir.join("Cargo.toml").is_file() {
+                continue;
+            }
+            plugin_count += 1;
+            let manifest = PluginManifest::from_path(&plugin_dir.join(MANIFEST_FILE_NAME))
+                .unwrap_or_else(|error| panic!("{}: {error}", plugin_dir.display()));
+            assert_eq!(
+                manifest.plugin.name,
+                plugin_dir.file_name().unwrap().to_string_lossy()
+            );
+            assert!(manifest.supports_host_api(crate::CURRENT_PLUGIN_API_VERSION));
+
+            let source = fs::read_to_string(plugin_dir.join("src/lib.rs")).unwrap();
+            assert!(
+                source.contains("declare_plugin!("),
+                "{} does not export the shared v1/v2 plugin ABI",
+                manifest.plugin.name
+            );
+            if source.contains("arboard::Clipboard") {
+                assert!(
+                    manifest.permissions.clipboard,
+                    "{} uses the clipboard without declaring it",
+                    manifest.plugin.name
+                );
+            }
+            let opens_urls = source.contains("xdg-open")
+                || source.contains("Command::new(\"open\")")
+                || source.contains("let open_command = \"start\"")
+                || source.contains("let cmd = \"start\"");
+            if opens_urls {
+                assert!(
+                    manifest.permissions.open_url,
+                    "{} opens URLs without declaring it",
+                    manifest.plugin.name
+                );
+            }
+            if source.contains("Command::new") && !opens_urls {
+                assert!(
+                    manifest.permissions.process,
+                    "{} executes processes without declaring it",
+                    manifest.plugin.name
+                );
+            }
+        }
+        assert!(plugin_count > 0);
+    }
+
+    #[test]
+    fn rejects_entrypoints_outside_the_package() {
+        let mut manifest: PluginManifest = toml::from_str(
+            r#"
+[plugin]
+id = "dev.lla.example"
+name = "example"
+version = "1.0.0"
+api_min = 2
+api_max = 2
+entrypoint = "example"
+"#,
+        )
+        .unwrap();
+
+        manifest.plugin.entrypoint = "../libexample.so".to_string();
+        assert!(manifest.validate().is_err());
+        manifest.plugin.entrypoint = "/tmp/libexample.so".to_string();
+        assert!(manifest.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_capabilities_and_fields() {
+        let manifest: PluginManifest = toml::from_str(
+            r#"
+[plugin]
+id = "dev.lla.example"
+name = "example"
+version = "1.0.0"
+api_min = 2
+api_max = 2
+entrypoint = "example"
+
+[capabilities]
+actions = ["help", "help"]
+
+[[fields]]
+name = "score"
+type = "integer"
+
+[[fields]]
+name = "score"
+type = "integer"
+"#,
+        )
+        .unwrap();
+
+        assert!(manifest.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_or_url_shaped_permissions() {
+        let mut manifest: PluginManifest = toml::from_str(
+            r#"
+[plugin]
+id = "dev.lla.example"
+name = "example"
+version = "1.0.0"
+api_min = 2
+api_max = 2
+entrypoint = "example"
+
+[permissions]
+filesystem = ["read:anywhere"]
+"#,
+        )
+        .unwrap();
+        assert!(manifest.validate().is_err());
+
+        manifest.permissions.filesystem.clear();
+        manifest.permissions.network = vec!["https://example.com".to_string()];
+        assert!(manifest.validate().is_err());
+    }
+}

--- a/lla_plugin_interface/src/plugin.proto
+++ b/lla_plugin_interface/src/plugin.proto
@@ -19,6 +19,7 @@ message DecoratedEntry {
     string path = 1;
     EntryMetadata metadata = 2;
     map<string, string> custom_fields = 3;
+    map<string, TypedValue> typed_fields = 4;
 }
 
 message PluginMessage {
@@ -31,6 +32,7 @@ message PluginMessage {
         FormatFieldRequest format_field = 6;
         ActionRequest action = 7;
         bool list_actions = 8;
+        BatchDecorateRequest decorate_batch = 9;
         string name_response = 101;
         string version_response = 102;
         string description_response = 103;
@@ -40,7 +42,29 @@ message PluginMessage {
         ActionResponse action_response = 107;
         string error_response = 108;
         ListActionsResponse list_actions_response = 109;
+        BatchDecorateResponse decorate_batch_response = 110;
     }
+}
+
+message TypedValue {
+    oneof value {
+        string string_value = 1;
+        sint64 integer_value = 2;
+        double float_value = 3;
+        bool boolean_value = 4;
+        uint64 bytes_value = 5;
+        uint64 timestamp_value = 6;
+        string path_value = 7;
+    }
+}
+
+message BatchDecorateRequest {
+    repeated DecoratedEntry entries = 1;
+    string format = 2;
+}
+
+message BatchDecorateResponse {
+    repeated DecoratedEntry entries = 1;
 }
 
 message FormatFieldRequest {
@@ -75,4 +99,4 @@ message ActionInfo {
 
 message ListActionsResponse {
     repeated ActionInfo actions = 1;
-} 
+}

--- a/lla_plugin_utils/Cargo.toml
+++ b/lla_plugin_utils/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.11" }
+lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.12" }
 serde = { workspace = true }
 colored = { workspace = true }
 toml = { workspace = true }

--- a/lla_plugin_utils/Cargo.toml
+++ b/lla_plugin_utils/Cargo.toml
@@ -2,9 +2,12 @@
 name = "lla_plugin_utils"
 version.workspace = true
 edition.workspace = true
-description.workspace = true
+description = "Shared utilities for building lla plugins"
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+keywords = ["cli", "plugins", "file-management"]
+categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.12" }

--- a/lla_plugin_utils/Cargo.toml
+++ b/lla_plugin_utils/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.5.12" }
 serde = { workspace = true }
+serde_json = { workspace = true }
 colored = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }
@@ -29,3 +30,6 @@ ui = []
 format = []
 syntax = ["syntect", "lazy_static"]
 interactive = []
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/lla_plugin_utils/src/config.rs
+++ b/lla_plugin_utils/src/config.rs
@@ -14,13 +14,16 @@ pub struct ConfigManager<T: PluginConfig> {
 
 impl<T: PluginConfig> ConfigManager<T> {
     pub fn new(plugin_name: &str) -> Self {
-        let config_path = dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(".config")
-            .join("lla")
-            .join("plugins")
-            .join(plugin_name)
-            .join("config.toml");
+        let config_root = std::env::var_os("LLA_PLUGIN_DATA_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                dirs::home_dir()
+                    .unwrap_or_else(|| PathBuf::from("."))
+                    .join(".config")
+                    .join("lla")
+                    .join("plugins")
+            });
+        let config_path = config_root.join(plugin_name).join("config.toml");
 
         if let Some(parent) = config_path.parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {

--- a/lla_plugin_utils/src/lib.rs
+++ b/lla_plugin_utils/src/lib.rs
@@ -2,6 +2,7 @@ pub mod actions;
 pub mod config;
 pub mod format;
 pub mod syntax;
+pub mod trash;
 pub mod ui;
 
 pub use actions::{Action, ActionHelp, ActionRegistry};

--- a/lla_plugin_utils/src/lib.rs
+++ b/lla_plugin_utils/src/lib.rs
@@ -12,7 +12,18 @@ pub use ui::{
     TextBlock, TextStyle,
 };
 
-use lla_plugin_interface::{proto, PluginRequest, PluginResponse};
+use lla_plugin_interface::{proto, DecoratedEntry, PluginRequest, PluginResponse};
+
+fn decode_decorated_entry(entry: proto::DecoratedEntry) -> Result<DecoratedEntry, String> {
+    let metadata = entry
+        .metadata
+        .ok_or_else(|| "Missing metadata in decorated entry".to_string())?;
+    Ok(DecoratedEntry {
+        path: std::path::PathBuf::from(entry.path),
+        metadata: metadata.into(),
+        custom_fields: entry.custom_fields,
+    })
+}
 
 pub struct BasePlugin<C: PluginConfig> {
     config_manager: ConfigManager<C>,
@@ -74,53 +85,14 @@ pub trait ProtobufHandler {
                 Ok(PluginRequest::GetSupportedFormats)
             }
             Some(proto::plugin_message::Message::Decorate(entry)) => {
-                let metadata = entry
-                    .metadata
-                    .map(|m| lla_plugin_interface::EntryMetadata {
-                        size: m.size,
-                        modified: m.modified,
-                        accessed: m.accessed,
-                        created: m.created,
-                        is_dir: m.is_dir,
-                        is_file: m.is_file,
-                        is_symlink: m.is_symlink,
-                        permissions: m.permissions,
-                        uid: m.uid,
-                        gid: m.gid,
-                    })
-                    .ok_or("Missing metadata in decorated entry")?;
-
-                let decorated = lla_plugin_interface::DecoratedEntry {
-                    path: std::path::PathBuf::from(entry.path),
-                    metadata,
-                    custom_fields: entry.custom_fields,
-                };
-                Ok(PluginRequest::Decorate(decorated))
+                Ok(PluginRequest::Decorate(decode_decorated_entry(entry)?))
             }
             Some(proto::plugin_message::Message::FormatField(req)) => {
                 let entry = req.entry.ok_or("Missing entry in format field request")?;
-                let metadata = entry
-                    .metadata
-                    .map(|m| lla_plugin_interface::EntryMetadata {
-                        size: m.size,
-                        modified: m.modified,
-                        accessed: m.accessed,
-                        created: m.created,
-                        is_dir: m.is_dir,
-                        is_file: m.is_file,
-                        is_symlink: m.is_symlink,
-                        permissions: m.permissions,
-                        uid: m.uid,
-                        gid: m.gid,
-                    })
-                    .ok_or("Missing metadata in decorated entry")?;
-
-                let decorated = lla_plugin_interface::DecoratedEntry {
-                    path: std::path::PathBuf::from(entry.path),
-                    metadata,
-                    custom_fields: entry.custom_fields,
-                };
-                Ok(PluginRequest::FormatField(decorated, req.format))
+                Ok(PluginRequest::FormatField(
+                    decode_decorated_entry(entry)?,
+                    req.format,
+                ))
             }
             Some(proto::plugin_message::Message::Action(req)) => {
                 Ok(PluginRequest::PerformAction(req.action, req.args))
@@ -148,25 +120,7 @@ pub trait ProtobufHandler {
                 })
             }
             PluginResponse::Decorated(entry) => {
-                let proto_metadata = proto::EntryMetadata {
-                    size: entry.metadata.size,
-                    modified: entry.metadata.modified,
-                    accessed: entry.metadata.accessed,
-                    created: entry.metadata.created,
-                    is_dir: entry.metadata.is_dir,
-                    is_file: entry.metadata.is_file,
-                    is_symlink: entry.metadata.is_symlink,
-                    permissions: entry.metadata.permissions,
-                    uid: entry.metadata.uid,
-                    gid: entry.metadata.gid,
-                };
-
-                let proto_entry = proto::DecoratedEntry {
-                    path: entry.path.to_string_lossy().to_string(),
-                    metadata: Some(proto_metadata),
-                    custom_fields: entry.custom_fields,
-                };
-                proto::plugin_message::Message::DecoratedResponse(proto_entry)
+                proto::plugin_message::Message::DecoratedResponse(entry.into())
             }
             PluginResponse::FormattedField(field) => {
                 proto::plugin_message::Message::FieldResponse(proto::FormattedFieldResponse {

--- a/lla_plugin_utils/src/trash.rs
+++ b/lla_plugin_utils/src/trash.rs
@@ -107,7 +107,7 @@ impl TrashStore {
             })?;
             records.push(record);
         }
-        records.sort_by(|left, right| right.deleted_at_epoch.cmp(&left.deleted_at_epoch));
+        records.sort_by_key(|record| std::cmp::Reverse(record.deleted_at_epoch));
         Ok(records)
     }
 

--- a/lla_plugin_utils/src/trash.rs
+++ b/lla_plugin_utils/src/trash.rs
@@ -1,0 +1,400 @@
+use chrono::{SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrashRecord {
+    pub id: String,
+    pub original_path: PathBuf,
+    pub stored_path: PathBuf,
+    pub deleted_at: String,
+    pub deleted_at_epoch: i64,
+    pub size: u64,
+    pub is_dir: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct TrashStore {
+    root: PathBuf,
+}
+
+impl TrashStore {
+    pub fn for_plugin_data() -> Self {
+        let data_root = std::env::var_os("LLA_PLUGIN_DATA_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                dirs::home_dir()
+                    .unwrap_or_else(|| PathBuf::from("."))
+                    .join(".config")
+                    .join("lla")
+                    .join("plugins")
+            });
+        Self::new(data_root.join("trash"))
+    }
+
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn put(&self, path: &Path) -> Result<TrashRecord, String> {
+        let metadata = fs::symlink_metadata(path)
+            .map_err(|error| format!("Cannot trash '{}': {error}", path.display()))?;
+        let original_path = absolute_path(path)?;
+        if original_path == self.root || self.root.starts_with(&original_path) {
+            return Err("Refusing to trash the trash store or one of its ancestors".to_string());
+        }
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| format!("Cannot trash '{}': path has no file name", path.display()))?
+            .to_string_lossy();
+        let id = make_id();
+        let stored_path = self.items_dir().join(format!("{id}--{file_name}"));
+        fs::create_dir_all(self.items_dir())
+            .map_err(|error| format!("Failed to create trash storage: {error}"))?;
+        fs::create_dir_all(self.records_dir())
+            .map_err(|error| format!("Failed to create trash metadata storage: {error}"))?;
+        let deleted_at = Utc::now();
+        let record = TrashRecord {
+            id: id.clone(),
+            original_path,
+            stored_path: stored_path.clone(),
+            deleted_at: deleted_at.to_rfc3339_opts(SecondsFormat::Secs, true),
+            deleted_at_epoch: deleted_at.timestamp(),
+            size: path_size(path).unwrap_or(metadata.len()),
+            is_dir: metadata.is_dir(),
+        };
+        self.write_record(&record)?;
+        if let Err(error) = move_path(path, &stored_path) {
+            let _ = fs::remove_file(self.record_path(&record.id));
+            return Err(error);
+        }
+        Ok(record)
+    }
+
+    pub fn list(&self) -> Result<Vec<TrashRecord>, String> {
+        if !self.records_dir().is_dir() {
+            return Ok(Vec::new());
+        }
+        let mut records = Vec::new();
+        for entry in fs::read_dir(self.records_dir())
+            .map_err(|error| format!("Failed to list trash metadata: {error}"))?
+        {
+            let entry = entry.map_err(|error| format!("Failed to list trash metadata: {error}"))?;
+            if entry.path().extension().and_then(|value| value.to_str()) != Some("json") {
+                continue;
+            }
+            let source = fs::read_to_string(entry.path()).map_err(|error| {
+                format!(
+                    "Failed to read trash record '{}': {error}",
+                    entry.path().display()
+                )
+            })?;
+            let record = serde_json::from_str::<TrashRecord>(&source).map_err(|error| {
+                format!(
+                    "Failed to parse trash record '{}': {error}",
+                    entry.path().display()
+                )
+            })?;
+            records.push(record);
+        }
+        records.sort_by(|left, right| right.deleted_at_epoch.cmp(&left.deleted_at_epoch));
+        Ok(records)
+    }
+
+    pub fn restore(&self, id: &str) -> Result<PathBuf, String> {
+        validate_id(id)?;
+        let record = self.read_record(id)?;
+        if !path_exists(&record.stored_path) {
+            return Err(format!("Trashed content for '{id}' is missing"));
+        }
+        let destination = unique_restore_path(&record.original_path);
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("Failed to recreate '{}': {error}", parent.display()))?;
+        }
+        move_path(&record.stored_path, &destination)?;
+        fs::remove_file(self.record_path(id))
+            .map_err(|error| format!("Restored data but failed to remove its record: {error}"))?;
+        Ok(destination)
+    }
+
+    pub fn empty_older_than(&self, days: u64) -> Result<usize, String> {
+        let cutoff = Utc::now().timestamp() - (days as i64).saturating_mul(86_400);
+        let mut removed = 0;
+        for record in self.list()? {
+            if record.deleted_at_epoch > cutoff {
+                continue;
+            }
+            if path_exists(&record.stored_path) {
+                remove_path(&record.stored_path)?;
+            }
+            fs::remove_file(self.record_path(&record.id)).map_err(|error| {
+                format!("Failed to remove trash record '{}': {error}", record.id)
+            })?;
+            removed += 1;
+        }
+        Ok(removed)
+    }
+
+    fn items_dir(&self) -> PathBuf {
+        self.root.join("items")
+    }
+
+    fn records_dir(&self) -> PathBuf {
+        self.root.join("records")
+    }
+
+    fn record_path(&self, id: &str) -> PathBuf {
+        self.records_dir().join(format!("{id}.json"))
+    }
+
+    fn write_record(&self, record: &TrashRecord) -> Result<(), String> {
+        let source = serde_json::to_string_pretty(record)
+            .map_err(|error| format!("Failed to serialize trash record: {error}"))?;
+        fs::write(self.record_path(&record.id), source)
+            .map_err(|error| format!("Failed to save trash record: {error}"))
+    }
+
+    fn read_record(&self, id: &str) -> Result<TrashRecord, String> {
+        let source = fs::read_to_string(self.record_path(id))
+            .map_err(|error| format!("Trash record '{id}' was not found: {error}"))?;
+        serde_json::from_str(&source)
+            .map_err(|error| format!("Trash record '{id}' is invalid: {error}"))
+    }
+}
+
+pub fn remove_path(path: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("Failed to inspect '{}': {error}", path.display()))?;
+    if metadata.file_type().is_symlink() || metadata.is_file() {
+        fs::remove_file(path)
+    } else if metadata.is_dir() {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_file(path)
+    }
+    .map_err(|error| format!("Failed to permanently remove '{}': {error}", path.display()))
+}
+
+fn move_path(source: &Path, destination: &Path) -> Result<(), String> {
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("Failed to create '{}': {error}", parent.display()))?;
+    }
+    match fs::rename(source, destination) {
+        Ok(()) => Ok(()),
+        Err(rename_error) => {
+            if let Err(copy_error) = copy_path(source, destination) {
+                if path_exists(destination) {
+                    let _ = remove_path(destination);
+                }
+                return Err(format!(
+                    "Failed to move '{}' to trash ({rename_error}); copy fallback failed: {copy_error}",
+                    source.display()
+                ));
+            }
+            if let Err(remove_error) = remove_path(source) {
+                let _ = remove_path(destination);
+                return Err(format!(
+                    "Copied '{}' to trash but could not remove the original: {remove_error}",
+                    source.display()
+                ));
+            }
+            Ok(())
+        }
+    }
+}
+
+fn copy_path(source: &Path, destination: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(source)?;
+    if metadata.file_type().is_symlink() {
+        let target_is_dir = fs::metadata(source)
+            .map(|target| target.is_dir())
+            .unwrap_or(false);
+        return copy_symlink(source, destination, target_is_dir);
+    }
+    if metadata.is_file() {
+        fs::copy(source, destination)?;
+        fs::set_permissions(destination, metadata.permissions())?;
+        return Ok(());
+    }
+    fs::create_dir(destination)?;
+    fs::set_permissions(destination, metadata.permissions())?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        copy_path(&entry.path(), &destination.join(entry.file_name()))?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn copy_symlink(source: &Path, destination: &Path, _is_dir: bool) -> io::Result<()> {
+    std::os::unix::fs::symlink(fs::read_link(source)?, destination)
+}
+
+#[cfg(windows)]
+fn copy_symlink(source: &Path, destination: &Path, is_dir: bool) -> io::Result<()> {
+    let target = fs::read_link(source)?;
+    if is_dir {
+        std::os::windows::fs::symlink_dir(target, destination)
+    } else {
+        std::os::windows::fs::symlink_file(target, destination)
+    }
+}
+
+fn path_size(path: &Path) -> io::Result<u64> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.is_file() || metadata.file_type().is_symlink() {
+        return Ok(metadata.len());
+    }
+    let mut total = 0u64;
+    for entry in fs::read_dir(path)? {
+        total = total.saturating_add(path_size(&entry?.path())?);
+    }
+    Ok(total)
+}
+
+fn absolute_path(path: &Path) -> Result<PathBuf, String> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        std::env::current_dir()
+            .map(|current| current.join(path))
+            .map_err(|error| format!("Failed to resolve '{}': {error}", path.display()))
+    }
+}
+
+fn unique_restore_path(original: &Path) -> PathBuf {
+    if !path_exists(original) {
+        return original.to_path_buf();
+    }
+    let parent = original.parent().unwrap_or_else(|| Path::new("."));
+    let stem = original
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("restored");
+    let extension = original.extension().and_then(|value| value.to_str());
+    for suffix in 1.. {
+        let name = match extension {
+            Some(extension) => format!("{stem} (restored {suffix}).{extension}"),
+            None => format!("{stem} (restored {suffix})"),
+        };
+        let candidate = parent.join(name);
+        if !path_exists(&candidate) {
+            return candidate;
+        }
+    }
+    unreachable!()
+}
+
+fn path_exists(path: &Path) -> bool {
+    fs::symlink_metadata(path).is_ok()
+}
+
+fn make_id() -> String {
+    format!(
+        "{}-{}-{}",
+        Utc::now().format("%Y%m%dT%H%M%S%.3fZ"),
+        std::process::id(),
+        NEXT_ID.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn validate_id(id: &str) -> Result<(), String> {
+    if id.is_empty()
+        || !id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '.'))
+    {
+        return Err("Invalid trash record id".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trashes_lists_and_restores_a_file_without_overwriting() {
+        let root = tempfile::tempdir().unwrap();
+        let store = TrashStore::new(root.path().join("store"));
+        let source = root.path().join("note.txt");
+        fs::write(&source, "original").unwrap();
+
+        let record = store.put(&source).unwrap();
+        assert!(!source.exists());
+        assert_eq!(store.list().unwrap(), vec![record.clone()]);
+
+        fs::write(&source, "replacement").unwrap();
+        let restored = store.restore(&record.id).unwrap();
+        assert_ne!(restored, source);
+        assert_eq!(fs::read_to_string(restored).unwrap(), "original");
+        assert!(store.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_is_age_gated() {
+        let root = tempfile::tempdir().unwrap();
+        let store = TrashStore::new(root.path().join("store"));
+        let source = root.path().join("old.txt");
+        fs::write(&source, "old").unwrap();
+        let mut record = store.put(&source).unwrap();
+        record.deleted_at_epoch = 0;
+        store.write_record(&record).unwrap();
+
+        assert_eq!(store.empty_older_than(1).unwrap(), 1);
+        assert!(!record.stored_path.exists());
+    }
+
+    #[test]
+    fn directory_trees_round_trip() {
+        let root = tempfile::tempdir().unwrap();
+        let store = TrashStore::new(root.path().join("store"));
+        let source = root.path().join("project");
+        fs::create_dir(&source).unwrap();
+        fs::write(source.join("README.md"), "restorable").unwrap();
+
+        let record = store.put(&source).unwrap();
+        assert!(record.is_dir);
+        let restored = store.restore(&record.id).unwrap();
+        assert_eq!(
+            fs::read_to_string(restored.join("README.md")).unwrap(),
+            "restorable"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinks_are_moved_without_touching_their_targets() {
+        let root = tempfile::tempdir().unwrap();
+        let store = TrashStore::new(root.path().join("store"));
+        let target = root.path().join("target.txt");
+        let link = root.path().join("link.txt");
+        fs::write(&target, "target").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let record = store.put(&link).unwrap();
+        assert!(target.is_file());
+        assert!(fs::symlink_metadata(&record.stored_path)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        let restored = store.restore(&record.id).unwrap();
+        assert!(fs::symlink_metadata(restored)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert!(target.is_file());
+    }
+}

--- a/plugins.md
+++ b/plugins.md
@@ -27,7 +27,91 @@ cd lla/plugins/
 cargo build --release
 ```
 
-then copy the generated `.so`, `.dll`, or `.dylib` file from the `target/release` directory to your lla plugins directory.
+then create a directory for the plugin under the lla plugins directory and copy
+both its `plugin.toml` and generated `.so`, `.dll`, or `.dylib` into that
+directory. Keeping the manifest beside the entrypoint enables v2 compatibility,
+permissions, and typed-field validation.
+
+## Plugin Platform v2
+
+Bundled plugins use the v2 package layout:
+
+```text
+plugin-name/
+├── plugin.toml
+├── libplugin_name.so   # .dylib on macOS, .dll on Windows
+├── checksums.toml
+└── README.md            # optional
+```
+
+The manifest supplies a stable plugin ID, supported host API range, runtime,
+entrypoint, capabilities, permissions, and typed listing fields. The v2 ABI
+keeps allocation and deallocation inside the plugin and supports batch entry
+decoration. Legacy flat v1 libraries remain loadable during migration.
+Release packages include SHA-256 coverage for both the manifest and native
+entrypoint; installation and `plugin doctor` reject a mismatched package before
+executing it.
+
+A minimal manifest looks like this:
+
+```toml
+[plugin]
+id = "dev.example.my-plugin"
+name = "my_plugin"
+version = "1.0.0"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "my_plugin"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["help"]
+machine_output = true
+
+[permissions]
+filesystem = ["read:selection"]
+
+[[fields]]
+name = "score"
+type = "integer"
+sortable = true
+filterable = true
+```
+
+`entrypoint` is a package-local logical name. lla adds the current platform's
+library prefix and suffix. Manifest IDs, field names, duplicate declarations,
+and entrypoint confinement are validated before loading.
+
+Filesystem permissions use validated scopes such as `metadata:selection`,
+`read:tree`, `write:user-path`, or `delete:quarantine`. Network entries are
+domain names (or `"*"` when the endpoint is inherently dynamic). Each plugin's
+private configuration/data directory is host-managed and implicit; filesystem
+permissions describe access outside that private namespace. Native permissions
+remain declarations because native libraries are trusted code.
+Set `LLA_PLUGIN_DATA_DIR` to relocate the host-managed plugin data root; the
+diagnostic command uses an isolated temporary root automatically.
+
+Useful diagnostics:
+
+```bash
+lla plugin doctor
+lla plugin info file_hash
+lla plugin permissions folder_cleaner
+```
+
+lla searches the writable `plugins_dir` first, followed by configured
+`plugin_dirs` and platform system locations. This allows package managers to
+upgrade system plugins without modifying a user's home directory.
+
+Repository and release verification can run the same manifest, checksum,
+metadata, action, formatter, single-decoration, and batch-decoration checks:
+
+```bash
+./scripts/build_plugins.sh --target "$(rustc -vV | sed -n 's/^host: //p')"
+./scripts/verify_plugins_v2.sh dist/plugins-<os>-<arch>
+```
 
 ## Available Plugins
 

--- a/plugins.md
+++ b/plugins.md
@@ -115,6 +115,11 @@ metadata, action, formatter, single-decoration, and batch-decoration checks:
 
 ## Available Plugins
 
+- [security_audit](https://github.com/chaqchase/lla/tree/main/plugins/security_audit): Audits unsafe permissions, privileged bits, suspicious symlinks, and exposed secret-like files
+- [media_inspector](https://github.com/chaqchase/lla/tree/main/plugins/media_inspector): Reports MIME, image dimensions and EXIF, plus audio/video duration, codecs, and bitrate
+- [project_context](https://github.com/chaqchase/lla/tree/main/plugins/project_context): Detects Rust, Node, Python, and Go projects with lockfile, build, toolchain, and Git health
+- [trash](https://github.com/chaqchase/lla/tree/main/plugins/trash): Provides cross-platform recoverable deletion with listing and conflict-safe restoration
+- [preview](https://github.com/chaqchase/lla/tree/main/plugins/preview): Previews highlighted text and Markdown, terminal images, and archive contents
 - [categorizer](https://github.com/chaqchase/lla/tree/main/plugins/categorizer): Categorizes files based on their extensions and metadata
 - [code_complexity](https://github.com/chaqchase/lla/tree/main/plugins/code_complexity): Analyzes code complexity using various metrics
 - [code_snippet_extractor](https://github.com/chaqchase/lla/tree/main/plugins/code_snippet_extractor): A plugin for extracting and managing code snippets
@@ -136,6 +141,6 @@ metadata, action, formatter, single-decoration, and batch-decoration checks:
 - [youtube](https://github.com/chaqchase/lla/tree/main/plugins/youtube): YouTube search with autosuggestions and history management
 - [file_mover](https://github.com/chaqchase/lla/tree/main/plugins/file_mover): A plugin that provides an intuitive clipboard-based interface for moving files and directories.
 - [file_copier](https://github.com/chaqchase/lla/tree/main/plugins/file_copier): A plugin that provides an intuitive clipboard-based interface for copying files and directories.
-- [file_remover](https://github.com/chaqchase/lla/tree/main/plugins/file_remover): A plugin that provides an interactive interface for safely removing files and directories.
+- [file_remover](https://github.com/chaqchase/lla/tree/main/plugins/file_remover): Interactively moves files to recoverable trash by default, with explicit permanent deletion.
 - [file_organizer](https://github.com/chaqchase/lla/tree/main/plugins/file_organizer): A plugin for organizing files using various strategies
 - [kill_process](https://github.com/chaqchase/lla/tree/main/plugins/kill_process): Interactive process management plugin for listing and terminating system processes with cross-platform support

--- a/plugins/brew/Cargo.toml
+++ b/plugins/brew/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brew"
 description = "Homebrew package manager plugin - install, uninstall, upgrade, and search packages"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/brew/plugin.toml
+++ b/plugins/brew/plugin.toml
@@ -1,0 +1,18 @@
+[plugin]
+id = "dev.lla.brew"
+name = "brew"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "brew"
+description = "Manage Homebrew packages"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["list", "search", "outdated", "install", "uninstall", "upgrade", "info", "cleanup", "doctor", "menu", "help"]
+
+[permissions]
+network = ["formulae.brew.sh", "github.com"]
+process = true

--- a/plugins/categorizer/Cargo.toml
+++ b/plugins/categorizer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "categorizer"
 description = "Categorizes files based on their extensions and metadata"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/categorizer/plugin.toml
+++ b/plugins/categorizer/plugin.toml
@@ -1,0 +1,31 @@
+[plugin]
+id = "dev.lla.categorizer"
+name = "categorizer"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "categorizer"
+description = "Categorize files from extensions and metadata"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["add-category", "add-subcategory", "list-categories", "help"]
+machine_output = true
+
+[permissions]
+filesystem = ["metadata:selection"]
+
+[[fields]]
+name = "category"
+type = "string"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "subcategory"
+type = "string"
+sortable = true
+filterable = true

--- a/plugins/categorizer/src/lib.rs
+++ b/plugins/categorizer/src/lib.rs
@@ -21,18 +21,18 @@ lazy_static! {
             "add-category",
             "add-category <name> <color> <ext1,ext2,...> [description]",
             "Add a new category",
-            vec!["lla plugin --name categorizer --action add-category --args Documents blue txt,doc,pdf \"Text documents\""],
+            ["lla plugin --name categorizer --action add-category --args Documents blue txt,doc,pdf \"Text documents\""],
             |args| {
                 if args.len() < 3 {
                     return Err("Usage: add-category <name> <color> <ext1,ext2,...> [description]".to_string());
                 }
-                let mut rule = CategoryRule::default();
-                rule.name = args[0].clone();
-                rule.color = args[1].clone();
-                rule.extensions = args[2].split(',').map(String::from).collect();
-                if let Some(desc) = args.get(3) {
-                    rule.description = desc.clone();
-                }
+                let rule = CategoryRule {
+                    name: args[0].clone(),
+                    color: args[1].clone(),
+                    extensions: args[2].split(',').map(String::from).collect(),
+                    description: args.get(3).cloned().unwrap_or_default(),
+                    ..CategoryRule::default()
+                };
                 let mut plugin = FileCategoryPlugin::new();
                 plugin.config_mut().rules.push(rule);
                 plugin.base.save_config().map_err(|e| e.to_string())?;
@@ -45,7 +45,7 @@ lazy_static! {
             "add-subcategory",
             "add-subcategory <category> <subcategory> <ext1,ext2,...>",
             "Add a subcategory to an existing category",
-            vec!["lla plugin --name categorizer --action add-subcategory --args Documents Text txt,md"],
+            ["lla plugin --name categorizer --action add-subcategory --args Documents Text txt,md"],
             |args| {
                 if args.len() != 3 {
                     return Err(
@@ -75,7 +75,7 @@ lazy_static! {
             "list-categories",
             "list-categories",
             "List all categories and their details",
-            vec!["lla plugin --name categorizer --action list-categories"],
+            ["lla plugin --name categorizer --action list-categories"],
             |_| {
                 let plugin = FileCategoryPlugin::new();
                 let mut list = List::new();
@@ -118,7 +118,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name categorizer --action help"],
+            ["lla plugin --name categorizer --action help"],
             |_| {
                 let plugin = FileCategoryPlugin::new();
                 let mut help = HelpFormatter::new("File Categorizer Plugin".to_string());

--- a/plugins/code_complexity/Cargo.toml
+++ b/plugins/code_complexity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "code_complexity"
 description = "Analyzes code complexity and provides metrics"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/code_complexity/plugin.toml
+++ b/plugins/code_complexity/plugin.toml
@@ -1,0 +1,24 @@
+[plugin]
+id = "dev.lla.code-complexity"
+name = "code_complexity"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "code_complexity"
+description = "Analyze source-code complexity"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["set-thresholds", "show-report", "help"]
+machine_output = true
+
+[permissions]
+filesystem = ["read:selection"]
+
+[[fields]]
+name = "complexity_metrics"
+type = "string"
+filterable = true

--- a/plugins/code_complexity/src/lib.rs
+++ b/plugins/code_complexity/src/lib.rs
@@ -26,7 +26,7 @@ lazy_static! {
             "set-thresholds",
             "set-thresholds <low> <medium> <high> <very-high>",
             "Set complexity thresholds",
-            vec!["lla plugin --name code_complexity --action set-thresholds --args 10 20 30 40"],
+            ["lla plugin --name code_complexity --action set-thresholds --args 10 20 30 40"],
             |args| {
                 if args.len() != 4 {
                     return Err(
@@ -65,7 +65,7 @@ lazy_static! {
             "show-report",
             "show-report",
             "Show detailed complexity report",
-            vec!["lla plugin --name code_complexity --action show-report"],
+            ["lla plugin --name code_complexity --action show-report"],
             |_| {
                 let state = PLUGIN_STATE.read();
                 println!("{}", state.generate_report());
@@ -78,7 +78,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name code_complexity --action help"],
+            ["lla plugin --name code_complexity --action help"],
             |_| {
                 let mut help = HelpFormatter::new("Code Complexity Plugin".to_string());
                 help.add_section("Description".to_string()).add_command(
@@ -425,7 +425,7 @@ impl PluginState {
         list.add_item(
             KeyValue::new(
                 "Complexity",
-                &format!(
+                format!(
                     "{} (MI: {:.1})",
                     metrics.cyclomatic_complexity, metrics.maintainability_index
                 ),
@@ -519,13 +519,13 @@ impl PluginState {
             for (path, metrics) in files {
                 list.add_item(
                     KeyValue::new(
-                        &format!("  {}", path.display()),
-                        &format!(
+                        format!("  {}", path.display()),
+                        format!(
                             "{} (MI: {:.1})",
                             metrics.cyclomatic_complexity, metrics.maintainability_index
                         ),
                     )
-                    .key_color(self.get_complexity_color(&metrics))
+                    .key_color(self.get_complexity_color(metrics))
                     .render(),
                 );
 

--- a/plugins/code_snippet_extractor/Cargo.toml
+++ b/plugins/code_snippet_extractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code_snippet_extractor"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 description = "Extract and manage code snippets with tagging support"
 

--- a/plugins/code_snippet_extractor/plugin.toml
+++ b/plugins/code_snippet_extractor/plugin.toml
@@ -1,0 +1,26 @@
+[plugin]
+id = "dev.lla.code-snippet-extractor"
+name = "code_snippet_extractor"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "code_snippet_extractor"
+description = "Extract and manage tagged code snippets"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["extract", "list", "get", "search", "add-tags", "remove-tags", "help", "list-categories", "list-by-category", "set-category", "export", "import"]
+machine_output = true
+
+[permissions]
+filesystem = ["read:selection", "read:user-path", "write:user-path"]
+clipboard = true
+
+[[fields]]
+name = "snippet_count"
+type = "integer"
+sortable = true
+filterable = true

--- a/plugins/code_snippet_extractor/src/lib.rs
+++ b/plugins/code_snippet_extractor/src/lib.rs
@@ -320,6 +320,10 @@ impl CodeSnippetExtractorPlugin {
         .to_string()
     }
 
+    fn format_snippet_count(value: &str) -> String {
+        format!("[{} snippets]", value)
+    }
+
     fn extract_snippet(
         &mut self,
         file_path: &str,
@@ -1251,19 +1255,20 @@ impl Plugin for CodeSnippetExtractorPlugin {
                         if let Some(file_path) = entry.path.to_str() {
                             let snippet_count = self.list_snippets_by_file(file_path).len();
                             if snippet_count > 0 {
-                                entry.custom_fields.insert(
-                                    "snippet_count".to_string(),
-                                    format!("[{} snippets]", snippet_count),
-                                );
+                                entry
+                                    .custom_fields
+                                    .insert("snippet_count".to_string(), snippet_count.to_string());
                             }
                         }
                         PluginResponse::Decorated(entry)
                     }
                     PluginRequest::FormatField(entry, format) => {
-                        let field = if format == "snippet_count" {
-                            entry.custom_fields.get("snippet_count").cloned()
-                        } else {
-                            None
+                        let field = match format.as_str() {
+                            "default" | "long" | "snippet_count" => entry
+                                .custom_fields
+                                .get("snippet_count")
+                                .map(|count| Self::format_snippet_count(count)),
+                            _ => None,
                         };
                         PluginResponse::FormattedField(field)
                     }
@@ -1301,5 +1306,18 @@ lla_plugin_interface::declare_plugin!(CodeSnippetExtractorPlugin);
 impl Default for CodeSnippetExtractorPlugin {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_snippet_counts_keep_the_existing_label() {
+        assert_eq!(
+            CodeSnippetExtractorPlugin::format_snippet_count("3"),
+            "[3 snippets]"
+        );
     }
 }

--- a/plugins/dirs_meta/Cargo.toml
+++ b/plugins/dirs_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dirs_meta"
 description = "Analyzes directories and shows metadata"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/dirs_meta/plugin.toml
+++ b/plugins/dirs_meta/plugin.toml
@@ -1,0 +1,37 @@
+[plugin]
+id = "dev.lla.dirs-meta"
+name = "dirs_meta"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "dirs_meta"
+description = "Calculate directory counts and sizes"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["clear-cache", "stats", "help"]
+machine_output = true
+
+[permissions]
+filesystem = ["metadata:tree"]
+
+[[fields]]
+name = "dir_file_count"
+type = "integer"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "dir_subdir_count"
+type = "integer"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "dir_total_size"
+type = "bytes"
+sortable = true
+filterable = true

--- a/plugins/dirs_meta/src/lib.rs
+++ b/plugins/dirs_meta/src/lib.rs
@@ -34,7 +34,7 @@ lazy_static! {
             "clear-cache",
             "clear-cache",
             "Clear the directory analysis cache",
-            vec!["lla plugin --name dirs_meta --action clear-cache"],
+            ["lla plugin --name dirs_meta --action clear-cache"],
             |_| {
                 let spinner = SPINNER.write();
                 spinner.set_status("Clearing cache...".to_string());
@@ -60,8 +60,8 @@ lazy_static! {
             "stats",
             "stats <path>",
             "Show detailed statistics for a directory",
-            vec!["lla plugin --name dirs_meta --action stats --args \"/path/to/dir\""],
-            |args| DirsPlugin::stats_action(args)
+            ["lla plugin --name dirs_meta --action stats --args \"/path/to/dir\""],
+            DirsPlugin::stats_action
         );
 
         lla_plugin_utils::define_action!(
@@ -69,7 +69,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name dirs_meta --action help"],
+            ["lla plugin --name dirs_meta --action help"],
             |_| {
                 let mut help = HelpFormatter::new("Directory Metadata Plugin".to_string());
                 help.add_section("Description".to_string())
@@ -311,6 +311,7 @@ impl DirsPlugin {
         };
 
         let colors = &self.base.config().colors;
+        let total_size_display = Self::format_total_size(total_size);
         match format {
             "long" => {
                 let modified = entry
@@ -352,7 +353,7 @@ impl DirsPlugin {
                 );
 
                 list.add_item(
-                    KeyValue::new("Total Size", total_size)
+                    KeyValue::new("Total Size", &total_size_display)
                         .key_color(colors.get("size").unwrap_or(&"white".to_string()))
                         .value_color(colors.get("size").unwrap_or(&"white".to_string()))
                         .key_width(12)
@@ -371,12 +372,19 @@ impl DirsPlugin {
             }
             "default" => Some(format!(
                 "\n{}\n",
-                TextBlock::new(format!("{} files, {}", file_count, total_size))
+                TextBlock::new(format!("{} files, {}", file_count, total_size_display))
                     .color(colors.get("info").unwrap_or(&"white".to_string()))
                     .build()
             )),
             _ => None,
         }
+    }
+
+    fn format_total_size(value: &str) -> String {
+        value
+            .parse::<u64>()
+            .map(format_size)
+            .unwrap_or_else(|_| value.to_string())
     }
 }
 
@@ -411,7 +419,7 @@ impl Plugin for DirsPlugin {
                                     .insert("dir_subdir_count".to_string(), dir_count.to_string());
                                 entry
                                     .custom_fields
-                                    .insert("dir_total_size".to_string(), format_size(total_size));
+                                    .insert("dir_total_size".to_string(), total_size.to_string());
                             }
                         }
                         PluginResponse::Decorated(entry)
@@ -456,3 +464,14 @@ impl ConfigurablePlugin for DirsPlugin {
 impl ProtobufHandler for DirsPlugin {}
 
 lla_plugin_interface::declare_plugin!(DirsPlugin);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_byte_values_keep_the_existing_human_size_display() {
+        assert_eq!(DirsPlugin::format_total_size("1024"), format_size(1024));
+        assert_eq!(DirsPlugin::format_total_size("legacy"), "legacy");
+    }
+}

--- a/plugins/duplicate_file_detector/Cargo.toml
+++ b/plugins/duplicate_file_detector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "duplicate_file_detector"
 description = "Detects duplicate files by comparing their content hashes"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/duplicate_file_detector/plugin.toml
+++ b/plugins/duplicate_file_detector/plugin.toml
@@ -1,0 +1,34 @@
+[plugin]
+id = "dev.lla.duplicate-file-detector"
+name = "duplicate_file_detector"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "duplicate_file_detector"
+description = "Detect files with identical content"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["clear-cache", "help"]
+machine_output = true
+
+[permissions]
+filesystem = ["read:tree"]
+
+[[fields]]
+name = "has_duplicates"
+type = "boolean"
+filterable = true
+
+[[fields]]
+name = "is_duplicate"
+type = "boolean"
+filterable = true
+
+[[fields]]
+name = "original_path"
+type = "path"
+filterable = true

--- a/plugins/duplicate_file_detector/src/lib.rs
+++ b/plugins/duplicate_file_detector/src/lib.rs
@@ -36,7 +36,7 @@ lazy_static! {
             "clear-cache",
             "clear-cache",
             "Clear the duplicate file detection cache",
-            vec!["lla plugin --name duplicate_file_detector --action clear-cache"],
+            ["lla plugin --name duplicate_file_detector --action clear-cache"],
             |_| {
                 let spinner = SPINNER.write();
                 spinner.set_status("Clearing cache...".to_string());
@@ -62,7 +62,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name duplicate_file_detector --action help"],
+            ["lla plugin --name duplicate_file_detector --action help"],
             |_| {
                 let mut help = HelpFormatter::new("Duplicate File Detector Plugin".to_string());
                 help.add_section("Description".to_string()).add_command(
@@ -235,7 +235,7 @@ impl DuplicateFileDetectorPlugin {
         let colors = &self.base.config().colors;
         let mut list = List::new().style(BoxStyle::Minimal).key_width(15);
 
-        if entry.custom_fields.get("has_duplicates").is_some() {
+        if entry.custom_fields.contains_key("has_duplicates") {
             match format {
                 "long" => {
                     list.add_item(
@@ -283,7 +283,7 @@ impl DuplicateFileDetectorPlugin {
                 }
                 _ => return None,
             }
-        } else if entry.custom_fields.get("is_duplicate").is_some() {
+        } else if entry.custom_fields.contains_key("is_duplicate") {
             match format {
                 "long" => {
                     list.add_item(

--- a/plugins/file_copier/Cargo.toml
+++ b/plugins/file_copier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_copier"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for copying files and directories"
 

--- a/plugins/file_copier/plugin.toml
+++ b/plugins/file_copier/plugin.toml
@@ -1,0 +1,18 @@
+[plugin]
+id = "dev.lla.file-copier"
+name = "file_copier"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "file_copier"
+description = "Interactively copy files and directories"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["add", "copy-all", "copy-partial", "clear", "show", "help"]
+
+[permissions]
+filesystem = ["read:tree", "write:selected-destination"]
+clipboard = true

--- a/plugins/file_copier/src/lib.rs
+++ b/plugins/file_copier/src/lib.rs
@@ -101,11 +101,11 @@ lazy_static! {
             "add",
             "add [path]",
             "Add files/directories to clipboard from current or specified directory",
-            vec![
+            [
                 "lla plugin --name file_copier --action add",
                 "lla plugin --name file_copier --action add --args /path/to/dir"
             ],
-            |args| FileCopierPlugin::add_action(args)
+            FileCopierPlugin::add_action
         );
 
         lla_plugin_utils::define_action!(
@@ -113,11 +113,11 @@ lazy_static! {
             "copy-all",
             "copy-all [target_path]",
             "Copy all items from clipboard to current or specified directory",
-            vec![
+            [
                 "lla plugin --name file_copier --action copy-all",
                 "lla plugin --name file_copier --action copy-all --args /path/to/target"
             ],
-            |args| FileCopierPlugin::copy_all_action(args)
+            FileCopierPlugin::copy_all_action
         );
 
         lla_plugin_utils::define_action!(
@@ -125,11 +125,11 @@ lazy_static! {
             "copy-partial",
             "copy-partial [target_path]",
             "Copy selected items from clipboard to current or specified directory",
-            vec![
+            [
                 "lla plugin --name file_copier --action copy-partial",
                 "lla plugin --name file_copier --action copy-partial --args /path/to/target"
             ],
-            |args| FileCopierPlugin::copy_partial_action(args)
+            FileCopierPlugin::copy_partial_action
         );
 
         lla_plugin_utils::define_action!(
@@ -137,7 +137,7 @@ lazy_static! {
             "clear",
             "clear",
             "Clear the clipboard",
-            vec!["lla plugin --name file_copier --action clear"],
+            ["lla plugin --name file_copier --action clear"],
             |_| FileCopierPlugin::clear_action()
         );
 
@@ -146,7 +146,7 @@ lazy_static! {
             "show",
             "show",
             "Show clipboard contents",
-            vec!["lla plugin --name file_copier --action show"],
+            ["lla plugin --name file_copier --action show"],
             |_| FileCopierPlugin::show_action()
         );
 
@@ -155,7 +155,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name file_copier --action help"],
+            ["lla plugin --name file_copier --action help"],
             |_| FileCopierPlugin::help_action()
         );
 
@@ -235,7 +235,7 @@ impl FileCopierPlugin {
 
     fn add_action(args: &[String]) -> Result<(), String> {
         let mut plugin = Self::new();
-        let dir = Self::get_directory(args.get(0).map(|s| s.as_str()))?;
+        let dir = Self::get_directory(args.first().map(|s| s.as_str()))?;
 
         let entries = fs::read_dir(&dir)
             .map_err(|e| format!("Failed to read directory '{}': {}", dir.display(), e))?
@@ -290,7 +290,7 @@ impl FileCopierPlugin {
             return Ok(());
         }
 
-        let target_dir = Self::get_directory(args.get(0).map(|s| s.as_str()))?;
+        let target_dir = Self::get_directory(args.first().map(|s| s.as_str()))?;
 
         for path in items {
             let new_path = target_dir.join(path.file_name().ok_or("Invalid file name")?);
@@ -328,7 +328,7 @@ impl FileCopierPlugin {
             return Ok(());
         }
 
-        let target_dir = Self::get_directory(args.get(0).map(|s| s.as_str()))?;
+        let target_dir = Self::get_directory(args.first().map(|s| s.as_str()))?;
 
         for &idx in &selections {
             let path = &items[idx];

--- a/plugins/file_hash/Cargo.toml
+++ b/plugins/file_hash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_hash"
 description = "Displays the hash of each file"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_hash/plugin.toml
+++ b/plugins/file_hash/plugin.toml
@@ -1,0 +1,29 @@
+[plugin]
+id = "dev.lla.file-hash"
+name = "file_hash"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "file_hash"
+description = "Calculate file hashes"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["help"]
+machine_output = true
+
+[permissions]
+filesystem = ["read:selection"]
+
+[[fields]]
+name = "sha1"
+type = "string"
+filterable = true
+
+[[fields]]
+name = "sha256"
+type = "string"
+filterable = true

--- a/plugins/file_meta/Cargo.toml
+++ b/plugins/file_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_meta"
 description = "Displays the file metadata of each file"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_meta/plugin.toml
+++ b/plugins/file_meta/plugin.toml
@@ -1,0 +1,36 @@
+[plugin]
+id = "dev.lla.file-meta"
+name = "file_meta"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "file_meta"
+description = "Expose detailed filesystem metadata"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["help"]
+machine_output = true
+
+[permissions]
+filesystem = ["metadata:selection"]
+
+[[fields]]
+name = "size"
+type = "bytes"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "modified"
+type = "timestamp"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "permissions"
+type = "integer"
+filterable = true

--- a/plugins/file_meta/src/lib.rs
+++ b/plugins/file_meta/src/lib.rs
@@ -21,7 +21,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name file_meta --action help"],
+            ["lla plugin --name file_meta --action help"],
             |_| {
                 let mut help = HelpFormatter::new("File Metadata Plugin".to_string());
                 help.add_section("Description".to_string())
@@ -115,6 +115,18 @@ impl FileMetadataPlugin {
         datetime.format("%Y-%m-%d %H:%M:%S").to_string()
     }
 
+    fn format_timestamp_value(value: &str) -> String {
+        value
+            .parse::<u64>()
+            .ok()
+            .map(|seconds| {
+                Self::format_timestamp(
+                    SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(seconds),
+                )
+            })
+            .unwrap_or_else(|| value.to_string())
+    }
+
     fn format_file_info(&self, entry: &DecoratedEntry, format: &str) -> Option<String> {
         let colors = &self.base.config().colors;
 
@@ -138,10 +150,13 @@ impl FileMetadataPlugin {
                         Some(size),
                         Some(permissions),
                     ) => {
+                        let accessed_display = Self::format_timestamp_value(accessed);
+                        let modified_display = Self::format_timestamp_value(modified);
+                        let created_display = Self::format_timestamp_value(created);
                         let mut list = List::new().style(BoxStyle::Minimal).key_width(12);
 
                         list.add_item(
-                            KeyValue::new("Accessed", accessed)
+                            KeyValue::new("Accessed", &accessed_display)
                                 .key_color(colors.get("accessed").unwrap_or(&"white".to_string()))
                                 .value_color(colors.get("accessed").unwrap_or(&"white".to_string()))
                                 .key_width(12)
@@ -149,7 +164,7 @@ impl FileMetadataPlugin {
                         );
 
                         list.add_item(
-                            KeyValue::new("Modified", modified)
+                            KeyValue::new("Modified", &modified_display)
                                 .key_color(colors.get("modified").unwrap_or(&"white".to_string()))
                                 .value_color(colors.get("modified").unwrap_or(&"white".to_string()))
                                 .key_width(12)
@@ -157,7 +172,7 @@ impl FileMetadataPlugin {
                         );
 
                         list.add_item(
-                            KeyValue::new("Created", created)
+                            KeyValue::new("Created", &created_display)
                                 .key_color(colors.get("created").unwrap_or(&"white".to_string()))
                                 .value_color(colors.get("created").unwrap_or(&"white".to_string()))
                                 .key_width(12)
@@ -222,27 +237,15 @@ impl Plugin for FileMetadataPlugin {
                         "long".to_string(),
                     ]),
                     PluginRequest::Decorate(mut entry) => {
-                        entry.custom_fields.insert(
-                            "accessed".to_string(),
-                            Self::format_timestamp(
-                                SystemTime::UNIX_EPOCH
-                                    + std::time::Duration::from_secs(entry.metadata.accessed),
-                            ),
-                        );
-                        entry.custom_fields.insert(
-                            "modified".to_string(),
-                            Self::format_timestamp(
-                                SystemTime::UNIX_EPOCH
-                                    + std::time::Duration::from_secs(entry.metadata.modified),
-                            ),
-                        );
-                        entry.custom_fields.insert(
-                            "created".to_string(),
-                            Self::format_timestamp(
-                                SystemTime::UNIX_EPOCH
-                                    + std::time::Duration::from_secs(entry.metadata.created),
-                            ),
-                        );
+                        entry
+                            .custom_fields
+                            .insert("accessed".to_string(), entry.metadata.accessed.to_string());
+                        entry
+                            .custom_fields
+                            .insert("modified".to_string(), entry.metadata.modified.to_string());
+                        entry
+                            .custom_fields
+                            .insert("created".to_string(), entry.metadata.created.to_string());
                         entry
                             .custom_fields
                             .insert("uid".to_string(), entry.metadata.uid.to_string());
@@ -299,3 +302,20 @@ impl ConfigurablePlugin for FileMetadataPlugin {
 impl ProtobufHandler for FileMetadataPlugin {}
 
 lla_plugin_interface::declare_plugin!(FileMetadataPlugin);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_timestamps_keep_the_existing_human_display() {
+        assert_eq!(
+            FileMetadataPlugin::format_timestamp_value("0"),
+            FileMetadataPlugin::format_timestamp(SystemTime::UNIX_EPOCH)
+        );
+        assert_eq!(
+            FileMetadataPlugin::format_timestamp_value("legacy"),
+            "legacy"
+        );
+    }
+}

--- a/plugins/file_mover/Cargo.toml
+++ b/plugins/file_mover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_mover"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for moving files and directories"
 

--- a/plugins/file_mover/plugin.toml
+++ b/plugins/file_mover/plugin.toml
@@ -1,0 +1,18 @@
+[plugin]
+id = "dev.lla.file-mover"
+name = "file_mover"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "file_mover"
+description = "Interactively move files and directories"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["add", "move-all", "move-partial", "clear", "show", "help"]
+
+[permissions]
+filesystem = ["read:tree", "write:selected-destination", "delete:selection"]
+clipboard = true

--- a/plugins/file_mover/src/lib.rs
+++ b/plugins/file_mover/src/lib.rs
@@ -101,11 +101,11 @@ lazy_static! {
             "add",
             "add [path]",
             "Add files/directories to clipboard from current or specified directory",
-            vec![
+            [
                 "lla plugin --name file_mover --action add",
                 "lla plugin --name file_mover --action add --args /path/to/dir"
             ],
-            |args| FileMoverPlugin::add_action(args)
+            FileMoverPlugin::add_action
         );
 
         lla_plugin_utils::define_action!(
@@ -113,11 +113,11 @@ lazy_static! {
             "move-all",
             "move-all [target_path]",
             "Move all items from clipboard to current or specified directory",
-            vec![
+            [
                 "lla plugin --name file_mover --action move-all",
                 "lla plugin --name file_mover --action move-all --args /path/to/target"
             ],
-            |args| FileMoverPlugin::move_all_action(args)
+            FileMoverPlugin::move_all_action
         );
 
         lla_plugin_utils::define_action!(
@@ -125,11 +125,11 @@ lazy_static! {
             "move-partial",
             "move-partial [target_path]",
             "Move selected items from clipboard to current or specified directory",
-            vec![
+            [
                 "lla plugin --name file_mover --action move-partial",
                 "lla plugin --name file_mover --action move-partial --args /path/to/target"
             ],
-            |args| FileMoverPlugin::move_partial_action(args)
+            FileMoverPlugin::move_partial_action
         );
 
         lla_plugin_utils::define_action!(
@@ -137,7 +137,7 @@ lazy_static! {
             "clear",
             "clear",
             "Clear the clipboard",
-            vec!["lla plugin --name file_mover --action clear"],
+            ["lla plugin --name file_mover --action clear"],
             |_| FileMoverPlugin::clear_action()
         );
 
@@ -146,7 +146,7 @@ lazy_static! {
             "show",
             "show",
             "Show clipboard contents",
-            vec!["lla plugin --name file_mover --action show"],
+            ["lla plugin --name file_mover --action show"],
             |_| FileMoverPlugin::show_action()
         );
 
@@ -155,7 +155,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name file_mover --action help"],
+            ["lla plugin --name file_mover --action help"],
             |_| FileMoverPlugin::help_action()
         );
 
@@ -187,7 +187,7 @@ impl FileMoverPlugin {
 
     fn add_action(args: &[String]) -> Result<(), String> {
         let mut plugin = Self::new();
-        let dir = Self::get_directory(args.get(0).map(|s| s.as_str()))?;
+        let dir = Self::get_directory(args.first().map(|s| s.as_str()))?;
 
         let entries = fs::read_dir(&dir)
             .map_err(|e| format!("Failed to read directory '{}': {}", dir.display(), e))?
@@ -250,7 +250,7 @@ impl FileMoverPlugin {
             return Ok(());
         }
 
-        let target_dir = Self::get_directory(args.get(0).map(|s| s.as_str()))?;
+        let target_dir = Self::get_directory(args.first().map(|s| s.as_str()))?;
 
         for path in items {
             let new_path = target_dir.join(path.file_name().ok_or("Invalid file name")?);
@@ -292,7 +292,7 @@ impl FileMoverPlugin {
             return Ok(());
         }
 
-        let target_dir = Self::get_directory(args.get(0).map(|s| s.as_str()))?;
+        let target_dir = Self::get_directory(args.first().map(|s| s.as_str()))?;
 
         for &idx in &selections {
             let path = &items[idx];

--- a/plugins/file_organizer/Cargo.toml
+++ b/plugins/file_organizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_organizer"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 description = "A plugin for lla that organizes files using various strategies"
 

--- a/plugins/file_organizer/plugin.toml
+++ b/plugins/file_organizer/plugin.toml
@@ -1,0 +1,17 @@
+[plugin]
+id = "dev.lla.file-organizer"
+name = "file_organizer"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "file_organizer"
+description = "Organize files using configurable strategies"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["organize", "preview", "help"]
+
+[permissions]
+filesystem = ["read:tree", "write:tree", "delete:selection"]

--- a/plugins/file_organizer/src/lib.rs
+++ b/plugins/file_organizer/src/lib.rs
@@ -24,14 +24,12 @@ lazy_static! {
             "organize",
             "organize <directory> [strategy]",
             "Organize files in the specified directory using the given strategy (defaults to extension)",
-            vec![
-                "lla plugin --name file_organizer --action organize --args /path/to/dir",
+            ["lla plugin --name file_organizer --action organize --args /path/to/dir",
                 "lla plugin --name file_organizer --action organize --args /path/to/dir extension",
                 "lla plugin --name file_organizer --action organize --args /path/to/dir date",
                 "lla plugin --name file_organizer --action organize --args /path/to/dir type",
-                "lla plugin --name file_organizer --action organize --args /path/to/dir size",
-            ],
-            |args| FileOrganizerPlugin::organize_action(args)
+                "lla plugin --name file_organizer --action organize --args /path/to/dir size"],
+            FileOrganizerPlugin::organize_action
         );
 
         lla_plugin_utils::define_action!(
@@ -39,14 +37,14 @@ lazy_static! {
             "preview",
             "preview <directory> [strategy]",
             "Preview organization changes without applying them",
-            vec![
+            [
                 "lla plugin --name file_organizer --action preview --args /path/to/dir",
                 "lla plugin --name file_organizer --action preview --args /path/to/dir extension",
                 "lla plugin --name file_organizer --action preview --args /path/to/dir date",
                 "lla plugin --name file_organizer --action preview --args /path/to/dir type",
-                "lla plugin --name file_organizer --action preview --args /path/to/dir size",
+                "lla plugin --name file_organizer --action preview --args /path/to/dir size"
             ],
-            |args| FileOrganizerPlugin::preview_action(args)
+            FileOrganizerPlugin::preview_action
         );
 
         lla_plugin_utils::define_action!(
@@ -54,7 +52,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name file_organizer --action help"],
+            ["lla plugin --name file_organizer --action help"],
             |_| FileOrganizerPlugin::help_action()
         );
 
@@ -159,7 +157,7 @@ impl FileOrganizerPlugin {
         println!("{}", "═".bright_black().repeat(50));
 
         for (target_dir, moves) in &moves_by_dir {
-            let relative_dir = target_dir.strip_prefix(&dir).unwrap_or(&target_dir);
+            let relative_dir = target_dir.strip_prefix(&dir).unwrap_or(target_dir);
             println!(
                 "\n{} {}",
                 "📁".bright_blue(),

--- a/plugins/file_remover/Cargo.toml
+++ b/plugins/file_remover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_remover"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 description = "A plugin for lla that provides interactive file and directory removal"
 

--- a/plugins/file_remover/README.md
+++ b/plugins/file_remover/README.md
@@ -1,13 +1,16 @@
 # lla File Remover Plugin
 
-A plugin for `lla` that provides an interactive interface for safely removing files and directories.
+A plugin for `lla` that provides an interactive interface for recoverable deletion. The
+default `remove` action moves entries into the shared `trash` store. Permanent deletion
+is available only through the explicit `purge` action and a second confirmation.
 
 ## Features
 
 - **Interactive Selection**: Multi-select interface for choosing files to remove
 - **Path Flexibility**: Support for both current and specified directories
-- **Safe Operations**: Confirmation prompts and error handling for safe removal
-- **Directory Support**: Recursive removal of directories
+- **Recoverable by Default**: `remove` records original paths and moves entries to trash
+- **Explicit Permanent Deletion**: `purge` is deliberately separate and irreversible
+- **Directory Support**: Files, symlinks, and complete directory trees are supported
 - **User Interface**: Colored output and interactive menus
 
 ## Configuration
@@ -25,11 +28,14 @@ path = "bright_yellow"
 ### Basic Operations
 
 ```bash
-# Remove files/directories from current directory
+# Move files/directories from the current directory to recoverable trash
 lla plugin --name file_remover --action remove
 
-# Remove files/directories from specified directory
+# Move files/directories from a specified directory to recoverable trash
 lla plugin --name file_remover --action remove --args /path/to/directory
+
+# Permanently delete selected entries (cannot be restored)
+lla plugin --name file_remover --action purge --args /path/to/directory
 
 # Show help information
 lla plugin --name file_remover --action help
@@ -37,21 +43,21 @@ lla plugin --name file_remover --action help
 
 ## Common Workflows
 
-### 1. Removing Files from Current Directory
+### 1. Trashing Files from Current Directory
 
 ```bash
 # In target directory
 cd /path/to/directory
 lla plugin --name file_remover --action remove
-# Select files to remove using space, confirm with enter
+# Select files to trash using space, confirm with enter
 ```
 
-### 2. Removing Files from Specific Directory
+### 2. Trashing Files from Specific Directory
 
 ```bash
-# Remove files from a specific directory without changing location
+# Trash files from a specific directory without changing location
 lla plugin --name file_remover --action remove --args /path/to/directory
-# Select files to remove using space, confirm with enter
+# Select files to trash using space, confirm with enter
 ```
 
 ## Display Format

--- a/plugins/file_remover/plugin.toml
+++ b/plugins/file_remover/plugin.toml
@@ -1,0 +1,17 @@
+[plugin]
+id = "dev.lla.file-remover"
+name = "file_remover"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "file_remover"
+description = "Interactively remove files and directories"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["remove", "help"]
+
+[permissions]
+filesystem = ["read:tree", "delete:selection"]

--- a/plugins/file_remover/plugin.toml
+++ b/plugins/file_remover/plugin.toml
@@ -6,12 +6,12 @@ api_min = 2
 api_max = 2
 runtime = "native"
 entrypoint = "file_remover"
-description = "Interactively remove files and directories"
+description = "Interactively trash files by default with explicit permanent deletion"
 license = "MIT"
 
 [capabilities]
 formats = ["default"]
-actions = ["remove", "help"]
+actions = ["remove", "purge", "help"]
 
 [permissions]
-filesystem = ["read:tree", "delete:selection"]
+filesystem = ["read:tree", "write:user-path", "delete:selection", "delete:quarantine"]

--- a/plugins/file_remover/src/lib.rs
+++ b/plugins/file_remover/src/lib.rs
@@ -49,11 +49,11 @@ lazy_static! {
             "remove",
             "remove [path]",
             "Remove files/directories from current or specified directory",
-            vec![
+            [
                 "lla plugin --name file_remover --action remove",
                 "lla plugin --name file_remover --action remove --args /path/to/dir"
             ],
-            |args| FileRemoverPlugin::remove_action(args)
+            FileRemoverPlugin::remove_action
         );
 
         lla_plugin_utils::define_action!(
@@ -61,7 +61,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name file_remover --action help"],
+            ["lla plugin --name file_remover --action help"],
             |_| FileRemoverPlugin::help_action()
         );
 
@@ -108,7 +108,7 @@ impl FileRemoverPlugin {
     }
 
     fn remove_action(args: &[String]) -> Result<(), String> {
-        let dir = Self::get_directory(args.get(0).map(|s| s.as_str()))?;
+        let dir = Self::get_directory(args.first().map(|s| s.as_str()))?;
 
         let entries = fs::read_dir(&dir)
             .map_err(|e| format!("Failed to read directory '{}': {}", dir.display(), e))?

--- a/plugins/file_remover/src/lib.rs
+++ b/plugins/file_remover/src/lib.rs
@@ -4,16 +4,13 @@ use lazy_static::lazy_static;
 use lla_plugin_interface::{Plugin, PluginRequest, PluginResponse};
 use lla_plugin_utils::{
     config::PluginConfig,
+    trash::{remove_path, TrashStore},
     ui::components::{BoxComponent, BoxStyle, HelpFormatter, LlaDialoguerTheme},
     ActionRegistry, BasePlugin, ConfigurablePlugin, ProtobufHandler,
 };
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::{
-    fs,
-    ops::Deref,
-    path::{Path, PathBuf},
-};
+use std::{fs, ops::Deref, path::PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RemoverConfig {
@@ -48,12 +45,24 @@ lazy_static! {
             registry,
             "remove",
             "remove [path]",
-            "Remove files/directories from current or specified directory",
+            "Move selected files/directories into recoverable trash",
             [
                 "lla plugin --name file_remover --action remove",
                 "lla plugin --name file_remover --action remove --args /path/to/dir"
             ],
             FileRemoverPlugin::remove_action
+        );
+
+        lla_plugin_utils::define_action!(
+            registry,
+            "purge",
+            "purge [path]",
+            "Permanently delete selected files/directories after confirmation",
+            [
+                "lla plugin --name file_remover --action purge",
+                "lla plugin --name file_remover --action purge --args /path/to/dir"
+            ],
+            FileRemoverPlugin::purge_action
         );
 
         lla_plugin_utils::define_action!(
@@ -89,25 +98,15 @@ impl FileRemoverPlugin {
         }
     }
 
-    fn remove_directory_recursively(path: &Path) -> Result<(), String> {
-        if !path.is_dir() {
-            return Err(format!("{} is not a directory", path.display()));
-        }
-
-        fs::remove_dir_all(path)
-            .map_err(|e| format!("Failed to remove directory {}: {}", path.display(), e))
-    }
-
-    fn remove_item(path: &Path) -> Result<(), String> {
-        if path.is_dir() {
-            Self::remove_directory_recursively(path)
-        } else {
-            fs::remove_file(path)
-                .map_err(|e| format!("Failed to remove file {}: {}", path.display(), e))
-        }
-    }
-
     fn remove_action(args: &[String]) -> Result<(), String> {
+        Self::select_and_remove(args, false)
+    }
+
+    fn purge_action(args: &[String]) -> Result<(), String> {
+        Self::select_and_remove(args, true)
+    }
+
+    fn select_and_remove(args: &[String], permanent: bool) -> Result<(), String> {
         let dir = Self::get_directory(args.first().map(|s| s.as_str()))?;
 
         let entries = fs::read_dir(&dir)
@@ -143,7 +142,11 @@ impl FileRemoverPlugin {
 
         let theme = LlaDialoguerTheme::default();
         let selections = MultiSelect::with_theme(&theme)
-            .with_prompt("Select items to remove (Space to select, Enter to confirm)")
+            .with_prompt(if permanent {
+                "Select items to PERMANENTLY delete (Space to select, Enter to confirm)"
+            } else {
+                "Select items to move to recoverable trash (Space to select, Enter to confirm)"
+            })
             .items(&items)
             .interact()
             .map_err(|e| format!("Failed to show selector: {}", e))?;
@@ -154,15 +157,24 @@ impl FileRemoverPlugin {
         }
 
         println!(
-            "\n{} The following items will be removed:",
-            "Warning:".bright_yellow()
+            "\n{} The following items will be {}:",
+            "Warning:".bright_yellow(),
+            if permanent {
+                "permanently deleted"
+            } else {
+                "moved to trash"
+            }
         );
         for &idx in &selections {
             println!("  {} {}", "→".bright_red(), items[idx].bright_yellow());
         }
 
         let confirmed = Confirm::with_theme(&theme)
-            .with_prompt("Are you sure you want to remove these items?")
+            .with_prompt(if permanent {
+                "Permanently delete these items? This cannot be undone"
+            } else {
+                "Move these items to recoverable trash?"
+            })
             .default(false)
             .interact()
             .map_err(|e| format!("Failed to show confirmation: {}", e))?;
@@ -174,15 +186,29 @@ impl FileRemoverPlugin {
 
         let mut success_count = 0;
         let mut error_count = 0;
+        let trash = TrashStore::for_plugin_data();
 
         for &idx in &selections {
             let path = &entries[idx];
-            match Self::remove_item(path) {
-                Ok(()) => {
+            let result = if permanent {
+                remove_path(path).map(|_| None)
+            } else {
+                trash.put(path).map(Some)
+            };
+            match result {
+                Ok(record) => {
                     println!(
-                        "{} Removed: {}",
+                        "{} {}: {}{}",
                         "Success:".bright_green(),
-                        path.display().to_string().bright_yellow()
+                        if permanent {
+                            "Permanently deleted"
+                        } else {
+                            "Trashed"
+                        },
+                        path.display().to_string().bright_yellow(),
+                        record
+                            .map(|record| format!(" (id: {})", record.id))
+                            .unwrap_or_default()
                     );
                     success_count += 1;
                 }
@@ -199,9 +225,14 @@ impl FileRemoverPlugin {
         }
 
         println!(
-            "\n{} Operation completed: {} items removed, {} errors",
+            "\n{} Operation completed: {} items {}, {} errors",
             "Summary:".bright_blue(),
             success_count.to_string().bright_green(),
+            if permanent {
+                "permanently deleted"
+            } else {
+                "trashed"
+            },
             error_count.to_string().bright_red()
         );
 
@@ -212,18 +243,27 @@ impl FileRemoverPlugin {
         let mut help = HelpFormatter::new("File Remover".to_string());
         help.add_section("Description".to_string()).add_command(
             "".to_string(),
-            "Remove files and directories with interactive selection".to_string(),
+            "Move files and directories to recoverable trash by default".to_string(),
             vec![],
         );
 
-        help.add_section("Commands".to_string()).add_command(
-            "remove [path]".to_string(),
-            "Remove files/directories from current or specified directory".to_string(),
-            vec![
-                "lla plugin --name file_remover --action remove".to_string(),
-                "lla plugin --name file_remover --action remove --args /path/to/dir".to_string(),
-            ],
-        );
+        help.add_section("Commands".to_string())
+            .add_command(
+                "remove [path]".to_string(),
+                "Move selected files/directories into recoverable trash".to_string(),
+                vec![
+                    "lla plugin --name file_remover --action remove".to_string(),
+                    "lla plugin --name file_remover --action remove --args /path/to/dir"
+                        .to_string(),
+                ],
+            )
+            .add_command(
+                "purge [path]".to_string(),
+                "Permanently delete selected items after an explicit confirmation".to_string(),
+                vec![
+                    "lla plugin --name file_remover --action purge --args /path/to/dir".to_string(),
+                ],
+            );
 
         println!(
             "{}",
@@ -297,5 +337,23 @@ lla_plugin_interface::declare_plugin!(FileRemoverPlugin);
 impl Default for FileRemoverPlugin {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recoverable_and_permanent_actions_are_both_explicit() {
+        let actions = ACTION_REGISTRY
+            .read()
+            .list_actions()
+            .into_iter()
+            .map(|action| action.name)
+            .collect::<std::collections::HashSet<_>>();
+        assert!(actions.contains("remove"));
+        assert!(actions.contains("purge"));
+        assert!(actions.contains("help"));
     }
 }

--- a/plugins/file_tagger/Cargo.toml
+++ b/plugins/file_tagger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_tagger"
 description = "Add and manage tags for files"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_tagger/plugin.toml
+++ b/plugins/file_tagger/plugin.toml
@@ -1,0 +1,24 @@
+[plugin]
+id = "dev.lla.file-tagger"
+name = "file_tagger"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "file_tagger"
+description = "Attach and query user-defined file tags"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["add-tag", "remove-tag", "list-tags", "all-tags", "files-by-tag", "help"]
+machine_output = true
+
+[permissions]
+filesystem = ["metadata:selection"]
+
+[[fields]]
+name = "tags"
+type = "string"
+filterable = true

--- a/plugins/file_tagger/src/lib.rs
+++ b/plugins/file_tagger/src/lib.rs
@@ -27,9 +27,7 @@ lazy_static! {
             "add-tag",
             "add-tag <file_path> <tag>",
             "Add a tag to a file",
-            vec![
-                "lla plugin --name file_tagger --action add-tag --args \"/path/to/file\" \"mytag\""
-            ],
+            ["lla plugin --name file_tagger --action add-tag --args \"/path/to/file\" \"mytag\""],
             |args| {
                 if args.len() != 2 {
                     return Err("Usage: add-tag <file_path> <tag>".to_string());
@@ -56,7 +54,7 @@ lazy_static! {
             "remove-tag",
             "remove-tag <file_path> <tag>",
             "Remove a tag from a file",
-            vec!["lla plugin --name file_tagger --action remove-tag --args \"/path/to/file\" \"mytag\""],
+            ["lla plugin --name file_tagger --action remove-tag --args \"/path/to/file\" \"mytag\""],
             |args| {
                 if args.len() != 2 {
                     return Err("Usage: remove-tag <file_path> <tag>".to_string());
@@ -83,7 +81,7 @@ lazy_static! {
             "list-tags",
             "list-tags <file_path>",
             "List all tags for a file",
-            vec!["lla plugin --name file_tagger --action list-tags --args \"/path/to/file\""],
+            ["lla plugin --name file_tagger --action list-tags --args \"/path/to/file\""],
             |args| {
                 if args.len() != 1 {
                     return Err("Usage: list-tags <file_path>".to_string());
@@ -120,7 +118,7 @@ lazy_static! {
             "all-tags",
             "all-tags",
             "List all registered tags",
-            vec!["lla plugin --name file_tagger --action all-tags"],
+            ["lla plugin --name file_tagger --action all-tags"],
             |_| {
                 let plugin = FileTaggerPlugin::new();
                 let tags = plugin.get_all_tags();
@@ -154,7 +152,7 @@ lazy_static! {
             "files-by-tag",
             "files-by-tag <tag-to-query>",
             "List all files tagged with the given tag",
-            vec!["lla plugin --name file_tagger --action files-by-tag --args \"tag-to-query\""],
+            ["lla plugin --name file_tagger --action files-by-tag --args \"tag-to-query\""],
             |args| {
                 if args.len() != 1 {
                     return Err("Usage: files-by-tag <tag-to-query>".to_string());
@@ -190,7 +188,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name file_tagger --action help"],
+            ["lla plugin --name file_tagger --action help"],
             |_| {
                 let mut help = HelpFormatter::new("File Tagger Plugin".to_string());
                 help.add_section("Description".to_string()).add_command(

--- a/plugins/file_tagger/src/lib.rs
+++ b/plugins/file_tagger/src/lib.rs
@@ -163,7 +163,7 @@ lazy_static! {
 
                 if files.is_empty() {
                     list.add_item(
-                        KeyValue::new("Info", format!("No files found for tag [{}].", &args[0]))
+                        KeyValue::new("Info", format!("No files found for tag [{}].", args[0]))
                             .key_color("bright_blue")
                             .value_color("bright_yellow")
                             .key_width(12)
@@ -171,7 +171,7 @@ lazy_static! {
                     );
                 } else {
                     list.add_item(
-                        KeyValue::new(format!("All Files for [{}]", &args[0]), files.join(", "))
+                        KeyValue::new(format!("All Files for [{}]", args[0]), files.join(", "))
                             .key_color("bright_green")
                             .value_color("bright_cyan")
                             .key_width(12)

--- a/plugins/flush_dns/Cargo.toml
+++ b/plugins/flush_dns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flush_dns"
 description = "Flush DNS cache on macOS, Linux, and Windows"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/flush_dns/plugin.toml
+++ b/plugins/flush_dns/plugin.toml
@@ -1,0 +1,17 @@
+[plugin]
+id = "dev.lla.flush-dns"
+name = "flush_dns"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "flush_dns"
+description = "Flush the operating system DNS cache"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["flush", "history", "clear-history", "preferences", "help"]
+
+[permissions]
+process = true

--- a/plugins/flush_dns/src/lib.rs
+++ b/plugins/flush_dns/src/lib.rs
@@ -197,7 +197,7 @@ impl FlushDnsPlugin {
         {
             // Linux command - try systemd-resolve first, then nscd
             let result = std::process::Command::new("sudo")
-                .args(&["systemd-resolve", "--flush-caches"])
+                .args(["systemd-resolve", "--flush-caches"])
                 .output();
 
             if let Ok(output) = result {
@@ -208,7 +208,7 @@ impl FlushDnsPlugin {
 
             // Try nscd as fallback
             let result = std::process::Command::new("sudo")
-                .args(&["systemctl", "restart", "nscd"])
+                .args(["systemctl", "restart", "nscd"])
                 .output();
 
             if let Ok(output) = result {
@@ -224,7 +224,7 @@ impl FlushDnsPlugin {
         {
             // Windows command
             let output = std::process::Command::new("ipconfig")
-                .args(&["/flushdns"])
+                .args(["/flushdns"])
                 .output()
                 .map_err(|e| format!("Failed to execute command: {}", e))?;
 

--- a/plugins/flush_dns/src/lib.rs
+++ b/plugins/flush_dns/src/lib.rs
@@ -177,13 +177,13 @@ impl FlushDnsPlugin {
         {
             // macOS command
             let output = std::process::Command::new("sudo")
-                .args(&["dscacheutil", "-flushcache"])
+                .args(["dscacheutil", "-flushcache"])
                 .output()
                 .map_err(|e| format!("Failed to execute command: {}", e))?;
 
             // Also flush mDNSResponder
             let _ = std::process::Command::new("sudo")
-                .args(&["killall", "-HUP", "mDNSResponder"])
+                .args(["killall", "-HUP", "mDNSResponder"])
                 .output();
 
             if output.status.success() {

--- a/plugins/folder_cleaner/Cargo.toml
+++ b/plugins/folder_cleaner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "folder_cleaner"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 description = "Safety-first folder organization and cleanup plugin for lla"
 

--- a/plugins/folder_cleaner/plugin.toml
+++ b/plugins/folder_cleaner/plugin.toml
@@ -1,0 +1,17 @@
+[plugin]
+id = "dev.lla.folder-cleaner"
+name = "folder_cleaner"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "folder_cleaner"
+description = "Plan, quarantine and restore generated-folder cleanup"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["scan", "preview", "clean", "apply", "restore", "quarantine-list", "quarantine-empty", "history", "show-plan", "doctor", "config-wizard", "help"]
+
+[permissions]
+filesystem = ["read:tree", "write:tree", "delete:quarantine"]

--- a/plugins/folder_cleaner/src/config.rs
+++ b/plugins/folder_cleaner/src/config.rs
@@ -103,8 +103,8 @@ impl FolderCleanerConfig {
         let mut changed = false;
 
         for (name, profile) in default_profiles() {
-            if !self.profiles.contains_key(&name) {
-                self.profiles.insert(name, profile);
+            if let std::collections::hash_map::Entry::Vacant(e) = self.profiles.entry(name) {
+                e.insert(profile);
                 changed = true;
             }
         }

--- a/plugins/folder_cleaner/src/lib.rs
+++ b/plugins/folder_cleaner/src/lib.rs
@@ -47,8 +47,8 @@ lazy_static! {
             "scan",
             "scan [directory]",
             "Analyze folder clutter and print a summary without saving a plan",
-            vec!["lla plugin --name folder_cleaner --action scan --args ~/Downloads"],
-            |args| FolderCleanerPlugin::scan_action(args)
+            ["lla plugin --name folder_cleaner --action scan --args ~/Downloads"],
+            FolderCleanerPlugin::scan_action
         );
 
         lla_plugin_utils::define_action!(
@@ -56,11 +56,11 @@ lazy_static! {
             "preview",
             "preview [directory] [profile]",
             "Show proposed organization and cleanup actions, then save the plan",
-            vec![
+            [
                 "lla plugin --name folder_cleaner --action preview --args ~/Downloads",
                 "lla plugin --name folder_cleaner --action preview --args ~/Downloads project"
             ],
-            |args| FolderCleanerPlugin::preview_action(args)
+            FolderCleanerPlugin::preview_action
         );
 
         lla_plugin_utils::define_action!(
@@ -68,8 +68,8 @@ lazy_static! {
             "clean",
             "clean [directory] [profile]",
             "Preview, interactively approve, then execute selected safe actions",
-            vec!["lla plugin --name folder_cleaner --action clean --args ~/Downloads downloads"],
-            |args| FolderCleanerPlugin::clean_action(args)
+            ["lla plugin --name folder_cleaner --action clean --args ~/Downloads downloads"],
+            FolderCleanerPlugin::clean_action
         );
 
         lla_plugin_utils::define_action!(
@@ -77,8 +77,8 @@ lazy_static! {
             "apply",
             "apply <plan_id>",
             "Apply a saved plan after validation and confirmation",
-            vec!["lla plugin --name folder_cleaner --action apply --args plan-20260508090000000"],
-            |args| FolderCleanerPlugin::apply_action(args)
+            ["lla plugin --name folder_cleaner --action apply --args plan-20260508090000000"],
+            FolderCleanerPlugin::apply_action
         );
 
         lla_plugin_utils::define_action!(
@@ -86,8 +86,8 @@ lazy_static! {
             "restore",
             "restore [run_id]",
             "Restore files moved by a previous run",
-            vec!["lla plugin --name folder_cleaner --action restore --args run-20260508090000000"],
-            |args| FolderCleanerPlugin::restore_action(args)
+            ["lla plugin --name folder_cleaner --action restore --args run-20260508090000000"],
+            FolderCleanerPlugin::restore_action
         );
 
         lla_plugin_utils::define_action!(
@@ -95,7 +95,7 @@ lazy_static! {
             "quarantine-list",
             "quarantine-list",
             "List files currently held in quarantine",
-            vec!["lla plugin --name folder_cleaner --action quarantine-list"],
+            ["lla plugin --name folder_cleaner --action quarantine-list"],
             |_| FolderCleanerPlugin::quarantine_list_action()
         );
 
@@ -104,8 +104,8 @@ lazy_static! {
             "quarantine-empty",
             "quarantine-empty [older_than_days]",
             "Permanently remove quarantined files older than the given number of days",
-            vec!["lla plugin --name folder_cleaner --action quarantine-empty --args 30"],
-            |args| FolderCleanerPlugin::quarantine_empty_action(args)
+            ["lla plugin --name folder_cleaner --action quarantine-empty --args 30"],
+            FolderCleanerPlugin::quarantine_empty_action
         );
 
         lla_plugin_utils::define_action!(
@@ -113,7 +113,7 @@ lazy_static! {
             "history",
             "history",
             "List saved plans and completed or partial runs",
-            vec!["lla plugin --name folder_cleaner --action history"],
+            ["lla plugin --name folder_cleaner --action history"],
             |_| FolderCleanerPlugin::history_action()
         );
 
@@ -122,10 +122,8 @@ lazy_static! {
             "show-plan",
             "show-plan <plan_id>",
             "Render a saved plan preview",
-            vec![
-                "lla plugin --name folder_cleaner --action show-plan --args plan-20260508090000000"
-            ],
-            |args| FolderCleanerPlugin::show_plan_action(args)
+            ["lla plugin --name folder_cleaner --action show-plan --args plan-20260508090000000"],
+            FolderCleanerPlugin::show_plan_action
         );
 
         lla_plugin_utils::define_action!(
@@ -133,11 +131,9 @@ lazy_static! {
             "doctor",
             "doctor [run_id] [--repair]",
             "Inspect run manifests and recover restorable items when requested",
-            vec![
-                "lla plugin --name folder_cleaner --action doctor",
-                "lla plugin --name folder_cleaner --action doctor --args run-20260508090000000 --repair"
-            ],
-            |args| FolderCleanerPlugin::doctor_action(args)
+            ["lla plugin --name folder_cleaner --action doctor",
+                "lla plugin --name folder_cleaner --action doctor --args run-20260508090000000 --repair"],
+            FolderCleanerPlugin::doctor_action
         );
 
         lla_plugin_utils::define_action!(
@@ -145,7 +141,7 @@ lazy_static! {
             "config-wizard",
             "config-wizard",
             "Interactively adjust common folder cleaner settings",
-            vec!["lla plugin --name folder_cleaner --action config-wizard"],
+            ["lla plugin --name folder_cleaner --action config-wizard"],
             |_| FolderCleanerPlugin::config_wizard_action()
         );
 
@@ -154,7 +150,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name folder_cleaner --action help"],
+            ["lla plugin --name folder_cleaner --action help"],
             |_| FolderCleanerPlugin::help_action()
         );
 

--- a/plugins/folder_cleaner/src/planner.rs
+++ b/plugins/folder_cleaner/src/planner.rs
@@ -117,6 +117,14 @@ fn plan_cleanup(
         .map(|action| action.source.clone())
         .collect::<HashSet<_>>();
     let protected_dirs = protected_dirs(report, destination_dirs, actions);
+    let mut quarantine = QuarantinePlanner {
+        report,
+        config,
+        plan_id,
+        actions,
+        reserved_targets,
+        cleanup_sources: &mut cleanup_sources,
+    };
 
     if config.cleanup.temp_files || config.cleanup.os_junk || config.cleanup.old_archives {
         for entry in report.entries.iter().filter(|entry| entry.is_file) {
@@ -126,17 +134,7 @@ fn plan_cleanup(
 
             let reason = cleanup_reason(entry, report, config);
             if let Some(reason) = reason {
-                add_quarantine_action(
-                    report,
-                    config,
-                    plan_id,
-                    entry,
-                    reason,
-                    None,
-                    actions,
-                    reserved_targets,
-                    &mut cleanup_sources,
-                );
+                quarantine.add(entry, reason, None);
             }
         }
     }
@@ -153,16 +151,10 @@ fn plan_cleanup(
             });
 
             for entry in sorted.into_iter().skip(1) {
-                add_quarantine_action(
-                    report,
-                    config,
-                    plan_id,
+                quarantine.add(
                     entry,
                     "duplicate file; oldest copy kept".to_string(),
                     Some(hash.clone()),
-                    actions,
-                    reserved_targets,
-                    &mut cleanup_sources,
                 );
             }
         }
@@ -200,56 +192,48 @@ fn plan_cleanup(
                 continue;
             }
 
-            add_quarantine_action(
-                report,
-                config,
-                plan_id,
-                entry,
-                "empty directory".to_string(),
-                None,
-                actions,
-                reserved_targets,
-                &mut cleanup_sources,
-            );
+            quarantine.add(entry, "empty directory".to_string(), None);
         }
     }
 }
 
-fn add_quarantine_action(
-    report: &ScanReport,
-    config: &FolderCleanerConfig,
-    plan_id: &str,
-    entry: &ScannedEntry,
-    reason: String,
-    hash: Option<String>,
-    actions: &mut Vec<PlanAction>,
-    reserved_targets: &mut HashSet<PathBuf>,
-    cleanup_sources: &mut HashSet<PathBuf>,
-) {
-    if !cleanup_sources.insert(entry.path.clone()) {
-        return;
+struct QuarantinePlanner<'a> {
+    report: &'a ScanReport,
+    config: &'a FolderCleanerConfig,
+    plan_id: &'a str,
+    actions: &'a mut Vec<PlanAction>,
+    reserved_targets: &'a mut HashSet<PathBuf>,
+    cleanup_sources: &'a mut HashSet<PathBuf>,
+}
+
+impl QuarantinePlanner<'_> {
+    fn add(&mut self, entry: &ScannedEntry, reason: String, hash: Option<String>) {
+        if !self.cleanup_sources.insert(entry.path.clone()) {
+            return;
+        }
+
+        self.actions.retain(|action| action.source != entry.path);
+        let relative = relative_to(&self.report.root, &entry.path);
+        let target = unique_target(
+            &self
+                .report
+                .root
+                .join(&self.config.safety.quarantine_dir)
+                .join(self.plan_id)
+                .join(relative),
+            self.reserved_targets,
+        );
+
+        self.actions.push(PlanAction {
+            id: self.actions.len() + 1,
+            kind: OperationKind::Quarantine,
+            source: entry.path.clone(),
+            target,
+            reason,
+            category: None,
+            hash,
+        });
     }
-
-    actions.retain(|action| action.source != entry.path);
-    let relative = relative_to(&report.root, &entry.path);
-    let target = unique_target(
-        &report
-            .root
-            .join(&config.safety.quarantine_dir)
-            .join(plan_id)
-            .join(relative),
-        reserved_targets,
-    );
-
-    actions.push(PlanAction {
-        id: actions.len() + 1,
-        kind: OperationKind::Quarantine,
-        source: entry.path.clone(),
-        target,
-        reason,
-        category: None,
-        hash,
-    });
 }
 
 fn destination_dirs(report: &ScanReport, config: &FolderCleanerConfig) -> HashSet<PathBuf> {

--- a/plugins/git_status/Cargo.toml
+++ b/plugins/git_status/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "git_status"
 description = "Shows Git repository status information"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/git_status/plugin.toml
+++ b/plugins/git_status/plugin.toml
@@ -1,0 +1,43 @@
+[plugin]
+id = "dev.lla.git-status"
+name = "git_status"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "git_status"
+description = "Expose repository and per-entry Git status"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["help"]
+machine_output = true
+
+[permissions]
+filesystem = ["metadata:tree"]
+process = true
+
+[[fields]]
+name = "git_status"
+type = "string"
+filterable = true
+
+[[fields]]
+name = "git_branch"
+type = "string"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "git_staged"
+type = "integer"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "git_modified"
+type = "integer"
+sortable = true
+filterable = true

--- a/plugins/git_status/src/lib.rs
+++ b/plugins/git_status/src/lib.rs
@@ -19,7 +19,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name git_status --action help"],
+            ["lla plugin --name git_status --action help"],
             |_| {
                 let mut help = HelpFormatter::new("Git Status Plugin".to_string());
                 help.add_section("Description".to_string()).add_command(

--- a/plugins/google_meet/Cargo.toml
+++ b/plugins/google_meet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_meet"
 description = "Google Meet plugin for creating meeting rooms and managing links"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_meet/plugin.toml
+++ b/plugins/google_meet/plugin.toml
@@ -1,0 +1,19 @@
+[plugin]
+id = "dev.lla.google-meet"
+name = "google_meet"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "google_meet"
+description = "Create and manage Google Meet links"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["create", "create-with-profile", "history", "profiles", "preferences", "help"]
+
+[permissions]
+network = ["meet.google.com"]
+clipboard = true
+open_url = true

--- a/plugins/google_meet/src/lib.rs
+++ b/plugins/google_meet/src/lib.rs
@@ -280,7 +280,7 @@ impl GoogleMeetPlugin {
         #[cfg(target_os = "windows")]
         {
             std::process::Command::new("cmd")
-                .args(&["/C", "start", &url])
+                .args(["/C", "start", &url])
                 .spawn()
                 .map_err(|e| format!("Failed to open browser: {}", e))?;
         }
@@ -308,7 +308,7 @@ impl GoogleMeetPlugin {
         #[cfg(target_os = "windows")]
         {
             std::process::Command::new("cmd")
-                .args(&["/C", "start", url])
+                .args(["/C", "start", url])
                 .spawn()
                 .map_err(|e| format!("Failed to open browser: {}", e))?;
         }

--- a/plugins/google_search/Cargo.toml
+++ b/plugins/google_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_search"
 description = "Google search with autosuggestions, search history management, and clipboard fallback"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_search/plugin.toml
+++ b/plugins/google_search/plugin.toml
@@ -1,0 +1,19 @@
+[plugin]
+id = "dev.lla.google-search"
+name = "google_search"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "google_search"
+description = "Search Google with suggestions and history"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["search", "search-selected", "history", "preferences", "help"]
+
+[permissions]
+network = ["google.com", "suggestqueries.google.com"]
+clipboard = true
+open_url = true

--- a/plugins/hackernews/Cargo.toml
+++ b/plugins/hackernews/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hackernews"
 description = "Hacker News plugin - browse top stories, best stories, new stories, ask HN, and show HN"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/hackernews/plugin.toml
+++ b/plugins/hackernews/plugin.toml
@@ -1,0 +1,19 @@
+[plugin]
+id = "dev.lla.hackernews"
+name = "hackernews"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "hackernews"
+description = "Browse Hacker News stories and discussions"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["top", "best", "new", "ask", "show", "jobs", "open", "comments", "copy", "browse", "menu", "help"]
+
+[permissions]
+network = ["hacker-news.firebaseio.com", "news.ycombinator.com"]
+clipboard = true
+open_url = true

--- a/plugins/jwt/Cargo.toml
+++ b/plugins/jwt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jwt"
 description = "JWT decoder and analyzer with search and validation capabilities"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/jwt/plugin.toml
+++ b/plugins/jwt/plugin.toml
@@ -1,0 +1,17 @@
+[plugin]
+id = "dev.lla.jwt"
+name = "jwt"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "jwt"
+description = "Decode and inspect JSON Web Tokens"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["decode", "search", "history", "preferences", "help"]
+
+[permissions]
+clipboard = true

--- a/plugins/keyword_search/Cargo.toml
+++ b/plugins/keyword_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "keyword_search"
 description = "Searches file contents for user-specified keywords"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/keyword_search/plugin.toml
+++ b/plugins/keyword_search/plugin.toml
@@ -1,0 +1,25 @@
+[plugin]
+id = "dev.lla.keyword-search"
+name = "keyword_search"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "keyword_search"
+description = "Search selected file contents for keywords"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["search", "help"]
+machine_output = true
+
+[permissions]
+filesystem = ["read:selection", "write:user-path"]
+clipboard = true
+
+[[fields]]
+name = "keyword_matches"
+type = "string"
+filterable = true

--- a/plugins/kill_process/Cargo.toml
+++ b/plugins/kill_process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kill_process"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 description = "A plugin for lla that allows killing processes with an interactive interface"
 

--- a/plugins/kill_process/plugin.toml
+++ b/plugins/kill_process/plugin.toml
@@ -1,0 +1,17 @@
+[plugin]
+id = "dev.lla.kill-process"
+name = "kill_process"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "kill_process"
+description = "Inspect and terminate operating-system processes"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["list", "kill", "force-kill", "kill-by-name", "force-kill-by-name", "kill-by-pid", "force-kill-by-pid", "help"]
+
+[permissions]
+process = true

--- a/plugins/last_git_commit/Cargo.toml
+++ b/plugins/last_git_commit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "last_git_commit"
 description = "A plugin for the lla that provides the last git commit hash"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/last_git_commit/plugin.toml
+++ b/plugins/last_git_commit/plugin.toml
@@ -1,0 +1,37 @@
+[plugin]
+id = "dev.lla.last-git-commit"
+name = "last_git_commit"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "last_git_commit"
+description = "Expose the last Git commit for each entry"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["help"]
+machine_output = true
+
+[permissions]
+filesystem = ["metadata:tree"]
+process = true
+
+[[fields]]
+name = "commit_hash"
+type = "string"
+filterable = true
+
+[[fields]]
+name = "commit_author"
+type = "string"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "commit_time"
+type = "timestamp"
+sortable = true
+filterable = true

--- a/plugins/last_git_commit/src/lib.rs
+++ b/plugins/last_git_commit/src/lib.rs
@@ -7,8 +7,12 @@ use lla_plugin_utils::{
 };
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use serde_json;
-use std::{collections::HashMap, path::Path, process::Command};
+use std::{
+    collections::HashMap,
+    path::Path,
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 lazy_static! {
     static ref SPINNER: RwLock<Spinner> = RwLock::new(Spinner::new());
@@ -20,7 +24,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name last_git_commit --action help"],
+            ["lla plugin --name last_git_commit --action help"],
             |_| {
                 let mut help = HelpFormatter::new("Last Git Commit Plugin".to_string());
                 help.add_section("Description".to_string()).add_command(
@@ -109,7 +113,7 @@ impl LastGitCommitPlugin {
             .args([
                 "log",
                 "-1",
-                "--format=format:{ \"hash\": \"%h\", \"author\": \"%an\", \"time\": \"%ar\" }",
+                "--format=format:{ \"hash\": \"%h\", \"author\": \"%an\", \"time\": \"%at\" }",
                 "--",
                 path.to_str()?,
             ])
@@ -146,6 +150,26 @@ impl LastGitCommitPlugin {
         }
     }
 
+    fn format_relative_time(value: &str) -> String {
+        let Some(timestamp) = value.parse::<u64>().ok() else {
+            return value.to_string();
+        };
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let elapsed = now.saturating_sub(timestamp);
+        if elapsed < 60 {
+            format!("{} seconds ago", elapsed)
+        } else if elapsed < 3_600 {
+            format!("{} minutes ago", elapsed / 60)
+        } else if elapsed < 86_400 {
+            format!("{} hours ago", elapsed / 3_600)
+        } else {
+            format!("{} days ago", elapsed / 86_400)
+        }
+    }
+
     fn format_commit_info(
         &self,
         entry: &lla_plugin_interface::DecoratedEntry,
@@ -159,6 +183,7 @@ impl LastGitCommitPlugin {
             entry.custom_fields.get("commit_author"),
             entry.custom_fields.get("commit_time"),
         ) {
+            let time_display = Self::format_relative_time(time);
             match format {
                 "long" => {
                     let key_color = colors
@@ -189,7 +214,7 @@ impl LastGitCommitPlugin {
                         .get("time")
                         .unwrap_or(&"white".to_string())
                         .to_string();
-                    let kv = KeyValue::new("Time", time)
+                    let kv = KeyValue::new("Time", &time_display)
                         .key_color(&key_color)
                         .value_color(&time_color)
                         .key_width(12);
@@ -204,7 +229,7 @@ impl LastGitCommitPlugin {
                         .get("hash")
                         .unwrap_or(&"white".to_string())
                         .to_string();
-                    let kv = KeyValue::new("Commit", format!("{} {}", hash, time))
+                    let kv = KeyValue::new("Commit", format!("{} {}", hash, time_display))
                         .key_color(&key_color)
                         .value_color(&hash_color)
                         .key_width(12);
@@ -297,3 +322,25 @@ impl ConfigurablePlugin for LastGitCommitPlugin {
 impl ProtobufHandler for LastGitCommitPlugin {}
 
 lla_plugin_interface::declare_plugin!(LastGitCommitPlugin);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_commit_timestamps_keep_a_relative_human_display() {
+        let two_minutes_ago = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .saturating_sub(120);
+        assert_eq!(
+            LastGitCommitPlugin::format_relative_time(&two_minutes_ago.to_string()),
+            "2 minutes ago"
+        );
+        assert_eq!(
+            LastGitCommitPlugin::format_relative_time("legacy"),
+            "legacy"
+        );
+    }
+}

--- a/plugins/last_git_commit/src/lib.rs
+++ b/plugins/last_git_commit/src/lib.rs
@@ -129,20 +129,9 @@ impl LastGitCommitPlugin {
 
         match serde_json::from_str::<serde_json::Value>(trimmed) {
             Ok(json) => {
-                let hash = match json.get("hash").and_then(|v| v.as_str()) {
-                    Some(h) => h.to_string(),
-                    None => return None,
-                };
-
-                let author = match json.get("author").and_then(|v| v.as_str()) {
-                    Some(a) => a.to_string(),
-                    None => return None,
-                };
-
-                let time = match json.get("time").and_then(|v| v.as_str()) {
-                    Some(t) => t.to_string(),
-                    None => return None,
-                };
+                let hash = json.get("hash").and_then(|v| v.as_str())?.to_string();
+                let author = json.get("author").and_then(|v| v.as_str())?.to_string();
+                let time = json.get("time").and_then(|v| v.as_str())?.to_string();
 
                 Some((hash, author, time))
             }

--- a/plugins/media_inspector/Cargo.toml
+++ b/plugins/media_inspector/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "file_remover"
+name = "media_inspector"
 version = "0.5.12"
 edition = "2021"
-description = "Interactively trash files by default with explicit permanent deletion"
+description = "Inspect MIME types, image metadata, and audio/video stream details"
 
 [lib]
 crate-type = ["cdylib"]
@@ -10,9 +10,10 @@ crate-type = ["cdylib"]
 [dependencies]
 lla_plugin_interface = { path = "../../lla_plugin_interface" }
 lla_plugin_utils = { path = "../../lla_plugin_utils" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-dialoguer = "0.11"
-colored = "2.0"
 lazy_static = "1.4"
 parking_lot = "0.12"
+serde_json = "1.0"
+kamadak-exif = "0.6"
+
+[dev-dependencies]
+tempfile = "3.2"

--- a/plugins/media_inspector/README.md
+++ b/plugins/media_inspector/README.md
@@ -1,0 +1,14 @@
+# Media Inspector Plugin
+
+Provides MIME and media metadata as listing fields. PNG, GIF, and JPEG dimensions have
+built-in parsers. Optional system tools enrich the result: `file` for MIME detection,
+`exiftool` for EXIF, `ffprobe` for audio/video duration and streams, and `sips` or
+ImageMagick `identify` as image-dimension fallbacks.
+
+```bash
+lla --enable-plugin media_inspector --long ./media
+lla plugin media_inspector inspect ./media/video.mp4
+lla plugin media_inspector tools
+```
+
+Missing optional tools do not prevent the plugin from loading or decorating entries.

--- a/plugins/media_inspector/plugin.toml
+++ b/plugins/media_inspector/plugin.toml
@@ -1,0 +1,66 @@
+[plugin]
+id = "dev.lla.media-inspector"
+name = "media_inspector"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "media_inspector"
+description = "Inspect MIME, dimensions, EXIF, duration, codecs, and bitrate"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["inspect", "tools", "help"]
+machine_output = true
+
+[permissions]
+filesystem = ["read:selection", "read:user-path"]
+process = true
+
+[[fields]]
+name = "mime_type"
+type = "string"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "media_kind"
+type = "string"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "media_width"
+type = "integer"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "media_height"
+type = "integer"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "duration_ms"
+type = "integer"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "codecs"
+type = "string"
+filterable = true
+
+[[fields]]
+name = "bitrate_bps"
+type = "integer"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "exif"
+type = "string"
+filterable = true

--- a/plugins/media_inspector/src/lib.rs
+++ b/plugins/media_inspector/src/lib.rs
@@ -1,0 +1,586 @@
+use lazy_static::lazy_static;
+use lla_plugin_interface::{DecoratedEntry, Plugin, PluginRequest, PluginResponse};
+use lla_plugin_utils::{ActionRegistry, ProtobufHandler};
+use parking_lot::RwLock;
+use serde_json::Value;
+use std::{
+    collections::BTreeSet,
+    fs::File,
+    io::{BufReader, Read},
+    path::Path,
+    process::{Command, Stdio},
+};
+
+lazy_static! {
+    static ref ACTIONS: RwLock<ActionRegistry> = RwLock::new({
+        let mut actions = ActionRegistry::new();
+        lla_plugin_utils::define_action!(
+            actions,
+            "inspect",
+            "inspect <path>",
+            "Print complete media metadata for a file",
+            ["lla plugin media_inspector inspect ./photo.jpg"],
+            MediaInspectorPlugin::inspect_action
+        );
+        lla_plugin_utils::define_action!(
+            actions,
+            "tools",
+            "tools",
+            "Report optional media metadata tools available on PATH",
+            ["lla plugin media_inspector tools"],
+            |_| MediaInspectorPlugin::tools_action()
+        );
+        lla_plugin_utils::define_action!(
+            actions,
+            "help",
+            "help",
+            "Show media inspector usage",
+            ["lla plugin media_inspector help"],
+            |_| MediaInspectorPlugin::help_action()
+        );
+        actions
+    });
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct MediaInfo {
+    mime_type: String,
+    kind: String,
+    width: Option<u32>,
+    height: Option<u32>,
+    duration_ms: Option<u64>,
+    codecs: Vec<String>,
+    bitrate_bps: Option<u64>,
+    exif: Option<String>,
+}
+
+pub struct MediaInspectorPlugin;
+
+impl MediaInspectorPlugin {
+    fn inspect_path(path: &Path) -> MediaInfo {
+        if path.is_dir() {
+            return MediaInfo {
+                mime_type: "inode/directory".to_string(),
+                kind: "directory".to_string(),
+                ..MediaInfo::default()
+            };
+        }
+        let mime_type = detect_mime(path);
+        let kind = media_kind(&mime_type).to_string();
+        let mut info = MediaInfo {
+            mime_type,
+            kind,
+            ..MediaInfo::default()
+        };
+
+        if info.kind == "image" {
+            let dimensions = builtin_dimensions(path).or_else(|| external_dimensions(path));
+            if let Some((width, height)) = dimensions {
+                info.width = Some(width);
+                info.height = Some(height);
+            }
+            info.exif = exif_summary(path);
+        }
+        if matches!(info.kind.as_str(), "audio" | "video") {
+            apply_ffprobe(path, &mut info);
+        }
+        info
+    }
+
+    fn decorate(mut entry: DecoratedEntry) -> DecoratedEntry {
+        let info = Self::inspect_path(&entry.path);
+        entry
+            .custom_fields
+            .insert("mime_type".to_string(), info.mime_type);
+        entry
+            .custom_fields
+            .insert("media_kind".to_string(), info.kind);
+        if let Some(width) = info.width {
+            entry
+                .custom_fields
+                .insert("media_width".to_string(), width.to_string());
+        }
+        if let Some(height) = info.height {
+            entry
+                .custom_fields
+                .insert("media_height".to_string(), height.to_string());
+        }
+        if let Some(duration) = info.duration_ms {
+            entry
+                .custom_fields
+                .insert("duration_ms".to_string(), duration.to_string());
+        }
+        if !info.codecs.is_empty() {
+            entry
+                .custom_fields
+                .insert("codecs".to_string(), info.codecs.join(", "));
+        }
+        if let Some(bitrate) = info.bitrate_bps {
+            entry
+                .custom_fields
+                .insert("bitrate_bps".to_string(), bitrate.to_string());
+        }
+        if let Some(exif) = info.exif {
+            entry.custom_fields.insert("exif".to_string(), exif);
+        }
+        entry
+    }
+
+    fn format(entry: &DecoratedEntry, format: &str) -> Option<String> {
+        let mime = entry.custom_fields.get("mime_type")?;
+        let kind = entry.custom_fields.get("media_kind")?;
+        let dimensions = entry
+            .custom_fields
+            .get("media_width")
+            .zip(entry.custom_fields.get("media_height"))
+            .map(|(width, height)| format!("{width}x{height}"));
+        match format {
+            "default" => Some(match dimensions {
+                Some(dimensions) => format!("[{mime}; {dimensions}]"),
+                None => format!("[{mime}]"),
+            }),
+            "long" => {
+                let mut rows = vec![format!("Type: {kind}"), format!("MIME: {mime}")];
+                if let Some(dimensions) = dimensions {
+                    rows.push(format!("Dimensions: {dimensions}"));
+                }
+                if let Some(duration) = entry.custom_fields.get("duration_ms") {
+                    rows.push(format!("Duration: {} ms", duration));
+                }
+                if let Some(codecs) = entry.custom_fields.get("codecs") {
+                    rows.push(format!("Codecs: {codecs}"));
+                }
+                if let Some(bitrate) = entry.custom_fields.get("bitrate_bps") {
+                    rows.push(format!("Bitrate: {bitrate} bps"));
+                }
+                if let Some(exif) = entry.custom_fields.get("exif") {
+                    rows.push(format!("EXIF: {exif}"));
+                }
+                Some(rows.join("\n"))
+            }
+            _ => None,
+        }
+    }
+
+    fn inspect_action(args: &[String]) -> Result<(), String> {
+        let path = args
+            .first()
+            .map(Path::new)
+            .ok_or_else(|| "Usage: inspect <path>".to_string())?;
+        if !path.exists() {
+            return Err(format!("Path does not exist: {}", path.display()));
+        }
+        let info = Self::inspect_path(path);
+        println!("Path: {}", path.display());
+        println!("Kind: {}", info.kind);
+        println!("MIME: {}", info.mime_type);
+        if let (Some(width), Some(height)) = (info.width, info.height) {
+            println!("Dimensions: {width}x{height}");
+        }
+        if let Some(duration) = info.duration_ms {
+            println!("Duration: {duration} ms");
+        }
+        if !info.codecs.is_empty() {
+            println!("Codecs: {}", info.codecs.join(", "));
+        }
+        if let Some(bitrate) = info.bitrate_bps {
+            println!("Bitrate: {bitrate} bps");
+        }
+        if let Some(exif) = info.exif {
+            println!("EXIF: {exif}");
+        }
+        Ok(())
+    }
+
+    fn tools_action() -> Result<(), String> {
+        for tool in ["file", "ffprobe", "exiftool", "sips", "identify"] {
+            println!(
+                "{tool}: {}",
+                if tool_available(tool) {
+                    "available"
+                } else {
+                    "not found"
+                }
+            );
+        }
+        Ok(())
+    }
+
+    fn help_action() -> Result<(), String> {
+        println!(
+            "media_inspector\n\n  inspect <path>  Print MIME, dimensions, EXIF, duration, codecs, and bitrate\n  tools           Show optional backends\n  help            Show this help\n\nBuilt-in image parsing works without external tools. ffprobe and exiftool add richer audio/video and EXIF data."
+        );
+        Ok(())
+    }
+}
+
+fn detect_mime(path: &Path) -> String {
+    let builtin = builtin_mime(path);
+    if builtin != "application/octet-stream" {
+        return builtin.to_string();
+    }
+    command_output("file", &["--brief", "--mime-type", &path.to_string_lossy()])
+        .filter(|value| value.contains('/'))
+        .unwrap_or_else(|| builtin.to_string())
+}
+
+fn builtin_mime(path: &Path) -> &'static str {
+    let mut header = [0u8; 16];
+    let read = File::open(path)
+        .and_then(|mut file| file.read(&mut header))
+        .unwrap_or(0);
+    let header = &header[..read];
+    if header.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return "image/png";
+    }
+    if header.starts_with(b"\xff\xd8\xff") {
+        return "image/jpeg";
+    }
+    if header.starts_with(b"GIF87a") || header.starts_with(b"GIF89a") {
+        return "image/gif";
+    }
+    if header.starts_with(b"RIFF") && header.get(8..12) == Some(b"WEBP") {
+        return "image/webp";
+    }
+    if header.starts_with(b"%PDF-") {
+        return "application/pdf";
+    }
+    if header.starts_with(b"PK\x03\x04") {
+        return "application/zip";
+    }
+    match path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "mp3" => "audio/mpeg",
+        "wav" => "audio/wav",
+        "flac" => "audio/flac",
+        "m4a" => "audio/mp4",
+        "mp4" | "m4v" => "video/mp4",
+        "mov" => "video/quicktime",
+        "mkv" => "video/x-matroska",
+        "webm" => "video/webm",
+        "svg" => "image/svg+xml",
+        "md" | "markdown" => "text/markdown",
+        "txt" | "rs" | "toml" | "json" | "yaml" | "yml" => "text/plain",
+        _ => "application/octet-stream",
+    }
+}
+
+fn media_kind(mime: &str) -> &'static str {
+    if mime.starts_with("image/") {
+        "image"
+    } else if mime.starts_with("audio/") {
+        "audio"
+    } else if mime.starts_with("video/") {
+        "video"
+    } else if mime.starts_with("text/") {
+        "text"
+    } else {
+        "other"
+    }
+}
+
+fn builtin_dimensions(path: &Path) -> Option<(u32, u32)> {
+    let mut bytes = Vec::new();
+    File::open(path)
+        .ok()?
+        .take(2 * 1024 * 1024)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") && bytes.len() >= 24 {
+        return Some((
+            u32::from_be_bytes(bytes[16..20].try_into().ok()?),
+            u32::from_be_bytes(bytes[20..24].try_into().ok()?),
+        ));
+    }
+    if (bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a")) && bytes.len() >= 10 {
+        return Some((
+            u16::from_le_bytes(bytes[6..8].try_into().ok()?) as u32,
+            u16::from_le_bytes(bytes[8..10].try_into().ok()?) as u32,
+        ));
+    }
+    jpeg_dimensions(&bytes)
+}
+
+fn jpeg_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
+    if !bytes.starts_with(b"\xff\xd8") {
+        return None;
+    }
+    let mut index = 2usize;
+    while index + 8 < bytes.len() {
+        if bytes[index] != 0xff {
+            index += 1;
+            continue;
+        }
+        let marker = bytes[index + 1];
+        index += 2;
+        if marker == 0xd8 || marker == 0xd9 || (0xd0..=0xd7).contains(&marker) {
+            continue;
+        }
+        let length = u16::from_be_bytes(bytes.get(index..index + 2)?.try_into().ok()?) as usize;
+        if length < 2 || index + length > bytes.len() {
+            return None;
+        }
+        if matches!(
+            marker,
+            0xc0 | 0xc1
+                | 0xc2
+                | 0xc3
+                | 0xc5
+                | 0xc6
+                | 0xc7
+                | 0xc9
+                | 0xca
+                | 0xcb
+                | 0xcd
+                | 0xce
+                | 0xcf
+        ) {
+            let height = u16::from_be_bytes(bytes.get(index + 3..index + 5)?.try_into().ok()?);
+            let width = u16::from_be_bytes(bytes.get(index + 5..index + 7)?.try_into().ok()?);
+            return Some((width as u32, height as u32));
+        }
+        index += length;
+    }
+    None
+}
+
+fn external_dimensions(path: &Path) -> Option<(u32, u32)> {
+    let path = path.to_string_lossy();
+    if let Some(output) = command_output("sips", &["-g", "pixelWidth", "-g", "pixelHeight", &path])
+    {
+        let values = output
+            .lines()
+            .filter_map(|line| line.split(':').nth(1)?.trim().parse::<u32>().ok())
+            .collect::<Vec<_>>();
+        if values.len() >= 2 {
+            return Some((values[0], values[1]));
+        }
+    }
+    command_output("identify", &["-format", "%w %h", &path]).and_then(|output| {
+        let mut values = output
+            .split_whitespace()
+            .filter_map(|value| value.parse().ok());
+        Some((values.next()?, values.next()?))
+    })
+}
+
+fn exif_summary(path: &Path) -> Option<String> {
+    builtin_exif_summary(path).or_else(|| external_exif_summary(path))
+}
+
+fn builtin_exif_summary(path: &Path) -> Option<String> {
+    let file = File::open(path).ok()?;
+    let mut reader = BufReader::new(file);
+    let exif = exif::Reader::new().read_from_container(&mut reader).ok()?;
+    let tags = [
+        ("captured", exif::Tag::DateTimeOriginal),
+        ("make", exif::Tag::Make),
+        ("model", exif::Tag::Model),
+        ("orientation", exif::Tag::Orientation),
+        ("gps-latitude", exif::Tag::GPSLatitude),
+        ("gps-longitude", exif::Tag::GPSLongitude),
+    ];
+    let values = tags
+        .iter()
+        .filter_map(|(label, tag)| {
+            exif.get_field(*tag, exif::In::PRIMARY)
+                .map(|field| format!("{label}={}", field.display_value().with_unit(&exif)))
+        })
+        .collect::<Vec<_>>();
+    (!values.is_empty()).then(|| values.join(" | "))
+}
+
+fn external_exif_summary(path: &Path) -> Option<String> {
+    command_output(
+        "exiftool",
+        &[
+            "-s",
+            "-s",
+            "-s",
+            "-DateTimeOriginal",
+            "-Make",
+            "-Model",
+            "-Orientation",
+            "-GPSPosition",
+            &path.to_string_lossy(),
+        ],
+    )
+    .map(|output| {
+        output
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>()
+            .join(" | ")
+    })
+    .filter(|output| !output.is_empty())
+}
+
+fn apply_ffprobe(path: &Path, info: &mut MediaInfo) {
+    let Some(output) = command_output(
+        "ffprobe",
+        &[
+            "-v",
+            "quiet",
+            "-print_format",
+            "json",
+            "-show_format",
+            "-show_streams",
+            &path.to_string_lossy(),
+        ],
+    ) else {
+        return;
+    };
+    let Ok(value) = serde_json::from_str::<Value>(&output) else {
+        return;
+    };
+    apply_ffprobe_value(&value, info);
+}
+
+fn apply_ffprobe_value(value: &Value, info: &mut MediaInfo) {
+    let format = value.get("format").unwrap_or(&Value::Null);
+    info.duration_ms = json_number(format.get("duration"))
+        .map(|duration| (duration * 1000.0).round().max(0.0) as u64);
+    info.bitrate_bps = json_u64(format.get("bit_rate"));
+    let mut codecs = BTreeSet::new();
+    if let Some(streams) = value.get("streams").and_then(Value::as_array) {
+        for stream in streams {
+            if let Some(codec) = stream.get("codec_name").and_then(Value::as_str) {
+                codecs.insert(codec.to_string());
+            }
+            if info.width.is_none() {
+                info.width = stream
+                    .get("width")
+                    .and_then(Value::as_u64)
+                    .map(|value| value as u32);
+            }
+            if info.height.is_none() {
+                info.height = stream
+                    .get("height")
+                    .and_then(Value::as_u64)
+                    .map(|value| value as u32);
+            }
+            if info.bitrate_bps.is_none() {
+                info.bitrate_bps = json_u64(stream.get("bit_rate"));
+            }
+        }
+    }
+    info.codecs = codecs.into_iter().collect();
+}
+
+fn json_number(value: Option<&Value>) -> Option<f64> {
+    value.and_then(|value| {
+        value
+            .as_f64()
+            .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
+    })
+}
+
+fn json_u64(value: Option<&Value>) -> Option<u64> {
+    value.and_then(|value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
+    })
+}
+
+fn command_output(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn tool_available(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("-version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok()
+}
+
+impl Plugin for MediaInspectorPlugin {
+    fn handle_raw_request(&mut self, request: &[u8]) -> Vec<u8> {
+        let response = match self.decode_request(request) {
+            Ok(PluginRequest::GetName) => PluginResponse::Name(env!("CARGO_PKG_NAME").into()),
+            Ok(PluginRequest::GetVersion) => {
+                PluginResponse::Version(env!("CARGO_PKG_VERSION").into())
+            }
+            Ok(PluginRequest::GetDescription) => {
+                PluginResponse::Description(env!("CARGO_PKG_DESCRIPTION").into())
+            }
+            Ok(PluginRequest::GetSupportedFormats) => {
+                PluginResponse::SupportedFormats(vec!["default".into(), "long".into()])
+            }
+            Ok(PluginRequest::Decorate(entry)) => PluginResponse::Decorated(Self::decorate(entry)),
+            Ok(PluginRequest::FormatField(entry, format)) => {
+                PluginResponse::FormattedField(Self::format(&entry, &format))
+            }
+            Ok(PluginRequest::PerformAction(action, args)) => {
+                PluginResponse::ActionResult(ACTIONS.read().handle(&action, &args))
+            }
+            Ok(PluginRequest::GetAvailableActions) => {
+                PluginResponse::AvailableActions(ACTIONS.read().list_actions())
+            }
+            Err(error) => return self.encode_error(&error),
+        };
+        self.encode_response(response)
+    }
+}
+
+impl ProtobufHandler for MediaInspectorPlugin {}
+
+lla_plugin_interface::declare_plugin!(MediaInspectorPlugin);
+
+impl Default for MediaInspectorPlugin {
+    fn default() -> Self {
+        Self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn reads_png_dimensions_without_external_tools() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("pixel.png");
+        let mut png = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR".to_vec();
+        png.extend_from_slice(&320u32.to_be_bytes());
+        png.extend_from_slice(&200u32.to_be_bytes());
+        png.extend_from_slice(&[8, 2, 0, 0, 0]);
+        fs::write(&path, png).unwrap();
+        assert_eq!(builtin_dimensions(&path), Some((320, 200)));
+        assert_eq!(builtin_mime(&path), "image/png");
+    }
+
+    #[test]
+    fn parses_ffprobe_shape() {
+        let value: Value = serde_json::from_str(
+            r#"{"format":{"duration":"2.5","bit_rate":"128000"},"streams":[{"codec_name":"h264","width":1920,"height":1080},{"codec_name":"aac"}]}"#,
+        )
+        .unwrap();
+        let mut info = MediaInfo::default();
+        apply_ffprobe_value(&value, &mut info);
+        assert_eq!(info.duration_ms, Some(2500));
+        assert_eq!(info.bitrate_bps, Some(128000));
+        assert_eq!(info.width, Some(1920));
+        assert_eq!(info.height, Some(1080));
+        assert_eq!(info.codecs, vec!["aac", "h264"]);
+    }
+}

--- a/plugins/npm/Cargo.toml
+++ b/plugins/npm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "npm"
 description = "NPM package search with bundlephobia integration and favorites management"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/npm/plugin.toml
+++ b/plugins/npm/plugin.toml
@@ -1,0 +1,19 @@
+[plugin]
+id = "dev.lla.npm"
+name = "npm"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "npm"
+description = "Search npm packages and inspect bundle size"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["search", "favorites", "preferences", "help"]
+
+[permissions]
+network = ["registry.npmjs.org", "bundlephobia.com"]
+clipboard = true
+open_url = true

--- a/plugins/preview/Cargo.toml
+++ b/plugins/preview/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "file_remover"
+name = "preview"
 version = "0.5.12"
 edition = "2021"
-description = "Interactively trash files by default with explicit permanent deletion"
+description = "Preview text, Markdown, images, and archive contents in the terminal"
 
 [lib]
 crate-type = ["cdylib"]
@@ -10,9 +10,8 @@ crate-type = ["cdylib"]
 [dependencies]
 lla_plugin_interface = { path = "../../lla_plugin_interface" }
 lla_plugin_utils = { path = "../../lla_plugin_utils" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-dialoguer = "0.11"
-colored = "2.0"
 lazy_static = "1.4"
 parking_lot = "0.12"
+
+[dev-dependencies]
+tempfile = "3.2"

--- a/plugins/preview/README.md
+++ b/plugins/preview/README.md
@@ -1,0 +1,16 @@
+# Preview Plugin
+
+Renders bounded terminal previews without extracting archives or modifying files.
+
+- Text and Markdown use `bat` when available, with a safe built-in text fallback.
+- Images use `chafa` when available, with a metadata fallback.
+- ZIP and tar-family archives are listed via `unzip`/`tar`; uncompressed ZIP and tar
+  files also have built-in listing fallbacks.
+
+```bash
+lla plugin preview show README.md
+lla plugin preview show src/main.rs -- --lines 80
+lla plugin preview show screenshot.png
+lla plugin preview show release.tar.gz
+lla plugin preview backends
+```

--- a/plugins/preview/plugin.toml
+++ b/plugins/preview/plugin.toml
@@ -1,0 +1,31 @@
+[plugin]
+id = "dev.lla.preview"
+name = "preview"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "preview"
+description = "Preview source text, Markdown, images, and archives in the terminal"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["show", "backends", "help"]
+machine_output = true
+
+[permissions]
+filesystem = ["read:selection", "read:user-path"]
+process = true
+
+[[fields]]
+name = "preview_kind"
+type = "string"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "preview_backend"
+type = "string"
+filterable = true

--- a/plugins/preview/src/lib.rs
+++ b/plugins/preview/src/lib.rs
@@ -1,0 +1,499 @@
+use lazy_static::lazy_static;
+use lla_plugin_interface::{DecoratedEntry, Plugin, PluginRequest, PluginResponse};
+use lla_plugin_utils::{ActionRegistry, ProtobufHandler};
+use parking_lot::RwLock;
+use std::{
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    path::Path,
+    process::{Command, Stdio},
+    sync::OnceLock,
+};
+
+static BAT_AVAILABLE: OnceLock<bool> = OnceLock::new();
+static CHAFA_AVAILABLE: OnceLock<bool> = OnceLock::new();
+static TAR_AVAILABLE: OnceLock<bool> = OnceLock::new();
+static UNZIP_AVAILABLE: OnceLock<bool> = OnceLock::new();
+
+lazy_static! {
+    static ref ACTIONS: RwLock<ActionRegistry> = RwLock::new({
+        let mut actions = ActionRegistry::new();
+        lla_plugin_utils::define_action!(
+            actions,
+            "show",
+            "show <path> [--lines <count>]",
+            "Render a terminal preview using bat, chafa, archive tools, or built-in fallbacks",
+            [
+                "lla plugin preview show README.md",
+                "lla plugin preview show src/main.rs -- --lines 80"
+            ],
+            PreviewPlugin::show_action
+        );
+        lla_plugin_utils::define_action!(
+            actions,
+            "backends",
+            "backends",
+            "Report optional preview backends available on PATH",
+            ["lla plugin preview backends"],
+            |_| PreviewPlugin::backends_action()
+        );
+        lla_plugin_utils::define_action!(
+            actions,
+            "help",
+            "help",
+            "Show preview usage",
+            ["lla plugin preview help"],
+            |_| PreviewPlugin::help_action()
+        );
+        actions
+    });
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PreviewKind {
+    Text,
+    Markdown,
+    Image,
+    Archive,
+    Directory,
+    Unsupported,
+}
+
+impl PreviewKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Markdown => "markdown",
+            Self::Image => "image",
+            Self::Archive => "archive",
+            Self::Directory => "directory",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+pub struct PreviewPlugin;
+
+impl PreviewPlugin {
+    fn decorate(mut entry: DecoratedEntry) -> DecoratedEntry {
+        let kind = classify(&entry.path);
+        entry
+            .custom_fields
+            .insert("preview_kind".to_string(), kind.as_str().to_string());
+        entry.custom_fields.insert(
+            "preview_backend".to_string(),
+            preferred_backend(kind).to_string(),
+        );
+        entry
+    }
+
+    fn format(entry: &DecoratedEntry, format: &str) -> Option<String> {
+        let kind = entry.custom_fields.get("preview_kind")?;
+        let backend = entry.custom_fields.get("preview_backend")?;
+        match format {
+            "default" => Some(format!("[preview: {kind} via {backend}]")),
+            "long" => Some(format!("Preview kind: {kind}\nBackend: {backend}")),
+            _ => None,
+        }
+    }
+
+    fn show_action(args: &[String]) -> Result<(), String> {
+        let path = args
+            .first()
+            .map(Path::new)
+            .ok_or_else(|| "Usage: show <path> [--lines <count>]".to_string())?;
+        if !path.exists() {
+            return Err(format!("Path does not exist: {}", path.display()));
+        }
+        let lines = args
+            .windows(2)
+            .find(|pair| pair[0] == "--lines")
+            .and_then(|pair| pair[1].parse::<usize>().ok())
+            .unwrap_or(120)
+            .clamp(1, 5_000);
+        match classify(path) {
+            PreviewKind::Text => preview_text(path, lines, None),
+            PreviewKind::Markdown => preview_text(path, lines, Some("markdown")),
+            PreviewKind::Image => preview_image(path),
+            PreviewKind::Archive => preview_archive(path),
+            PreviewKind::Directory => Err("Preview expects a file, not a directory".to_string()),
+            PreviewKind::Unsupported => Err(format!(
+                "No safe preview backend is available for '{}'",
+                path.display()
+            )),
+        }
+    }
+
+    fn backends_action() -> Result<(), String> {
+        for backend in ["bat", "chafa", "tar", "unzip"] {
+            println!(
+                "{backend}: {}",
+                if command_available(backend) {
+                    "available"
+                } else {
+                    "not found (built-in fallback will be used where possible)"
+                }
+            );
+        }
+        Ok(())
+    }
+
+    fn help_action() -> Result<(), String> {
+        println!(
+            "preview\n\n  show <path> [--lines N]  Render text, Markdown, image, or archive previews\n  backends                 Report bat/chafa/archive tool availability\n  help                     Show this help\n\nText is bounded to avoid loading huge files. Archives use listing-only commands and are never extracted."
+        );
+        Ok(())
+    }
+}
+
+fn classify(path: &Path) -> PreviewKind {
+    if path.is_dir() {
+        return PreviewKind::Directory;
+    }
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if matches!(extension.as_str(), "md" | "markdown" | "mdown" | "mkd") {
+        return PreviewKind::Markdown;
+    }
+    if matches!(
+        extension.as_str(),
+        "png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "tiff" | "tif" | "avif" | "heic"
+    ) {
+        return PreviewKind::Image;
+    }
+    if matches!(
+        extension.as_str(),
+        "zip" | "tar" | "tgz" | "gz" | "bz2" | "xz" | "7z"
+    ) || path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .is_some_and(|name| name.ends_with(".tar.gz") || name.ends_with(".tar.xz"))
+    {
+        return PreviewKind::Archive;
+    }
+    if matches!(
+        extension.as_str(),
+        "txt"
+            | "rs"
+            | "toml"
+            | "json"
+            | "yaml"
+            | "yml"
+            | "js"
+            | "jsx"
+            | "ts"
+            | "tsx"
+            | "py"
+            | "go"
+            | "c"
+            | "h"
+            | "cpp"
+            | "hpp"
+            | "java"
+            | "sh"
+            | "zsh"
+            | "fish"
+            | "css"
+            | "html"
+            | "xml"
+            | "sql"
+            | "log"
+            | "csv"
+    ) || extension.is_empty()
+    {
+        PreviewKind::Text
+    } else {
+        PreviewKind::Unsupported
+    }
+}
+
+fn preferred_backend(kind: PreviewKind) -> &'static str {
+    match kind {
+        PreviewKind::Text | PreviewKind::Markdown if command_available("bat") => "bat",
+        PreviewKind::Text | PreviewKind::Markdown => "builtin",
+        PreviewKind::Image if command_available("chafa") => "chafa",
+        PreviewKind::Image => "metadata",
+        PreviewKind::Archive => "listing",
+        PreviewKind::Directory => "none",
+        PreviewKind::Unsupported => "none",
+    }
+}
+
+fn preview_text(path: &Path, lines: usize, language: Option<&str>) -> Result<(), String> {
+    if command_available("bat") {
+        let mut command = Command::new("bat");
+        command
+            .arg("--color=always")
+            .arg("--style=plain")
+            .arg("--paging=never")
+            .arg("--line-range")
+            .arg(format!(":{lines}"));
+        if let Some(language) = language {
+            command.arg("--language").arg(language);
+        }
+        let status = command
+            .arg(path)
+            .stdin(Stdio::null())
+            .status()
+            .map_err(|error| format!("Failed to run bat: {error}"))?;
+        return status
+            .success()
+            .then_some(())
+            .ok_or_else(|| "bat could not preview the file".to_string());
+    }
+    let preview = builtin_text_preview(path, lines)?;
+    print!("{preview}");
+    Ok(())
+}
+
+fn builtin_text_preview(path: &Path, lines: usize) -> Result<String, String> {
+    let mut bytes = Vec::new();
+    File::open(path)
+        .map_err(|error| format!("Failed to open '{}': {error}", path.display()))?
+        .take(512 * 1024)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("Failed to read '{}': {error}", path.display()))?;
+    if bytes.contains(&0) {
+        return Err("File appears to be binary".to_string());
+    }
+    let source = String::from_utf8_lossy(&bytes);
+    let mut output = source.lines().take(lines).collect::<Vec<_>>().join("\n");
+    if !output.is_empty() {
+        output.push('\n');
+    }
+    Ok(output)
+}
+
+fn preview_image(path: &Path) -> Result<(), String> {
+    if command_available("chafa") {
+        let status = Command::new("chafa")
+            .args(["--format", "symbols", "--size", "80x40"])
+            .arg(path)
+            .stdin(Stdio::null())
+            .status()
+            .map_err(|error| format!("Failed to run chafa: {error}"))?;
+        return status
+            .success()
+            .then_some(())
+            .ok_or_else(|| "chafa could not render the image".to_string());
+    }
+    let metadata = std::fs::metadata(path)
+        .map_err(|error| format!("Failed to inspect '{}': {error}", path.display()))?;
+    println!(
+        "Image: {} ({} bytes)\nInstall chafa for an inline terminal rendering.",
+        path.display(),
+        metadata.len()
+    );
+    Ok(())
+}
+
+fn preview_archive(path: &Path) -> Result<(), String> {
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    let command = if extension.eq_ignore_ascii_case("zip") && command_available("unzip") {
+        Some(("unzip", vec!["-l"]))
+    } else if (name.ends_with(".tar.gz") || name.ends_with(".tgz")) && command_available("tar") {
+        Some(("tar", vec!["-tzf"]))
+    } else if name.ends_with(".tar.xz") && command_available("tar") {
+        Some(("tar", vec!["-tJf"]))
+    } else if extension.eq_ignore_ascii_case("tar") && command_available("tar") {
+        Some(("tar", vec!["-tf"]))
+    } else {
+        None
+    };
+    if let Some((program, args)) = command {
+        let status = Command::new(program)
+            .args(args)
+            .arg(path)
+            .stdin(Stdio::null())
+            .status()
+            .map_err(|error| format!("Failed to run {program}: {error}"))?;
+        return status
+            .success()
+            .then_some(())
+            .ok_or_else(|| format!("{program} could not list the archive"));
+    }
+
+    let entries = builtin_archive_entries(path)?;
+    println!("Archive: {}", path.display());
+    for entry in entries.iter().take(200) {
+        println!("  {entry}");
+    }
+    if entries.len() > 200 {
+        println!("  … {} more entries", entries.len() - 200);
+    }
+    Ok(())
+}
+
+fn builtin_archive_entries(path: &Path) -> Result<Vec<String>, String> {
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    if extension.eq_ignore_ascii_case("zip") {
+        return zip_entries(path);
+    }
+    if extension.eq_ignore_ascii_case("tar") {
+        return tar_entries(path);
+    }
+    Err("Install tar, unzip, or 7z to list this compressed archive".to_string())
+}
+
+fn zip_entries(path: &Path) -> Result<Vec<String>, String> {
+    let mut bytes = Vec::new();
+    File::open(path)
+        .map_err(|error| format!("Failed to open archive: {error}"))?
+        .take(64 * 1024 * 1024)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("Failed to read archive: {error}"))?;
+    let mut entries = Vec::new();
+    let mut index = 0usize;
+    while index + 46 <= bytes.len() {
+        if bytes[index..].starts_with(b"PK\x01\x02") {
+            let name_len = u16::from_le_bytes([bytes[index + 28], bytes[index + 29]]) as usize;
+            let extra_len = u16::from_le_bytes([bytes[index + 30], bytes[index + 31]]) as usize;
+            let comment_len = u16::from_le_bytes([bytes[index + 32], bytes[index + 33]]) as usize;
+            let name_start = index + 46;
+            let name_end = name_start.saturating_add(name_len);
+            if name_end > bytes.len() {
+                break;
+            }
+            entries.push(String::from_utf8_lossy(&bytes[name_start..name_end]).to_string());
+            index = name_end
+                .saturating_add(extra_len)
+                .saturating_add(comment_len);
+        } else {
+            index += 1;
+        }
+    }
+    Ok(entries)
+}
+
+fn tar_entries(path: &Path) -> Result<Vec<String>, String> {
+    let mut file = File::open(path).map_err(|error| format!("Failed to open archive: {error}"))?;
+    let mut entries = Vec::new();
+    loop {
+        let mut header = [0u8; 512];
+        if file.read_exact(&mut header).is_err() || header.iter().all(|byte| *byte == 0) {
+            break;
+        }
+        let name_end = header[..100]
+            .iter()
+            .position(|byte| *byte == 0)
+            .unwrap_or(100);
+        entries.push(String::from_utf8_lossy(&header[..name_end]).to_string());
+        let size_end = header[124..136]
+            .iter()
+            .position(|byte| *byte == 0 || *byte == b' ')
+            .unwrap_or(12);
+        let size_text = String::from_utf8_lossy(&header[124..124 + size_end]);
+        let size = u64::from_str_radix(size_text.trim(), 8).unwrap_or(0);
+        let blocks = size.div_ceil(512);
+        file.seek(SeekFrom::Current((blocks * 512) as i64))
+            .map_err(|error| format!("Failed to scan archive: {error}"))?;
+    }
+    Ok(entries)
+}
+
+fn command_available(program: &str) -> bool {
+    let probe = || {
+        Command::new(program)
+            .arg("--version")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok()
+    };
+    match program {
+        "bat" => *BAT_AVAILABLE.get_or_init(probe),
+        "chafa" => *CHAFA_AVAILABLE.get_or_init(probe),
+        "tar" => *TAR_AVAILABLE.get_or_init(probe),
+        "unzip" => *UNZIP_AVAILABLE.get_or_init(probe),
+        _ => probe(),
+    }
+}
+
+impl Plugin for PreviewPlugin {
+    fn handle_raw_request(&mut self, request: &[u8]) -> Vec<u8> {
+        let response = match self.decode_request(request) {
+            Ok(PluginRequest::GetName) => PluginResponse::Name(env!("CARGO_PKG_NAME").into()),
+            Ok(PluginRequest::GetVersion) => {
+                PluginResponse::Version(env!("CARGO_PKG_VERSION").into())
+            }
+            Ok(PluginRequest::GetDescription) => {
+                PluginResponse::Description(env!("CARGO_PKG_DESCRIPTION").into())
+            }
+            Ok(PluginRequest::GetSupportedFormats) => {
+                PluginResponse::SupportedFormats(vec!["default".into(), "long".into()])
+            }
+            Ok(PluginRequest::Decorate(entry)) => PluginResponse::Decorated(Self::decorate(entry)),
+            Ok(PluginRequest::FormatField(entry, format)) => {
+                PluginResponse::FormattedField(Self::format(&entry, &format))
+            }
+            Ok(PluginRequest::PerformAction(action, args)) => {
+                PluginResponse::ActionResult(ACTIONS.read().handle(&action, &args))
+            }
+            Ok(PluginRequest::GetAvailableActions) => {
+                PluginResponse::AvailableActions(ACTIONS.read().list_actions())
+            }
+            Err(error) => return self.encode_error(&error),
+        };
+        self.encode_response(response)
+    }
+}
+
+impl ProtobufHandler for PreviewPlugin {}
+
+lla_plugin_interface::declare_plugin!(PreviewPlugin);
+
+impl Default for PreviewPlugin {
+    fn default() -> Self {
+        Self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn classifies_requested_preview_types() {
+        assert_eq!(classify(Path::new("README.md")), PreviewKind::Markdown);
+        assert_eq!(classify(Path::new("photo.png")), PreviewKind::Image);
+        assert_eq!(classify(Path::new("source.rs")), PreviewKind::Text);
+        assert_eq!(classify(Path::new("bundle.tar")), PreviewKind::Archive);
+    }
+
+    #[test]
+    fn builtin_text_preview_is_bounded() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("notes.txt");
+        fs::write(&path, "one\ntwo\nthree\n").unwrap();
+        assert_eq!(builtin_text_preview(&path, 2).unwrap(), "one\ntwo\n");
+    }
+
+    #[test]
+    fn builtin_tar_preview_lists_entries_without_extracting() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("sample.tar");
+        let mut archive = vec![0u8; 512 * 4];
+        archive[..9].copy_from_slice(b"hello.txt");
+        archive[124..136].copy_from_slice(b"00000000005\0");
+        archive[156] = b'0';
+        archive[512..517].copy_from_slice(b"hello");
+        fs::write(&path, archive).unwrap();
+
+        assert_eq!(tar_entries(&path).unwrap(), vec!["hello.txt"]);
+    }
+}

--- a/plugins/project_context/Cargo.toml
+++ b/plugins/project_context/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "file_remover"
+name = "project_context"
 version = "0.5.12"
 edition = "2021"
-description = "Interactively trash files by default with explicit permanent deletion"
+description = "Detect project ecosystems, toolchains, lockfiles, artifacts, and repository health"
 
 [lib]
 crate-type = ["cdylib"]
@@ -10,9 +10,8 @@ crate-type = ["cdylib"]
 [dependencies]
 lla_plugin_interface = { path = "../../lla_plugin_interface" }
 lla_plugin_utils = { path = "../../lla_plugin_utils" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-dialoguer = "0.11"
-colored = "2.0"
 lazy_static = "1.4"
 parking_lot = "0.12"
+
+[dev-dependencies]
+tempfile = "3.2"

--- a/plugins/project_context/README.md
+++ b/plugins/project_context/README.md
@@ -1,0 +1,15 @@
+# Project Context Plugin
+
+Detects the nearest Rust, Node, Python, or Go project and exposes its root, dependency
+lock state, generated artifacts, toolchain versions, and Git branch/working-tree health.
+Multi-ecosystem repositories are reported as combined project types.
+
+```bash
+lla --enable-plugin project_context --long .
+lla --enable-plugin project_context --json --pretty .
+lla plugin project_context inspect .
+lla plugin project_context refresh
+```
+
+The cache avoids running toolchain and Git probes once per displayed entry; use
+`refresh` before inspecting state changed by another process.

--- a/plugins/project_context/plugin.toml
+++ b/plugins/project_context/plugin.toml
@@ -1,0 +1,68 @@
+[plugin]
+id = "dev.lla.project-context"
+name = "project_context"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "project_context"
+description = "Detect project type, toolchains, dependency locks, artifacts, and repository health"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["inspect", "refresh", "help"]
+machine_output = true
+
+[permissions]
+filesystem = ["metadata:tree", "read:tree", "read:user-path"]
+process = true
+
+[[fields]]
+name = "project_type"
+type = "string"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "project_root"
+type = "path"
+filterable = true
+
+[[fields]]
+name = "project_health"
+type = "string"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "project_issues"
+type = "integer"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "lockfile_state"
+type = "string"
+filterable = true
+
+[[fields]]
+name = "build_artifacts"
+type = "string"
+filterable = true
+
+[[fields]]
+name = "toolchains"
+type = "string"
+filterable = true
+
+[[fields]]
+name = "repository_state"
+type = "string"
+filterable = true
+
+[[fields]]
+name = "git_branch"
+type = "string"
+filterable = true

--- a/plugins/project_context/src/lib.rs
+++ b/plugins/project_context/src/lib.rs
@@ -1,0 +1,493 @@
+use lazy_static::lazy_static;
+use lla_plugin_interface::{DecoratedEntry, Plugin, PluginRequest, PluginResponse};
+use lla_plugin_utils::{ActionRegistry, ProtobufHandler};
+use parking_lot::RwLock;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+lazy_static! {
+    static ref CACHE: RwLock<HashMap<PathBuf, ProjectInfo>> = RwLock::new(HashMap::new());
+    static ref ACTIONS: RwLock<ActionRegistry> = RwLock::new({
+        let mut actions = ActionRegistry::new();
+        lla_plugin_utils::define_action!(
+            actions,
+            "inspect",
+            "inspect <path>",
+            "Inspect the nearest project and print ecosystem and repository health",
+            ["lla plugin project_context inspect ."],
+            ProjectContextPlugin::inspect_action
+        );
+        lla_plugin_utils::define_action!(
+            actions,
+            "refresh",
+            "refresh",
+            "Clear cached project detection results",
+            ["lla plugin project_context refresh"],
+            |_| {
+                CACHE.write().clear();
+                println!("Project context cache cleared.");
+                Ok(())
+            }
+        );
+        lla_plugin_utils::define_action!(
+            actions,
+            "help",
+            "help",
+            "Show project context usage",
+            ["lla plugin project_context help"],
+            |_| ProjectContextPlugin::help_action()
+        );
+        actions
+    });
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct ProjectInfo {
+    project_types: Vec<String>,
+    root: PathBuf,
+    health: String,
+    issues: usize,
+    lockfile_state: String,
+    build_artifacts: Vec<String>,
+    toolchains: Vec<String>,
+    repository_state: String,
+    git_branch: Option<String>,
+}
+
+pub struct ProjectContextPlugin;
+
+impl ProjectContextPlugin {
+    fn find_root(path: &Path) -> Option<PathBuf> {
+        let start = if path.is_dir() { path } else { path.parent()? };
+        start
+            .ancestors()
+            .take(12)
+            .find(|candidate| has_project_marker(candidate))
+            .map(Path::to_path_buf)
+    }
+
+    fn analyze(root: &Path) -> ProjectInfo {
+        if let Some(info) = CACHE.read().get(root).cloned() {
+            return info;
+        }
+        let mut project_types = Vec::new();
+        let mut expected_locks = Vec::<(&str, Vec<&str>)>::new();
+        if root.join("Cargo.toml").is_file() {
+            project_types.push("rust".to_string());
+            expected_locks.push(("rust", vec!["Cargo.lock"]));
+        }
+        if root.join("package.json").is_file() {
+            project_types.push("node".to_string());
+            expected_locks.push((
+                "node",
+                vec![
+                    "package-lock.json",
+                    "yarn.lock",
+                    "pnpm-lock.yaml",
+                    "bun.lockb",
+                    "bun.lock",
+                ],
+            ));
+        }
+        if ["pyproject.toml", "requirements.txt", "setup.py", "Pipfile"]
+            .iter()
+            .any(|marker| root.join(marker).is_file())
+        {
+            project_types.push("python".to_string());
+            expected_locks.push((
+                "python",
+                vec!["uv.lock", "poetry.lock", "Pipfile.lock", "requirements.txt"],
+            ));
+        }
+        if root.join("go.mod").is_file() {
+            project_types.push("go".to_string());
+            expected_locks.push(("go", vec!["go.sum"]));
+        }
+
+        let mut lock_states = Vec::new();
+        let mut issues = 0usize;
+        for (ecosystem, locks) in expected_locks {
+            let present = locks
+                .iter()
+                .filter(|lock| root.join(lock).is_file())
+                .copied()
+                .collect::<Vec<_>>();
+            match present.len() {
+                0 => {
+                    issues += 1;
+                    lock_states.push(format!("{ecosystem}:missing"));
+                }
+                1 => lock_states.push(format!("{ecosystem}:{}", present[0])),
+                _ => {
+                    issues += 1;
+                    lock_states.push(format!("{ecosystem}:multiple({})", present.join(",")));
+                }
+            }
+        }
+
+        let build_artifacts = [
+            "target",
+            "node_modules",
+            ".venv",
+            "venv",
+            "dist",
+            "build",
+            "__pycache__",
+        ]
+        .iter()
+        .filter(|artifact| root.join(artifact).exists())
+        .map(|artifact| (*artifact).to_string())
+        .collect::<Vec<_>>();
+
+        let mut toolchains = Vec::new();
+        for project_type in &project_types {
+            let version = match project_type.as_str() {
+                "rust" => command_line("rustc", &["--version"]),
+                "node" => {
+                    command_line("node", &["--version"]).map(|version| format!("node {version}"))
+                }
+                "python" => command_line("python3", &["--version"]),
+                "go" => command_line("go", &["version"]),
+                _ => None,
+            };
+            toolchains.push(version.unwrap_or_else(|| format!("{project_type}:not-found")));
+        }
+
+        let (repository_state, git_branch, dirty_count) = repository_health(root);
+        issues = issues.saturating_add(dirty_count);
+        let health = if project_types.is_empty() {
+            "not-a-project"
+        } else if repository_state == "dirty" {
+            "dirty"
+        } else if issues > 0 {
+            "warning"
+        } else {
+            "healthy"
+        }
+        .to_string();
+        let info = ProjectInfo {
+            project_types,
+            root: root.to_path_buf(),
+            health,
+            issues,
+            lockfile_state: if lock_states.is_empty() {
+                "none".to_string()
+            } else {
+                lock_states.join("; ")
+            },
+            build_artifacts,
+            toolchains,
+            repository_state,
+            git_branch,
+        };
+        CACHE.write().insert(root.to_path_buf(), info.clone());
+        info
+    }
+
+    fn info_for(path: &Path) -> ProjectInfo {
+        Self::find_root(path)
+            .map(|root| Self::analyze(&root))
+            .unwrap_or_else(|| ProjectInfo {
+                root: if path.is_dir() {
+                    path.to_path_buf()
+                } else {
+                    path.parent()
+                        .unwrap_or_else(|| Path::new("."))
+                        .to_path_buf()
+                },
+                health: "not-a-project".to_string(),
+                lockfile_state: "none".to_string(),
+                repository_state: "none".to_string(),
+                ..ProjectInfo::default()
+            })
+    }
+
+    fn decorate(mut entry: DecoratedEntry) -> DecoratedEntry {
+        let info = Self::info_for(&entry.path);
+        entry.custom_fields.insert(
+            "project_type".to_string(),
+            if info.project_types.is_empty() {
+                "none".to_string()
+            } else {
+                info.project_types.join("+")
+            },
+        );
+        entry.custom_fields.insert(
+            "project_root".to_string(),
+            info.root.to_string_lossy().to_string(),
+        );
+        entry
+            .custom_fields
+            .insert("project_health".to_string(), info.health);
+        entry
+            .custom_fields
+            .insert("project_issues".to_string(), info.issues.to_string());
+        entry
+            .custom_fields
+            .insert("lockfile_state".to_string(), info.lockfile_state);
+        entry.custom_fields.insert(
+            "build_artifacts".to_string(),
+            if info.build_artifacts.is_empty() {
+                "none".to_string()
+            } else {
+                info.build_artifacts.join(", ")
+            },
+        );
+        entry.custom_fields.insert(
+            "toolchains".to_string(),
+            if info.toolchains.is_empty() {
+                "none".to_string()
+            } else {
+                info.toolchains.join("; ")
+            },
+        );
+        entry
+            .custom_fields
+            .insert("repository_state".to_string(), info.repository_state);
+        if let Some(branch) = info.git_branch {
+            entry.custom_fields.insert("git_branch".to_string(), branch);
+        }
+        entry
+    }
+
+    fn format(entry: &DecoratedEntry, format: &str) -> Option<String> {
+        let kind = entry.custom_fields.get("project_type")?;
+        let health = entry.custom_fields.get("project_health")?;
+        match format {
+            "default" => Some(format!("[project: {kind}; {health}]")),
+            "long" => Some(format!(
+                "Project: {kind}\nRoot: {}\nHealth: {health} ({} issues)\nLocks: {}\nArtifacts: {}\nToolchains: {}\nRepository: {}{}",
+                entry.custom_fields.get("project_root")?,
+                entry.custom_fields.get("project_issues")?,
+                entry.custom_fields.get("lockfile_state")?,
+                entry.custom_fields.get("build_artifacts")?,
+                entry.custom_fields.get("toolchains")?,
+                entry.custom_fields.get("repository_state")?,
+                entry
+                    .custom_fields
+                    .get("git_branch")
+                    .map(|branch| format!(" ({branch})"))
+                    .unwrap_or_default()
+            )),
+            _ => None,
+        }
+    }
+
+    fn inspect_action(args: &[String]) -> Result<(), String> {
+        let path = args
+            .first()
+            .map(Path::new)
+            .unwrap_or_else(|| Path::new("."));
+        if !path.exists() {
+            return Err(format!("Path does not exist: {}", path.display()));
+        }
+        CACHE.write().clear();
+        let info = Self::info_for(path);
+        println!("Root: {}", info.root.display());
+        println!(
+            "Project types: {}",
+            if info.project_types.is_empty() {
+                "none".to_string()
+            } else {
+                info.project_types.join(", ")
+            }
+        );
+        println!("Health: {} ({} issues)", info.health, info.issues);
+        println!("Locks: {}", info.lockfile_state);
+        println!(
+            "Artifacts: {}",
+            if info.build_artifacts.is_empty() {
+                "none".to_string()
+            } else {
+                info.build_artifacts.join(", ")
+            }
+        );
+        println!(
+            "Toolchains: {}",
+            if info.toolchains.is_empty() {
+                "none".to_string()
+            } else {
+                info.toolchains.join("; ")
+            }
+        );
+        println!("Repository: {}", info.repository_state);
+        if let Some(branch) = info.git_branch {
+            println!("Branch: {branch}");
+        }
+        Ok(())
+    }
+
+    fn help_action() -> Result<(), String> {
+        println!(
+            "project_context\n\n  inspect [path]  Detect Rust, Node, Python, and Go context\n  refresh         Clear cached project state\n  help            Show this help\n\nThe decorator exposes typed project health, lockfile, artifact, toolchain, and Git fields."
+        );
+        Ok(())
+    }
+}
+
+fn has_project_marker(path: &Path) -> bool {
+    [
+        "Cargo.toml",
+        "package.json",
+        "pyproject.toml",
+        "requirements.txt",
+        "setup.py",
+        "Pipfile",
+        "go.mod",
+    ]
+    .iter()
+    .any(|marker| path.join(marker).is_file())
+}
+
+fn command_line(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    Some(if stdout.is_empty() { stderr } else { stdout })
+}
+
+fn repository_health(root: &Path) -> (String, Option<String>, usize) {
+    let Some(output) = command_line(
+        "git",
+        &[
+            "-C",
+            &root.to_string_lossy(),
+            "status",
+            "--porcelain=v1",
+            "--branch",
+        ],
+    ) else {
+        return ("not-a-repository".to_string(), None, 0);
+    };
+    let mut lines = output.lines();
+    let branch = lines.next().and_then(|line| {
+        line.strip_prefix("## ")
+            .and_then(|branch| branch.split("...").next())
+            .map(str::to_string)
+    });
+    let dirty = lines.filter(|line| !line.trim().is_empty()).count();
+    (
+        if dirty == 0 { "clean" } else { "dirty" }.to_string(),
+        branch,
+        dirty,
+    )
+}
+
+impl Plugin for ProjectContextPlugin {
+    fn handle_raw_request(&mut self, request: &[u8]) -> Vec<u8> {
+        let response = match self.decode_request(request) {
+            Ok(PluginRequest::GetName) => PluginResponse::Name(env!("CARGO_PKG_NAME").into()),
+            Ok(PluginRequest::GetVersion) => {
+                PluginResponse::Version(env!("CARGO_PKG_VERSION").into())
+            }
+            Ok(PluginRequest::GetDescription) => {
+                PluginResponse::Description(env!("CARGO_PKG_DESCRIPTION").into())
+            }
+            Ok(PluginRequest::GetSupportedFormats) => {
+                PluginResponse::SupportedFormats(vec!["default".into(), "long".into()])
+            }
+            Ok(PluginRequest::Decorate(entry)) => PluginResponse::Decorated(Self::decorate(entry)),
+            Ok(PluginRequest::FormatField(entry, format)) => {
+                PluginResponse::FormattedField(Self::format(&entry, &format))
+            }
+            Ok(PluginRequest::PerformAction(action, args)) => {
+                PluginResponse::ActionResult(ACTIONS.read().handle(&action, &args))
+            }
+            Ok(PluginRequest::GetAvailableActions) => {
+                PluginResponse::AvailableActions(ACTIONS.read().list_actions())
+            }
+            Err(error) => return self.encode_error(&error),
+        };
+        self.encode_response(response)
+    }
+}
+
+impl ProtobufHandler for ProjectContextPlugin {}
+
+lla_plugin_interface::declare_plugin!(ProjectContextPlugin);
+
+impl Default for ProjectContextPlugin {
+    fn default() -> Self {
+        Self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn detects_multi_ecosystem_projects_locks_and_artifacts() {
+        CACHE.write().clear();
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("Cargo.toml"), "[package]\nname='demo'").unwrap();
+        fs::write(root.path().join("Cargo.lock"), "").unwrap();
+        fs::write(root.path().join("package.json"), "{}").unwrap();
+        fs::create_dir(root.path().join("target")).unwrap();
+
+        let info = ProjectContextPlugin::analyze(root.path());
+        assert_eq!(info.project_types, vec!["rust", "node"]);
+        assert!(info.lockfile_state.contains("rust:Cargo.lock"));
+        assert!(info.lockfile_state.contains("node:missing"));
+        assert_eq!(info.build_artifacts, vec!["target"]);
+        assert!(info.issues >= 1);
+    }
+
+    #[test]
+    fn nearest_parent_project_is_used_for_files() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("go.mod"), "module example.test/demo").unwrap();
+        fs::create_dir(root.path().join("src")).unwrap();
+        let file = root.path().join("src/main.go");
+        fs::write(&file, "package main").unwrap();
+        assert_eq!(
+            ProjectContextPlugin::find_root(&file),
+            Some(root.path().to_path_buf())
+        );
+    }
+
+    #[test]
+    fn detects_python_and_go_projects_with_locks() {
+        CACHE.write().clear();
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("pyproject.toml"), "[project]\nname='demo'").unwrap();
+        fs::write(root.path().join("uv.lock"), "").unwrap();
+        fs::write(root.path().join("go.mod"), "module example.test/demo").unwrap();
+        fs::write(root.path().join("go.sum"), "").unwrap();
+
+        let info = ProjectContextPlugin::analyze(root.path());
+        assert_eq!(info.project_types, vec!["python", "go"]);
+        assert!(info.lockfile_state.contains("python:uv.lock"));
+        assert!(info.lockfile_state.contains("go:go.sum"));
+    }
+
+    #[test]
+    fn repository_health_reports_dirty_worktrees() {
+        let root = tempfile::tempdir().unwrap();
+        let initialized = Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(root.path())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+        if !initialized {
+            return;
+        }
+        fs::write(root.path().join("untracked.txt"), "dirty").unwrap();
+
+        let (state, _branch, dirty) = repository_health(root.path());
+        assert_eq!(state, "dirty");
+        assert_eq!(dirty, 1);
+    }
+}

--- a/plugins/remove_paywall/Cargo.toml
+++ b/plugins/remove_paywall/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "remove_paywall"
 description = "Remove paywalls from URLs using services like 12ft.io, archive.is, and removepaywall.com"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/remove_paywall/plugin.toml
+++ b/plugins/remove_paywall/plugin.toml
@@ -1,0 +1,19 @@
+[plugin]
+id = "dev.lla.remove-paywall"
+name = "remove_paywall"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "remove_paywall"
+description = "Create archival and reader links for URLs"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["remove", "clipboard", "choose", "try-all", "services", "history", "12ft", "archive", "freedium", "menu", "help"]
+
+[permissions]
+network = ["archive.is", "12ft.io", "removepaywall.com", "freedium.cfd", "webcache.googleusercontent.com"]
+clipboard = true
+open_url = true

--- a/plugins/remove_paywall/src/lib.rs
+++ b/plugins/remove_paywall/src/lib.rs
@@ -11,8 +11,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use url::Url;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum PaywallService {
+    #[default]
     TwelveFt,
     ArchiveIs,
     RemovePaywall,
@@ -96,12 +97,6 @@ impl PaywallService {
             PaywallService::Freedium,
             PaywallService::GoogleCache,
         ]
-    }
-}
-
-impl Default for PaywallService {
-    fn default() -> Self {
-        PaywallService::TwelveFt
     }
 }
 
@@ -369,14 +364,12 @@ impl RemovePaywallPlugin {
         println!("{}", list.render());
 
         // Copy to clipboard if enabled
-        if self.base.config().copy_to_clipboard {
-            if Self::copy_to_clipboard(&bypass_url).is_ok() {
-                println!(
-                    "   {} {}",
-                    "📋".bright_green(),
-                    "Bypass URL copied to clipboard!".bright_green()
-                );
-            }
+        if self.base.config().copy_to_clipboard && Self::copy_to_clipboard(&bypass_url).is_ok() {
+            println!(
+                "   {} {}",
+                "📋".bright_green(),
+                "Bypass URL copied to clipboard!".bright_green()
+            );
         }
 
         // Open in browser if enabled

--- a/plugins/security_audit/Cargo.toml
+++ b/plugins/security_audit/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "file_remover"
+name = "security_audit"
 version = "0.5.12"
 edition = "2021"
-description = "Interactively trash files by default with explicit permanent deletion"
+description = "Audit filesystem entries for unsafe permissions, risky links, and exposed secrets"
 
 [lib]
 crate-type = ["cdylib"]
@@ -10,9 +10,9 @@ crate-type = ["cdylib"]
 [dependencies]
 lla_plugin_interface = { path = "../../lla_plugin_interface" }
 lla_plugin_utils = { path = "../../lla_plugin_utils" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-dialoguer = "0.11"
-colored = "2.0"
 lazy_static = "1.4"
 parking_lot = "0.12"
+walkdir = "2.5"
+
+[dev-dependencies]
+tempfile = "3.2"

--- a/plugins/security_audit/README.md
+++ b/plugins/security_audit/README.md
@@ -1,0 +1,14 @@
+# Security Audit Plugin
+
+Audits listing entries and directory trees without reading file contents. It reports
+world-writable entries, SUID/SGID bits, dangling or escaping symlinks, and secret-like
+files whose permissions expose them to a group or other users.
+
+```bash
+lla --enable-plugin security_audit --long .
+lla --enable-plugin security_audit --json --pretty .
+lla plugin security_audit audit . -- --recursive
+```
+
+Machine output includes `security_risk`, `security_score`, `security_findings`,
+`suspicious_symlink`, and `secret_exposed`.

--- a/plugins/security_audit/plugin.toml
+++ b/plugins/security_audit/plugin.toml
@@ -1,0 +1,46 @@
+[plugin]
+id = "dev.lla.security-audit"
+name = "security_audit"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "security_audit"
+description = "Audit unsafe permissions, privileged bits, risky symlinks, and exposed secrets"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["audit", "help"]
+machine_output = true
+
+[permissions]
+filesystem = ["metadata:tree"]
+
+[[fields]]
+name = "security_risk"
+type = "string"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "security_score"
+type = "integer"
+sortable = true
+filterable = true
+
+[[fields]]
+name = "security_findings"
+type = "string"
+filterable = true
+
+[[fields]]
+name = "suspicious_symlink"
+type = "boolean"
+filterable = true
+
+[[fields]]
+name = "secret_exposed"
+type = "boolean"
+filterable = true

--- a/plugins/security_audit/src/lib.rs
+++ b/plugins/security_audit/src/lib.rs
@@ -1,0 +1,380 @@
+use lazy_static::lazy_static;
+use lla_plugin_interface::{DecoratedEntry, Plugin, PluginRequest, PluginResponse};
+use lla_plugin_utils::{ActionRegistry, ProtobufHandler};
+use parking_lot::RwLock;
+use std::{fs, path::Path};
+use walkdir::WalkDir;
+
+lazy_static! {
+    static ref ACTIONS: RwLock<ActionRegistry> = RwLock::new({
+        let mut actions = ActionRegistry::new();
+        lla_plugin_utils::define_action!(
+            actions,
+            "audit",
+            "audit <path> [--recursive]",
+            "Audit a file or directory and print security findings",
+            [
+                "lla plugin security_audit audit .",
+                "lla plugin security_audit audit . -- --recursive"
+            ],
+            SecurityAuditPlugin::audit_action
+        );
+        lla_plugin_utils::define_action!(
+            actions,
+            "help",
+            "help",
+            "Show security audit usage and risk rules",
+            ["lla plugin security_audit help"],
+            |_| SecurityAuditPlugin::help_action()
+        );
+        actions
+    });
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct AuditResult {
+    score: u32,
+    findings: Vec<String>,
+    suspicious_symlink: bool,
+    secret_exposed: bool,
+}
+
+impl AuditResult {
+    fn risk(&self) -> &'static str {
+        match self.score {
+            0 => "clean",
+            1..=29 => "low",
+            30..=59 => "medium",
+            60..=89 => "high",
+            _ => "critical",
+        }
+    }
+}
+
+pub struct SecurityAuditPlugin;
+
+impl SecurityAuditPlugin {
+    fn inspect(
+        path: &Path,
+        permissions: u32,
+        is_file: bool,
+        is_dir: bool,
+        is_symlink: bool,
+    ) -> AuditResult {
+        let mut result = AuditResult::default();
+
+        if permissions & 0o002 != 0 {
+            if is_dir && permissions & 0o1000 != 0 {
+                result.score += 20;
+                result
+                    .findings
+                    .push("world-writable directory protected by sticky bit".to_string());
+            } else {
+                result.score += 65;
+                result.findings.push("world-writable entry".to_string());
+            }
+        }
+        if is_file && permissions & 0o4000 != 0 {
+            result.score += 80;
+            result
+                .findings
+                .push("SUID executable bit is set".to_string());
+        }
+        if is_file && permissions & 0o2000 != 0 {
+            result.score += 65;
+            result
+                .findings
+                .push("SGID executable bit is set".to_string());
+        }
+        if is_file && permissions & 0o111 != 0 && permissions & 0o022 != 0 {
+            result.score += 50;
+            result
+                .findings
+                .push("executable is writable by group or others".to_string());
+        }
+        if is_dir && permissions & 0o020 != 0 && permissions & 0o1000 == 0 {
+            result.score += 30;
+            result
+                .findings
+                .push("group-writable directory lacks a sticky bit".to_string());
+        }
+
+        if is_symlink {
+            let parent = path.parent().unwrap_or_else(|| Path::new("."));
+            match fs::read_link(path) {
+                Err(_) => {
+                    result.score += 50;
+                    result.suspicious_symlink = true;
+                    result
+                        .findings
+                        .push("unreadable symlink target".to_string());
+                }
+                Ok(target) => {
+                    let resolved = if target.is_absolute() {
+                        target.clone()
+                    } else {
+                        parent.join(&target)
+                    };
+                    if !resolved.exists() {
+                        result.score += 45;
+                        result.suspicious_symlink = true;
+                        result.findings.push("dangling symlink".to_string());
+                    }
+                    let outside_parent = parent
+                        .canonicalize()
+                        .ok()
+                        .zip(resolved.canonicalize().ok())
+                        .is_some_and(|(parent, resolved)| !resolved.starts_with(parent));
+                    if target.is_absolute() || outside_parent {
+                        result.score += 35;
+                        result.suspicious_symlink = true;
+                        result
+                            .findings
+                            .push("symlink targets outside its containing directory".to_string());
+                    }
+                }
+            }
+        }
+
+        if is_secret_name(path) && permissions & 0o077 != 0 {
+            result.score += 75;
+            result.secret_exposed = true;
+            result
+                .findings
+                .push("secret-like file is readable or writable by group/others".to_string());
+        }
+
+        result.score = result.score.min(100);
+        result
+    }
+
+    fn decorate(mut entry: DecoratedEntry) -> DecoratedEntry {
+        let is_symlink = fs::symlink_metadata(&entry.path)
+            .map(|metadata| metadata.file_type().is_symlink())
+            .unwrap_or(entry.metadata.is_symlink);
+        let result = Self::inspect(
+            &entry.path,
+            entry.metadata.permissions,
+            entry.metadata.is_file,
+            entry.metadata.is_dir,
+            is_symlink,
+        );
+        entry
+            .custom_fields
+            .insert("security_risk".to_string(), result.risk().to_string());
+        entry
+            .custom_fields
+            .insert("security_score".to_string(), result.score.to_string());
+        entry.custom_fields.insert(
+            "security_findings".to_string(),
+            if result.findings.is_empty() {
+                "none".to_string()
+            } else {
+                result.findings.join("; ")
+            },
+        );
+        entry.custom_fields.insert(
+            "suspicious_symlink".to_string(),
+            result.suspicious_symlink.to_string(),
+        );
+        entry.custom_fields.insert(
+            "secret_exposed".to_string(),
+            result.secret_exposed.to_string(),
+        );
+        entry
+    }
+
+    fn format(entry: &DecoratedEntry, format: &str) -> Option<String> {
+        let risk = entry.custom_fields.get("security_risk")?;
+        let score = entry.custom_fields.get("security_score")?;
+        let findings = entry.custom_fields.get("security_findings")?;
+        match format {
+            "default" => Some(format!("[security: {risk} ({score})]")),
+            "long" => Some(format!(
+                "Security risk: {risk} ({score}/100)\nFindings: {findings}"
+            )),
+            _ => None,
+        }
+    }
+
+    fn audit_action(args: &[String]) -> Result<(), String> {
+        let path = args
+            .first()
+            .map(Path::new)
+            .ok_or_else(|| "Usage: audit <path> [--recursive]".to_string())?;
+        let recursive = args.iter().any(|arg| arg == "--recursive");
+        if !path.exists() && fs::symlink_metadata(path).is_err() {
+            return Err(format!("Path does not exist: {}", path.display()));
+        }
+        let walker = WalkDir::new(path)
+            .follow_links(false)
+            .max_depth(if recursive { usize::MAX } else { 1 });
+        let mut scanned = 0usize;
+        let mut risky = 0usize;
+        for item in walker {
+            let item = item.map_err(|error| format!("Audit traversal failed: {error}"))?;
+            let metadata = fs::symlink_metadata(item.path()).map_err(|error| {
+                format!("Failed to inspect '{}': {error}", item.path().display())
+            })?;
+            #[cfg(unix)]
+            let permissions = {
+                use std::os::unix::fs::MetadataExt;
+                metadata.mode()
+            };
+            #[cfg(not(unix))]
+            let permissions = 0;
+            let result = Self::inspect(
+                item.path(),
+                permissions,
+                metadata.is_file(),
+                metadata.is_dir(),
+                metadata.file_type().is_symlink(),
+            );
+            scanned += 1;
+            if result.score > 0 {
+                risky += 1;
+                println!(
+                    "{}  {:>3}/100  {}",
+                    result.risk(),
+                    result.score,
+                    item.path().display()
+                );
+                for finding in result.findings {
+                    println!("  - {finding}");
+                }
+            }
+        }
+        println!("Audited {scanned} entries; {risky} had findings.");
+        Ok(())
+    }
+
+    fn help_action() -> Result<(), String> {
+        println!(
+            "security_audit\n\n  audit <path> [--recursive]  Scan permissions, SUID/SGID, symlinks, and exposed secret files\n  help                        Show this help\n\nRisk scores are emitted as typed fields for JSON, sorting, and filtering."
+        );
+        Ok(())
+    }
+}
+
+fn is_secret_name(path: &Path) -> bool {
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    matches!(
+        name.as_str(),
+        ".env"
+            | ".env.local"
+            | ".env.production"
+            | ".npmrc"
+            | ".pypirc"
+            | ".netrc"
+            | "id_rsa"
+            | "id_dsa"
+            | "id_ed25519"
+            | "credentials"
+            | "credentials.json"
+            | "service-account.json"
+    ) || name.ends_with(".pem")
+        || name.ends_with(".key")
+        || name.ends_with(".p12")
+        || name.ends_with(".pfx")
+}
+
+impl Plugin for SecurityAuditPlugin {
+    fn handle_raw_request(&mut self, request: &[u8]) -> Vec<u8> {
+        let response = match self.decode_request(request) {
+            Ok(PluginRequest::GetName) => PluginResponse::Name(env!("CARGO_PKG_NAME").into()),
+            Ok(PluginRequest::GetVersion) => {
+                PluginResponse::Version(env!("CARGO_PKG_VERSION").into())
+            }
+            Ok(PluginRequest::GetDescription) => {
+                PluginResponse::Description(env!("CARGO_PKG_DESCRIPTION").into())
+            }
+            Ok(PluginRequest::GetSupportedFormats) => {
+                PluginResponse::SupportedFormats(vec!["default".into(), "long".into()])
+            }
+            Ok(PluginRequest::Decorate(entry)) => PluginResponse::Decorated(Self::decorate(entry)),
+            Ok(PluginRequest::FormatField(entry, format)) => {
+                PluginResponse::FormattedField(Self::format(&entry, &format))
+            }
+            Ok(PluginRequest::PerformAction(action, args)) => {
+                PluginResponse::ActionResult(ACTIONS.read().handle(&action, &args))
+            }
+            Ok(PluginRequest::GetAvailableActions) => {
+                PluginResponse::AvailableActions(ACTIONS.read().list_actions())
+            }
+            Err(error) => return self.encode_error(&error),
+        };
+        self.encode_response(response)
+    }
+}
+
+impl ProtobufHandler for SecurityAuditPlugin {}
+
+lla_plugin_interface::declare_plugin!(SecurityAuditPlugin);
+
+impl Default for SecurityAuditPlugin {
+    fn default() -> Self {
+        Self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_world_writable_privileged_and_exposed_secret_files() {
+        let result = SecurityAuditPlugin::inspect(Path::new(".env"), 0o106677, true, false, false);
+        assert_eq!(result.risk(), "critical");
+        assert!(result.secret_exposed);
+        assert!(result
+            .findings
+            .iter()
+            .any(|finding| finding.contains("SUID")));
+        assert!(result
+            .findings
+            .iter()
+            .any(|finding| finding.contains("SGID")));
+        assert!(result
+            .findings
+            .iter()
+            .any(|finding| finding.contains("world-writable")));
+        assert!(result
+            .findings
+            .iter()
+            .any(|finding| finding.contains("executable is writable")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detects_dangling_symlinks() {
+        let root = tempfile::tempdir().unwrap();
+        let link = root.path().join("dangling");
+        std::os::unix::fs::symlink("missing", &link).unwrap();
+        let result = SecurityAuditPlugin::inspect(&link, 0o777, false, false, true);
+        assert!(result.suspicious_symlink);
+        assert!(result
+            .findings
+            .iter()
+            .any(|finding| finding.contains("dangling")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recursive_audit_action_accepts_real_unsafe_fixtures() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let secret = root.path().join(".env");
+        fs::write(&secret, "TOKEN=test").unwrap();
+        fs::set_permissions(&secret, fs::Permissions::from_mode(0o666)).unwrap();
+        SecurityAuditPlugin::audit_action(&[
+            root.path().to_string_lossy().to_string(),
+            "--recursive".to_string(),
+        ])
+        .unwrap();
+    }
+}

--- a/plugins/sizeviz/Cargo.toml
+++ b/plugins/sizeviz/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sizeviz"
 description = "File size visualizer plugin for lla"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/sizeviz/plugin.toml
+++ b/plugins/sizeviz/plugin.toml
@@ -1,0 +1,25 @@
+[plugin]
+id = "dev.lla.sizeviz"
+name = "sizeviz"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "sizeviz"
+description = "Visualize file sizes"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["help"]
+machine_output = true
+
+[permissions]
+filesystem = ["metadata:selection"]
+
+[[fields]]
+name = "size"
+type = "bytes"
+sortable = true
+filterable = true

--- a/plugins/sizeviz/src/lib.rs
+++ b/plugins/sizeviz/src/lib.rs
@@ -20,7 +20,7 @@ lazy_static! {
             "help",
             "help",
             "Show help information",
-            vec!["lla plugin --name sizeviz --action help"],
+            ["lla plugin --name sizeviz --action help"],
             |_| {
                 let mut help = HelpFormatter::new("Size Visualizer Plugin".to_string());
                 help.add_section("Description".to_string()).add_command(
@@ -207,7 +207,7 @@ impl FileSizeVisualizerPlugin {
             .custom_fields
             .get("size")
             .and_then(|size_str| size_str.parse::<u64>().ok())
-            .map(|size| {
+            .and_then(|size| {
                 let max_size = 1_073_741_824;
                 let result = match format {
                     "long" => {
@@ -215,31 +215,29 @@ impl FileSizeVisualizerPlugin {
                         let bar_color = self.get_size_color(size);
                         let percentage = Self::get_percentage(size, max_size);
 
-                        format!(
-                            "\n{}\n{}\n{}\n{}",
-                            format!(
-                                "┌─ {} ─{}",
-                                "Size".bright_blue(),
-                                "─".repeat(40).bright_black()
-                            ),
-                            format!(
-                                "│ {} {}",
-                                bar.color(match bar_color.as_str() {
-                                    "bright_green" => colored::Color::BrightGreen,
-                                    "bright_cyan" => colored::Color::BrightCyan,
-                                    "bright_yellow" => colored::Color::BrightYellow,
-                                    "bright_red" => colored::Color::BrightRed,
-                                    "bright_magenta" => colored::Color::BrightMagenta,
-                                    _ => colored::Color::White,
-                                }),
-                                Self::format_size(size).bright_yellow()
-                            ),
-                            format!(
-                                "│ {}% of reference (1GB)",
-                                format!("{:.1}", percentage).bright_magenta()
-                            ),
-                            format!("└{}", "─".repeat(50).bright_black())
-                        )
+                        let heading = format!(
+                            "┌─ {} ─{}",
+                            "Size".bright_blue(),
+                            "─".repeat(40).bright_black()
+                        );
+                        let bar_line = format!(
+                            "│ {} {}",
+                            bar.color(match bar_color.as_str() {
+                                "bright_green" => colored::Color::BrightGreen,
+                                "bright_cyan" => colored::Color::BrightCyan,
+                                "bright_yellow" => colored::Color::BrightYellow,
+                                "bright_red" => colored::Color::BrightRed,
+                                "bright_magenta" => colored::Color::BrightMagenta,
+                                _ => colored::Color::White,
+                            }),
+                            Self::format_size(size).bright_yellow()
+                        );
+                        let percentage_line = format!(
+                            "│ {}% of reference (1GB)",
+                            format!("{:.1}", percentage).bright_magenta()
+                        );
+                        let footer = format!("└{}", "─".repeat(50).bright_black());
+                        format!("\n{heading}\n{bar_line}\n{percentage_line}\n{footer}")
                     }
                     "default" => {
                         let bar = Self::size_to_bar(size, max_size, 10);
@@ -261,7 +259,6 @@ impl FileSizeVisualizerPlugin {
                 };
                 Some(result)
             })
-            .flatten()
     }
 }
 

--- a/plugins/speed_test/Cargo.toml
+++ b/plugins/speed_test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "speed_test"
 description = "Internet speed test plugin - test download/upload speeds and latency"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/speed_test/plugin.toml
+++ b/plugins/speed_test/plugin.toml
@@ -1,0 +1,17 @@
+[plugin]
+id = "dev.lla.speed-test"
+name = "speed_test"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "speed_test"
+description = "Measure network latency and throughput"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["test", "quick", "history", "clear-history", "menu", "help"]
+
+[permissions]
+network = ["*"]

--- a/plugins/trash/Cargo.toml
+++ b/plugins/trash/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "file_remover"
+name = "trash"
 version = "0.5.12"
 edition = "2021"
-description = "Interactively trash files by default with explicit permanent deletion"
+description = "Cross-platform recoverable deletion with listing, restoration, and explicit emptying"
 
 [lib]
 crate-type = ["cdylib"]
@@ -10,9 +10,5 @@ crate-type = ["cdylib"]
 [dependencies]
 lla_plugin_interface = { path = "../../lla_plugin_interface" }
 lla_plugin_utils = { path = "../../lla_plugin_utils" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-dialoguer = "0.11"
-colored = "2.0"
 lazy_static = "1.4"
 parking_lot = "0.12"

--- a/plugins/trash/README.md
+++ b/plugins/trash/README.md
@@ -1,0 +1,18 @@
+# Trash Plugin
+
+Provides recoverable deletion with the same behavior on macOS, Linux, and Windows.
+Content is moved into lla's plugin data directory with a JSON record of its original
+path, deletion time, size, and restore id. If a restore target exists, a conflict-safe
+`(restored N)` name is chosen instead of overwriting it.
+
+```bash
+lla plugin trash put ./draft.txt ./old-directory
+lla plugin trash list
+lla plugin trash restore <id>
+
+# Irreversible and intentionally requires --yes
+lla plugin trash empty 30 -- --yes
+```
+
+The existing `file_remover remove` action uses this same store. Its `purge` action is
+the explicit permanent-deletion alternative.

--- a/plugins/trash/plugin.toml
+++ b/plugins/trash/plugin.toml
@@ -1,0 +1,29 @@
+[plugin]
+id = "dev.lla.trash"
+name = "trash"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "trash"
+description = "Cross-platform recoverable deletion with restore support"
+license = "MIT"
+
+[capabilities]
+decorates_entries = true
+formats = ["default", "long"]
+actions = ["put", "list", "restore", "empty", "help"]
+machine_output = true
+
+[permissions]
+filesystem = ["metadata:selection", "read:user-path", "write:user-path", "delete:selection", "delete:quarantine"]
+
+[[fields]]
+name = "trashable"
+type = "boolean"
+filterable = true
+
+[[fields]]
+name = "trash_state"
+type = "string"
+filterable = true

--- a/plugins/trash/src/lib.rs
+++ b/plugins/trash/src/lib.rs
@@ -1,0 +1,212 @@
+use lazy_static::lazy_static;
+use lla_plugin_interface::{DecoratedEntry, Plugin, PluginRequest, PluginResponse};
+use lla_plugin_utils::{trash::TrashStore, ActionRegistry, ProtobufHandler};
+use parking_lot::RwLock;
+use std::path::Path;
+
+lazy_static! {
+    static ref ACTIONS: RwLock<ActionRegistry> = RwLock::new({
+        let mut actions = ActionRegistry::new();
+        lla_plugin_utils::define_action!(
+            actions,
+            "put",
+            "put <path>...",
+            "Move one or more files or directories into recoverable trash",
+            ["lla plugin trash put ./draft.txt ./old-folder"],
+            TrashPlugin::put_action
+        );
+        lla_plugin_utils::define_action!(
+            actions,
+            "list",
+            "list",
+            "List recoverable trash records and their original paths",
+            ["lla plugin trash list"],
+            |_| TrashPlugin::list_action()
+        );
+        lla_plugin_utils::define_action!(
+            actions,
+            "restore",
+            "restore <id>",
+            "Restore a trashed item without overwriting an existing path",
+            ["lla plugin trash restore 20260815T120000.000Z-123-0"],
+            TrashPlugin::restore_action
+        );
+        lla_plugin_utils::define_action!(
+            actions,
+            "empty",
+            "empty [older-than-days] --yes",
+            "Permanently delete old trash records after explicit confirmation",
+            ["lla plugin trash empty 30 -- --yes"],
+            TrashPlugin::empty_action
+        );
+        lla_plugin_utils::define_action!(
+            actions,
+            "help",
+            "help",
+            "Show recoverable trash usage",
+            ["lla plugin trash help"],
+            |_| TrashPlugin::help_action()
+        );
+        actions
+    });
+}
+
+pub struct TrashPlugin;
+
+impl TrashPlugin {
+    fn decorate(mut entry: DecoratedEntry) -> DecoratedEntry {
+        let store = TrashStore::for_plugin_data();
+        let in_trash = entry.path.starts_with(store.root());
+        entry
+            .custom_fields
+            .insert("trashable".to_string(), (!in_trash).to_string());
+        entry.custom_fields.insert(
+            "trash_state".to_string(),
+            if in_trash { "trashed" } else { "available" }.to_string(),
+        );
+        entry
+    }
+
+    fn format(entry: &DecoratedEntry, format: &str) -> Option<String> {
+        let state = entry.custom_fields.get("trash_state")?;
+        match format {
+            "default" => Some(format!("[trash: {state}]")),
+            "long" => Some(format!(
+                "Trash state: {state}\nRecoverable deletion: {}",
+                entry.custom_fields.get("trashable")?
+            )),
+            _ => None,
+        }
+    }
+
+    fn put_action(args: &[String]) -> Result<(), String> {
+        if args.is_empty() {
+            return Err("Usage: put <path>...".to_string());
+        }
+        let store = TrashStore::for_plugin_data();
+        let mut failures = Vec::new();
+        for value in args {
+            if value.starts_with('-') {
+                failures.push(format!("Unknown option: {value}"));
+                continue;
+            }
+            match store.put(Path::new(value)) {
+                Ok(record) => println!(
+                    "Trashed {}\n  id: {}\n  restore: lla plugin trash restore {}",
+                    record.original_path.display(),
+                    record.id,
+                    record.id
+                ),
+                Err(error) => failures.push(error),
+            }
+        }
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(failures.join("\n"))
+        }
+    }
+
+    fn list_action() -> Result<(), String> {
+        let records = TrashStore::for_plugin_data().list()?;
+        if records.is_empty() {
+            println!("Trash is empty.");
+            return Ok(());
+        }
+        for record in records {
+            println!(
+                "{}  {}  {} bytes  {}",
+                record.id,
+                record.deleted_at,
+                record.size,
+                record.original_path.display()
+            );
+        }
+        Ok(())
+    }
+
+    fn restore_action(args: &[String]) -> Result<(), String> {
+        let id = args
+            .first()
+            .ok_or_else(|| "Usage: restore <id>".to_string())?;
+        let restored = TrashStore::for_plugin_data().restore(id)?;
+        println!("Restored to {}", restored.display());
+        Ok(())
+    }
+
+    fn empty_action(args: &[String]) -> Result<(), String> {
+        if !args.iter().any(|arg| arg == "--yes") {
+            return Err(
+                "Permanent deletion requires --yes. Example: lla plugin trash empty 30 -- --yes"
+                    .to_string(),
+            );
+        }
+        let days = args
+            .iter()
+            .find(|arg| !arg.starts_with('-'))
+            .map(|value| value.parse::<u64>())
+            .transpose()
+            .map_err(|_| "older-than-days must be a non-negative integer".to_string())?
+            .unwrap_or(30);
+        let removed = TrashStore::for_plugin_data().empty_older_than(days)?;
+        println!("Permanently removed {removed} trash item(s) at least {days} day(s) old.");
+        Ok(())
+    }
+
+    fn help_action() -> Result<(), String> {
+        println!(
+            "trash\n\n  put <path>...              Recoverably delete files or directories\n  list                       List trash ids and original paths\n  restore <id>               Restore without overwriting conflicts\n  empty [days] --yes         Permanently remove old trash\n  help                       Show this help\n\nTrash data lives in the lla plugin data directory and works consistently across supported platforms."
+        );
+        Ok(())
+    }
+}
+
+impl Plugin for TrashPlugin {
+    fn handle_raw_request(&mut self, request: &[u8]) -> Vec<u8> {
+        let response = match self.decode_request(request) {
+            Ok(PluginRequest::GetName) => PluginResponse::Name(env!("CARGO_PKG_NAME").into()),
+            Ok(PluginRequest::GetVersion) => {
+                PluginResponse::Version(env!("CARGO_PKG_VERSION").into())
+            }
+            Ok(PluginRequest::GetDescription) => {
+                PluginResponse::Description(env!("CARGO_PKG_DESCRIPTION").into())
+            }
+            Ok(PluginRequest::GetSupportedFormats) => {
+                PluginResponse::SupportedFormats(vec!["default".into(), "long".into()])
+            }
+            Ok(PluginRequest::Decorate(entry)) => PluginResponse::Decorated(Self::decorate(entry)),
+            Ok(PluginRequest::FormatField(entry, format)) => {
+                PluginResponse::FormattedField(Self::format(&entry, &format))
+            }
+            Ok(PluginRequest::PerformAction(action, args)) => {
+                PluginResponse::ActionResult(ACTIONS.read().handle(&action, &args))
+            }
+            Ok(PluginRequest::GetAvailableActions) => {
+                PluginResponse::AvailableActions(ACTIONS.read().list_actions())
+            }
+            Err(error) => return self.encode_error(&error),
+        };
+        self.encode_response(response)
+    }
+}
+
+impl ProtobufHandler for TrashPlugin {}
+
+lla_plugin_interface::declare_plugin!(TrashPlugin);
+
+impl Default for TrashPlugin {
+    fn default() -> Self {
+        Self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permanent_emptying_requires_explicit_confirmation() {
+        let error = TrashPlugin::empty_action(&[]).unwrap_err();
+        assert!(error.contains("requires --yes"));
+    }
+}

--- a/plugins/youtube/Cargo.toml
+++ b/plugins/youtube/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "youtube"
 description = "YouTube search plugin with autosuggestions and history management"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 [dependencies]

--- a/plugins/youtube/plugin.toml
+++ b/plugins/youtube/plugin.toml
@@ -1,0 +1,19 @@
+[plugin]
+id = "dev.lla.youtube"
+name = "youtube"
+version = "0.5.12"
+api_min = 2
+api_max = 2
+runtime = "native"
+entrypoint = "youtube"
+description = "Search and open YouTube videos"
+license = "MIT"
+
+[capabilities]
+formats = ["default"]
+actions = ["search", "search-selected", "history", "preferences", "help"]
+
+[permissions]
+network = ["youtube.com", "suggestqueries.google.com"]
+clipboard = true
+open_url = true

--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -112,6 +112,14 @@ fi
 
 echo "Found plugins: ${PLUGIN_CRATES[*]}"
 
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
 # Ensure target toolchain installed (no-op if already present)
 rustup target add "$TARGET_TRIPLE" >/dev/null 2>&1 || true
 
@@ -125,12 +133,17 @@ if [[ -n "$GLIBC_VERSION" ]]; then
   BUILD_TARGET="${TARGET_TRIPLE}.${GLIBC_VERSION}"
   echo "Running: cargo zigbuild --release --target $BUILD_TARGET ${BUILD_PKGS[*]}"
   cargo zigbuild --release --target "$BUILD_TARGET" "${BUILD_PKGS[@]}"
+elif [[ "$OS_LABEL" == "macos" ]]; then
+  # rustc's Mach-O stripping can produce malformed LINKEDIT string pools for
+  # some cdylibs. Keep plugin symbols intact; the CLI binary remains stripped.
+  echo "Running: CARGO_PROFILE_RELEASE_STRIP=none cargo build --release --target $TARGET_TRIPLE ${BUILD_PKGS[*]}"
+  CARGO_PROFILE_RELEASE_STRIP=none cargo build --release --target "$TARGET_TRIPLE" "${BUILD_PKGS[@]}"
 else
   echo "Running: cargo build --release --target $TARGET_TRIPLE ${BUILD_PKGS[*]}"
   cargo build --release --target "$TARGET_TRIPLE" "${BUILD_PKGS[@]}"
 fi
 
-# Copy resulting dynamic libraries to staging
+# Package each plugin as a v2 directory containing its manifest and native entrypoint.
 for crate in "${PLUGIN_CRATES[@]}"; do
   # Cargo turns '-' into '_' in library filenames (e.g. my-plugin -> libmy_plugin.so)
   artifact_name="${crate//-/_}"
@@ -145,7 +158,23 @@ for crate in "${PLUGIN_CRATES[@]}"; do
     exit 1
   fi
 
-  cp "$SRC" "$STAGING_DIR/"
+  PACKAGE_DIR="$STAGING_DIR/$crate"
+  MANIFEST="plugins/$crate/plugin.toml"
+  if [[ ! -f "$MANIFEST" ]]; then
+    echo "Expected v2 plugin manifest not found: $MANIFEST" 1>&2
+    exit 1
+  fi
+  mkdir -p "$PACKAGE_DIR"
+  cp "$SRC" "$PACKAGE_DIR/"
+  cp "$MANIFEST" "$PACKAGE_DIR/plugin.toml"
+  if [[ -f "plugins/$crate/README.md" ]]; then
+    cp "plugins/$crate/README.md" "$PACKAGE_DIR/README.md"
+  fi
+  artifact_file=$(basename "$SRC")
+  artifact_hash=$(hash_file "$PACKAGE_DIR/$artifact_file")
+  manifest_hash=$(hash_file "$PACKAGE_DIR/plugin.toml")
+  printf '[files]\n"%s" = "%s"\n"plugin.toml" = "%s"\n' \
+    "$artifact_file" "$artifact_hash" "$manifest_hash" > "$PACKAGE_DIR/checksums.toml"
 done
 
 # Create archive per-OS format

--- a/scripts/generate_plugins.sh
+++ b/scripts/generate_plugins.sh
@@ -62,10 +62,10 @@ cd lla/${plugin_dir}
 cargo build --release
 \`\`\`
 
-Then, copy the generated \`.so\`, \`.dll\`, or \`.dylib\` file from the \`target/release\` directory to your LLA plugins directory.
+Then create \`~/.config/lla/plugins/${name}\` and copy both \`plugin.toml\` and the generated \`.so\`, \`.dll\`, or \`.dylib\` into it.
 
 EOL
     fi
 done
 
-echo "Generated $output_file" 
+echo "Generated $output_file"

--- a/scripts/verify_plugins_v2.sh
+++ b/scripts/verify_plugins_v2.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <packaged-plugin-directory>" 1>&2
+  exit 2
+fi
+
+PACKAGE_DIR="$1"
+if [[ ! -d "$PACKAGE_DIR" ]]; then
+  echo "Plugin package directory not found: $PACKAGE_DIR" 1>&2
+  exit 1
+fi
+
+expected_count=$(find plugins -mindepth 2 -maxdepth 2 -name Cargo.toml -type f | wc -l | tr -d ' ')
+packaged_count=$(find "$PACKAGE_DIR" -mindepth 2 -maxdepth 2 -name plugin.toml -type f | wc -l | tr -d ' ')
+if [[ "$packaged_count" != "$expected_count" ]]; then
+  echo "Expected $expected_count plugin packages, found $packaged_count in $PACKAGE_DIR" 1>&2
+  exit 1
+fi
+
+for manifest in plugins/*/plugin.toml; do
+  plugin_name=$(basename "$(dirname "$manifest")")
+  packaged_manifest="$PACKAGE_DIR/$plugin_name/plugin.toml"
+  if [[ ! -f "$packaged_manifest" ]]; then
+    echo "Missing packaged manifest for $plugin_name" 1>&2
+    exit 1
+  fi
+  if ! cmp -s "$manifest" "$packaged_manifest"; then
+    echo "Packaged manifest for $plugin_name differs from the source manifest" 1>&2
+    exit 1
+  fi
+done
+
+cargo build -p lla
+target/debug/lla --plugins-dir "$PACKAGE_DIR" plugin doctor


### PR DESCRIPTION
## What changed

- Introduces Plugin Platform v2 with manifest-based packages, API negotiation, plugin-owned buffers, batch decoration, typed fields, declared permissions, checksums, diagnostics, and ordered discovery.
- Migrates all bundled plugins to v2 packages while preserving legacy v1 loading.
- Adds `security_audit`, `media_inspector`, `project_context`, `trash`, and `preview`.
- Changes `file_remover remove` to recoverable trash and makes permanent deletion explicit through `purge`.
- Prepares version `0.5.12`, release notes, crates.io metadata, and strict lint gates.

## Why

This establishes a validated and distributable plugin contract, improves performance and machine output, and provides safer recoverable deletion workflows.

## Compatibility

Legacy flat v1 plugins remain loadable. Automations that require irreversible deletion must replace `file_remover remove` with `file_remover purge`.

## Validation

- `cargo test --workspace --all-targets --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- Release version and changelog validation for `0.5.12`
- Optimized macOS ARM64 CLI build
- Optimized archives for all 33 plugins
- Plugin Platform v2 checksum and functional contract verification for all 33 packages
- crates.io dry-run for `lla_plugin_interface`
