### PR TITLE
chore: prepare release v0.6.1

### DIFF
--- a/.github/scripts/prepare_release.sh
+++ b/.github/scripts/prepare_release.sh
@@ -36,6 +36,7 @@ perl -0pi -e '
 
 perl -0pi -e '
   s/(lla_plugin_interface = \{[^}]*version = ")[^"]+(")/$1$ENV{VERSION}$2/g;
+  s/(lla_plugin_sdk = \{[^}]*version = ")[^"]+(")/$1$ENV{VERSION}$2/g;
 ' utils/Cargo.toml
 
 perl -0pi -e '

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-17
+
 ### Added
 
 - `reclaimable_space`, `activity_history`, `tree_summary`, and `change_risk` plugins for sizemap, timeline, tree, and Git views.
 - Plugin decoration and formatting support across specialized human-readable views, including directory summaries in tree output and complete plugin annotations in timeline output.
+
 
 ## [0.6.0] - 2026-08-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "activity_history"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lla_plugin_sdk",
  "tempfile",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "brew"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "categorizer"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "colored",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "change_risk"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lla_plugin_sdk",
  "tempfile",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "code_complexity"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "colored",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "code_snippet_extractor"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "base64 0.21.7",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "dirs_meta"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "colored",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "duplicate_file_detector"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "colored",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "file_copier"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "colored",
  "dialoguer",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "file_hash"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lla_plugin_sdk",
  "serde",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "file_meta"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "file_mover"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "colored",
  "dialoguer",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "file_organizer"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "colored",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "file_remover"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "colored",
  "dialoguer",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "file_tagger"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "colored",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "flush_dns"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -1153,7 +1153,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "folder_cleaner"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "colored",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "git_status"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "colored",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "google_meet"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "bytes",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "google_search"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "bytes",
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "hackernews"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "bytes",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "jwt"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "keyword_search"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "bytes",
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "kill_process"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "colored",
  "console",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "last_git_commit"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "colored",
@@ -2132,7 +2132,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lla"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "atty",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_interface"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "prost",
  "prost-build",
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_sdk"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lla_plugin_interface",
  "lla_plugin_sdk_macros",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_sdk_macros"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lla_plugin_interface",
  "quote",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_utils"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "colored",
@@ -2282,7 +2282,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "media_inspector"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "kamadak-exif",
  "lazy_static",
@@ -2363,7 +2363,7 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "npm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "bytes",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "preview"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lazy_static",
  "lla_plugin_sdk",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "project_context"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lazy_static",
  "lla_plugin_sdk",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "reclaimable_space"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lla_plugin_sdk",
  "tempfile",
@@ -3094,7 +3094,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remove_paywall"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "bytes",
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "security_audit"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lazy_static",
  "lla_plugin_sdk",
@@ -3499,7 +3499,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sizeviz"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "colored",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "speed_test"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "trash"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lazy_static",
  "lla_plugin_sdk",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "tree_summary"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lla_plugin_sdk",
  "tempfile",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "youtube"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 [workspace.package]
 description = "Blazing Fast and highly customizable ls Replacement with Superpowers"
 authors = ["Achaq <hi@achaq.dev>"]
-version = "0.6.0"
+version = "0.6.1"
 categories = ["utilities", "file-system", "cli", "file-management"]
 edition = "2021"
 license = "MIT"
@@ -34,8 +34,8 @@ serde_json = "1.0"
 walkdir = "2.5"
 tempfile = "3.2"
 users = "0.11"
-lla_plugin_interface = { path = "interface", version = "0.6.0" }
-lla_plugin_sdk = { path = "sdk", version = "0.6.0" }
+lla_plugin_interface = { path = "interface", version = "0.6.1" }
+lla_plugin_sdk = { path = "sdk", version = "0.6.1" }
 dashmap = "5.5.3"
 parking_lot = "0.12"
 once_cell = "1.18"

--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -32,8 +32,8 @@ walkdir.workspace = true
 tempfile.workspace = true
 users.workspace = true
 parking_lot.workspace = true
-lla_plugin_interface = { version = "0.6.0", path = "../interface" }
-lla_plugin_utils = { version = "0.6.0", path = "../utils" }
+lla_plugin_interface = { version = "0.6.1", path = "../interface" }
+lla_plugin_utils = { version = "0.6.1", path = "../utils" }
 once_cell.workspace = true
 dashmap.workspace = true
 unicode-width.workspace = true

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -13,6 +13,6 @@ documentation = "https://docs.rs/macros"
 proc-macro = true
 
 [dependencies]
-lla_plugin_interface = { path = "../interface", version = "0.6.0" }
+lla_plugin_interface = { path = "../interface", version = "0.6.1" }
 quote = "1"
 syn = { version = "2", features = ["full"] }

--- a/plugins/activity_history/Cargo.toml
+++ b/plugins/activity_history/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "activity_history"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Add Git-backed file activity history to timeline listings"
 

--- a/plugins/activity_history/plugin.toml
+++ b/plugins/activity_history/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.activity-history"
 name = "activity_history"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/brew/Cargo.toml
+++ b/plugins/brew/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brew"
 description = "Homebrew package manager plugin - install, uninstall, upgrade, and search packages"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/brew/plugin.toml
+++ b/plugins/brew/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.brew"
 name = "brew"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/categorizer/Cargo.toml
+++ b/plugins/categorizer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "categorizer"
 description = "Categorizes files based on their extensions and metadata"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/categorizer/plugin.toml
+++ b/plugins/categorizer/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.categorizer"
 name = "categorizer"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/change_risk/Cargo.toml
+++ b/plugins/change_risk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "change_risk"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Estimate per-file change risk from size, complexity, Git churn, and worktree state"
 

--- a/plugins/change_risk/plugin.toml
+++ b/plugins/change_risk/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.change-risk"
 name = "change_risk"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/code_complexity/Cargo.toml
+++ b/plugins/code_complexity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "code_complexity"
 description = "Analyzes code complexity and provides metrics"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/code_complexity/plugin.toml
+++ b/plugins/code_complexity/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.code-complexity"
 name = "code_complexity"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/code_snippet_extractor/Cargo.toml
+++ b/plugins/code_snippet_extractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code_snippet_extractor"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Extract and manage code snippets with tagging support"
 

--- a/plugins/code_snippet_extractor/plugin.toml
+++ b/plugins/code_snippet_extractor/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.code-snippet-extractor"
 name = "code_snippet_extractor"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/dirs_meta/Cargo.toml
+++ b/plugins/dirs_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dirs_meta"
 description = "Analyzes directories and shows metadata"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/dirs_meta/plugin.toml
+++ b/plugins/dirs_meta/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.dirs-meta"
 name = "dirs_meta"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/duplicate_file_detector/Cargo.toml
+++ b/plugins/duplicate_file_detector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "duplicate_file_detector"
 description = "Detects duplicate files by comparing their content hashes"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/duplicate_file_detector/plugin.toml
+++ b/plugins/duplicate_file_detector/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.duplicate-file-detector"
 name = "duplicate_file_detector"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/file_copier/Cargo.toml
+++ b/plugins/file_copier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_copier"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for copying files and directories"
 

--- a/plugins/file_copier/plugin.toml
+++ b/plugins/file_copier/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.file-copier"
 name = "file_copier"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/file_hash/Cargo.toml
+++ b/plugins/file_hash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_hash"
 description = "Displays the hash of each file"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_hash/plugin.toml
+++ b/plugins/file_hash/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.file-hash"
 name = "file_hash"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "wasm-component"

--- a/plugins/file_meta/Cargo.toml
+++ b/plugins/file_meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_meta"
 description = "Displays the file metadata of each file"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_meta/plugin.toml
+++ b/plugins/file_meta/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.file-meta"
 name = "file_meta"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/file_mover/Cargo.toml
+++ b/plugins/file_mover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_mover"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "A plugin for lla that provides clipboard functionality for moving files and directories"
 

--- a/plugins/file_mover/plugin.toml
+++ b/plugins/file_mover/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.file-mover"
 name = "file_mover"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/file_organizer/Cargo.toml
+++ b/plugins/file_organizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_organizer"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "A plugin for lla that organizes files using various strategies"
 

--- a/plugins/file_organizer/plugin.toml
+++ b/plugins/file_organizer/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.file-organizer"
 name = "file_organizer"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/file_remover/Cargo.toml
+++ b/plugins/file_remover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_remover"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Interactively trash files by default with explicit permanent deletion"
 

--- a/plugins/file_remover/plugin.toml
+++ b/plugins/file_remover/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.file-remover"
 name = "file_remover"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/file_tagger/Cargo.toml
+++ b/plugins/file_tagger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_tagger"
 description = "Add and manage tags for files"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/file_tagger/plugin.toml
+++ b/plugins/file_tagger/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.file-tagger"
 name = "file_tagger"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/flush_dns/Cargo.toml
+++ b/plugins/flush_dns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flush_dns"
 description = "Flush DNS cache on macOS, Linux, and Windows"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/flush_dns/plugin.toml
+++ b/plugins/flush_dns/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.flush-dns"
 name = "flush_dns"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/folder_cleaner/Cargo.toml
+++ b/plugins/folder_cleaner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "folder_cleaner"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Safety-first folder organization and cleanup plugin for lla"
 

--- a/plugins/folder_cleaner/plugin.toml
+++ b/plugins/folder_cleaner/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.folder-cleaner"
 name = "folder_cleaner"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/git_status/Cargo.toml
+++ b/plugins/git_status/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "git_status"
 description = "Shows Git repository status information"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/git_status/plugin.toml
+++ b/plugins/git_status/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.git-status"
 name = "git_status"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/google_meet/Cargo.toml
+++ b/plugins/google_meet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_meet"
 description = "Google Meet plugin for creating meeting rooms and managing links"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_meet/plugin.toml
+++ b/plugins/google_meet/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.google-meet"
 name = "google_meet"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/google_search/Cargo.toml
+++ b/plugins/google_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google_search"
 description = "Google search with autosuggestions, search history management, and clipboard fallback"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/google_search/plugin.toml
+++ b/plugins/google_search/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.google-search"
 name = "google_search"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/hackernews/Cargo.toml
+++ b/plugins/hackernews/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hackernews"
 description = "Hacker News plugin - browse top stories, best stories, new stories, ask HN, and show HN"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/hackernews/plugin.toml
+++ b/plugins/hackernews/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.hackernews"
 name = "hackernews"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/jwt/Cargo.toml
+++ b/plugins/jwt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jwt"
 description = "JWT decoder and analyzer with search and validation capabilities"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/jwt/plugin.toml
+++ b/plugins/jwt/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.jwt"
 name = "jwt"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/keyword_search/Cargo.toml
+++ b/plugins/keyword_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "keyword_search"
 description = "Searches file contents for user-specified keywords"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/keyword_search/plugin.toml
+++ b/plugins/keyword_search/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.keyword-search"
 name = "keyword_search"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/kill_process/Cargo.toml
+++ b/plugins/kill_process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kill_process"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "A plugin for lla that allows killing processes with an interactive interface"
 

--- a/plugins/kill_process/plugin.toml
+++ b/plugins/kill_process/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.kill-process"
 name = "kill_process"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/last_git_commit/Cargo.toml
+++ b/plugins/last_git_commit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "last_git_commit"
 description = "A plugin for the lla that provides the last git commit hash"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/last_git_commit/plugin.toml
+++ b/plugins/last_git_commit/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.last-git-commit"
 name = "last_git_commit"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/media_inspector/Cargo.toml
+++ b/plugins/media_inspector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "media_inspector"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Inspect MIME types, image metadata, and audio/video stream details"
 

--- a/plugins/media_inspector/plugin.toml
+++ b/plugins/media_inspector/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.media-inspector"
 name = "media_inspector"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/npm/Cargo.toml
+++ b/plugins/npm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "npm"
 description = "NPM package search with bundlephobia integration and favorites management"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/npm/plugin.toml
+++ b/plugins/npm/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.npm"
 name = "npm"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/preview/Cargo.toml
+++ b/plugins/preview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "preview"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Preview text, Markdown, images, and archive contents in the terminal"
 

--- a/plugins/preview/plugin.toml
+++ b/plugins/preview/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.preview"
 name = "preview"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/project_context/Cargo.toml
+++ b/plugins/project_context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "project_context"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Detect project ecosystems, toolchains, lockfiles, artifacts, and repository health"
 

--- a/plugins/project_context/plugin.toml
+++ b/plugins/project_context/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.project-context"
 name = "project_context"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/reclaimable_space/Cargo.toml
+++ b/plugins/reclaimable_space/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reclaimable_space"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Identify generated, cached, and temporary files that can be reclaimed"
 

--- a/plugins/reclaimable_space/plugin.toml
+++ b/plugins/reclaimable_space/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.reclaimable-space"
 name = "reclaimable_space"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/remove_paywall/Cargo.toml
+++ b/plugins/remove_paywall/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "remove_paywall"
 description = "Remove paywalls from URLs using services like 12ft.io, archive.is, and removepaywall.com"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/remove_paywall/plugin.toml
+++ b/plugins/remove_paywall/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.remove-paywall"
 name = "remove_paywall"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/security_audit/Cargo.toml
+++ b/plugins/security_audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security_audit"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Audit filesystem entries for unsafe permissions, risky links, and exposed secrets"
 

--- a/plugins/security_audit/plugin.toml
+++ b/plugins/security_audit/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.security-audit"
 name = "security_audit"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/sizeviz/Cargo.toml
+++ b/plugins/sizeviz/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sizeviz"
 description = "File size visualizer plugin for lla"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/sizeviz/plugin.toml
+++ b/plugins/sizeviz/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.sizeviz"
 name = "sizeviz"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/speed_test/Cargo.toml
+++ b/plugins/speed_test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "speed_test"
 description = "Internet speed test plugin - test download/upload speeds and latency"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/speed_test/plugin.toml
+++ b/plugins/speed_test/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.speed-test"
 name = "speed_test"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/trash/Cargo.toml
+++ b/plugins/trash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trash"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Cross-platform recoverable deletion with listing, restoration, and explicit emptying"
 

--- a/plugins/trash/plugin.toml
+++ b/plugins/trash/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.trash"
 name = "trash"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/tree_summary/Cargo.toml
+++ b/plugins/tree_summary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree_summary"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Add recursive directory totals to tree listings"
 

--- a/plugins/tree_summary/plugin.toml
+++ b/plugins/tree_summary/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.tree-summary"
 name = "tree_summary"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/plugins/youtube/Cargo.toml
+++ b/plugins/youtube/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "youtube"
 description = "YouTube search plugin with autosuggestions and history management"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/plugins/youtube/plugin.toml
+++ b/plugins/youtube/plugin.toml
@@ -3,7 +3,7 @@ schema_version = 3
 [plugin]
 id = "dev.lla.youtube"
 name = "youtube"
-version = "0.6.0"
+version = "0.6.1"
 api_min = 3
 api_max = 3
 runtime = "native"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 lla_plugin_interface.workspace = true
-lla_plugin_sdk_macros = { path = "../macros", version = "0.6.0" }
+lla_plugin_sdk_macros = { path = "../macros", version = "0.6.1" }
 prost.workspace = true
 toml.workspace = true
 wit-bindgen = { version = "0.60.0", optional = true }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["cli", "plugins", "file-management"]
 categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
-lla_plugin_interface = { path = "../interface", version = "0.6.0" }
-lla_plugin_sdk = { path = "../sdk", version = "0.6.0" }
+lla_plugin_interface = { path = "../interface", version = "0.6.1" }
+lla_plugin_sdk = { path = "../sdk", version = "0.6.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 colored = { workspace = true }


### PR DESCRIPTION
This PR prepares v0.6.1 by:

- updating workspace, internal crate, and all plugin versions
- promoting the Unreleased changelog entries
- fixing release preparation so `lla_plugin_sdk` is bumped in `utils/Cargo.toml`

Validated locally with release version/changelog validation, formatting, and workspace clippy.